### PR TITLE
Do not send content-length on GET request

### DIFF
--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -395,8 +395,10 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
                 pBuff->pubseekoff(0, std::ios::end, std::ios::in);
             pBuff->pubseekpos(0, std::ios::in);
 
-            poco_req.setContentLength(size);
-            poco_req.set("Content-Encoding", "gzip");
+            if (req.method != Poco::Net::HTTPRequest::HTTP_GET){
+                poco_req.setContentLength(size);
+                poco_req.set("Content-Encoding", "gzip");
+            }
 
             session.sendRequest(poco_req) << pBuff << std::flush;
         } else {


### PR DESCRIPTION
should fix https://github.com/toggl/toggldesktop/issues/2273