### PR TITLE
Windows: Fix spelling of 'feedback' in menu

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/WPF/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/WPF/windows/MainWindow.xaml
@@ -124,7 +124,7 @@
             <Separator />
             <MenuItem Header="Clear Cache"
                       Command="{StaticResource ClearCacheCommand}"/>
-            <MenuItem Header="Send Feedack"
+            <MenuItem Header="Send Feedback"
                       Command="{StaticResource SendFeedbackCommand}"/>
             <MenuItem Header="About"
                       Command="{StaticResource AboutCommand}"/>


### PR DESCRIPTION
The relevant menu item is currently shown as "Send Feedack".