### PR TITLE
Make the dropdown on main screen fit 2/3 of the window width (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -50,6 +50,8 @@ projectId(0) {
     ui->billable->setVisible(false);
     ui->tags->setVisible(false);
 
+    dropdown->setMinimumWidth(width() * 2 / 3);
+
     descriptionPlaceholder = "What are you doing?";
     tagsHolder = "";
 }


### PR DESCRIPTION
Fixes #2568