### PR TITLE
Add more required dependencies to Debian section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Below are some distribution specific package requirements:
 ## Debian
 
 * qt5-default
+* libxss-dev
+* libqt5x11extras5-dev
+* libqt5webkit5-dev
 
 ## Ubuntu
 


### PR DESCRIPTION
Hi!

I was trying to build the client under Debian Stretch/Sid (provided .deb didn't work for me because of some missing Ubuntu dependency) and found that these three packages are also required

* installing `libqt5x11extras5-dev` and `libqt5webkit5-dev` solves:
```
Project ERROR: Unknown module(s) in QT: x11extras webkitwidgets
```
* and `libxss-dev` solves:
```
idlenotificationdialog.cpp:9:49: fatal error: X11/extensions/scrnsaver.h: No such file or directory
 #include <X11/extensions/scrnsaver.h>  // NOLINT
                                                 ^
```

// woah, #1999! so close :smiley: 