### PR TITLE
Reword visibility preference for clarity

### DIFF
--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -234,7 +234,7 @@
                                         </button>
                                         <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n4h-zi-TcC">
                                             <rect key="frame" x="16" y="120" width="286" height="18"/>
-                                            <buttonCell key="cell" type="check" title="On top of other windows" bezelStyle="regularSquare" imagePosition="left" inset="2" id="shd-cT-4Jq">
+                                            <buttonCell key="cell" type="check" title="Keep Toggl on top of other windows" bezelStyle="regularSquare" imagePosition="left" inset="2" id="shd-cT-4Jq">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -84,7 +84,7 @@
                             Margin="5">Record timeline</CheckBox>
                         <CheckBox Grid.Column="0" Grid.Row="4"
                             Name="onTopCheckBox" x:FieldModifier="private"
-                            Margin="5">On top of other windows</CheckBox>
+                            Margin="5">Keep Toggl on top of other windows</CheckBox>
 
                     </Grid>
                     


### PR DESCRIPTION
Preference settings are typically verbs ("Do this") but the always-shown visibility setting wasn't. Currently, it reads `On top of other windows` which is rather confusing for the end user.

This minor change moves it to `Keep Toggl on top of other windows` which should hopefully be a bit more clear.