### PR TITLE
(linux) Rely on RPATH instead of LD_LIBRARY_PATH

### DIFF
--- a/src/ui/linux/TogglDesktop.sh
+++ b/src/ui/linux/TogglDesktop.sh
@@ -7,9 +7,6 @@ if [ "${dirname%$tmp}" != "/" ]; then
 dirname=$PWD/$dirname
 fi
 
-LD_LIBRARY_PATH=$dirname/lib
-export LD_LIBRARY_PATH
-
 QTWEBENGINEPROCESS_PATH=$dirname/lib/QtWebEngineProcess
 export QTWEBENGINEPROCESS_PATH
 


### PR DESCRIPTION
Not sure if it will actually work for the build bot, I'm in Fedora and Qt packages are quite different there. Also, if chrpath complains about a missing RPATH, we can use patchelf instead.

Fixes #2611 #2308 
