### PR TITLE
(linux) Ignore PrtScr in the autocomplete combobox

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -39,6 +39,11 @@ void AutocompleteCombobox::keyPressEvent(QKeyEvent *e)
         return;
     }
 
+    if (e->key() == Qt::Key_Print) {
+        QComboBox::keyPressEvent(e);
+        return;
+    }
+
     if ((e->key() == Qt::Key_Enter
          || e->key() == Qt::Key_Return
          || e->key() == Qt::Key_Down)


### PR DESCRIPTION
Capturing a screenshot doesn't work anyway but it at least doesn't change the state of the dropdown

Fixes #2570