### PR TITLE
Fix autocomplete behavior on Linux

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -26,6 +26,11 @@ void AutocompleteCombobox::setView(QAbstractItemView *itemView)
 
 }
 
+void AutocompleteCombobox::showPopup()
+{
+    triggerFilter();
+}
+
 void AutocompleteCombobox::keyPress(QKeyEvent *e)
 {
     keyPressEvent(e);
@@ -66,9 +71,9 @@ void AutocompleteCombobox::triggerFilter()
 {
     QString lastText = currentText();
     if (list->filterItems(currentText())) {
-        showPopup();
+        QComboBox::showPopup();
     } else {
-        hidePopup();
+        QComboBox::hidePopup();
     }
     setEditText(lastText);
 }

--- a/src/ui/linux/TogglDesktop/autocompletecombobox.h
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.h
@@ -16,6 +16,8 @@ class AutocompleteCombobox : public QComboBox
         void setView(QAbstractItemView *itemView);
         AutocompleteDropdownList *list;
 
+        void showPopup() override;
+
     private:
         QTimer *timer;
 

--- a/src/ui/linux/TogglDesktop/autocompletedropdownlist.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletedropdownlist.cpp
@@ -69,134 +69,162 @@ bool AutocompleteDropdownList::filterItems(QString filter) {
     setUpdatesEnabled(false);
     render_m_.lock();
 
-    if (fullList && loadedOnce) {
-        for (int i = 0; i < size; i++) {
-            QListWidgetItem *it = 0;
-            it = item(i);
-            it->setHidden(false);
-        }
-    } else {
-        for (int i = 0; i < size; i++) {
-            AutocompleteView *view = list.at(i);
-            itemText = (view->Type == 1) ? view->ProjectAndTaskLabel.toLower(): view->Text.toLower();
-            matchCount = 0;
+    for (int i = 0; i < size; i++) {
+        AutocompleteView *view = list.at(i);
+        itemText = (view->Type == 1) ? view->ProjectAndTaskLabel.toLower(): view->Text.toLower();
+        matchCount = 0;
 
-            for (int j = 0; j < stringList.size(); j++) {
-                currentFilter = stringList.at(j).toLower();
-                if (currentFilter.length() > 0
-                        && itemText.indexOf(currentFilter) == -1) {
-                    break;
-                }
-                matchCount++;
-                if (matchCount < stringList.size() && !fullList) {
-                    continue;
-                }
-                // Add workspace title
-                if (view->WorkspaceID != lastWID) {
+        for (int j = 0; j < stringList.size(); j++) {
+            currentFilter = stringList.at(j).toLower();
+            if (currentFilter.length() > 0
+                    && itemText.indexOf(currentFilter) == -1) {
+                break;
+            }
+            matchCount++;
+            if (matchCount < stringList.size() && !fullList) {
+                continue;
+            }
+            // Add workspace title
+            if (view->WorkspaceID != lastWID) {
 
-                    QListWidgetItem *it = 0;
-                    AutocompleteCellWidget *cl = 0;
+                QListWidgetItem *it = 0;
+                AutocompleteCellWidget *cl = 0;
 
-                    if (count() > itemCount) {
-                        it = item(itemCount);
-                        cl = static_cast<AutocompleteCellWidget *>(
-                            itemWidget(it));
-                    }
-
-                    if (!it) {
-                        it = new QListWidgetItem();
-                        cl = new AutocompleteCellWidget();
-
-                        addItem(it);
-                        setItemWidget(it, cl);
-                    }
-                    it->setHidden(false);
-                    it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
-
-                    AutocompleteView *v = new AutocompleteView();
-                    v->Type = 13;
-                    v->Text = view->WorkspaceName;
-                    cl->display(v);
-                    it->setSizeHint(QSize(it->sizeHint().width(), h));
-
-                    lastWID = view->WorkspaceID;
-                    lastCID = -1;
-                    lastType = 99;
-
-                    itemCount++;
+                if (count() > itemCount) {
+                    it = item(itemCount);
+                    cl = static_cast<AutocompleteCellWidget *>(
+                        itemWidget(it));
                 }
 
-                // Add category title
-                if (view->Type != lastType && view->Type != 1) {
-                    QListWidgetItem *it = 0;
-                    AutocompleteCellWidget *cl = 0;
+                if (!it) {
+                    it = new QListWidgetItem();
+                    cl = new AutocompleteCellWidget();
 
-                    if (count() > itemCount) {
-                        it = item(itemCount);
-                        cl = static_cast<AutocompleteCellWidget *>(
-                            itemWidget(it));
-                    }
+                    addItem(it);
+                    setItemWidget(it, cl);
+                }
+                it->setHidden(false);
+                it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
 
-                    if (!it) {
-                        it = new QListWidgetItem();
-                        cl = new AutocompleteCellWidget();
+                AutocompleteView *v = new AutocompleteView();
+                v->Type = 13;
+                v->Text = view->WorkspaceName;
+                cl->display(v);
+                it->setSizeHint(QSize(it->sizeHint().width(), h));
 
-                        addItem(it);
-                        setItemWidget(it, cl);
-                    }
-                    it->setHidden(false);
-                    it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
+                lastWID = view->WorkspaceID;
+                lastCID = -1;
+                lastType = 99;
 
-                    AutocompleteView *v = new AutocompleteView();
-                    v->Type = 11;
-                    v->Text = types[view->Type];
-                    cl->display(v);
-                    it->setSizeHint(QSize(it->sizeHint().width(), h));
+                itemCount++;
+            }
 
-                    lastType = view->Type;
+            // Add category title
+            if (view->Type != lastType && view->Type != 1) {
+                QListWidgetItem *it = 0;
+                AutocompleteCellWidget *cl = 0;
 
-                    itemCount++;
-
-                    // Add 'No project' item
-                    if (view->Type == 2 && currentFilter.length() == 0
-                            && !noProjectAdded)
-                    {
-                        QListWidgetItem *it = 0;
-                        AutocompleteCellWidget *cl = 0;
-
-                        if (count() > itemCount) {
-                            it = item(itemCount);
-                            cl = static_cast<AutocompleteCellWidget *>(
-                                itemWidget(it));
-                        }
-
-                        if (!it) {
-                            it = new QListWidgetItem();
-                            cl = new AutocompleteCellWidget();
-
-                            addItem(it);
-                            setItemWidget(it, cl);
-                        }
-                        it->setHidden(false);
-                        it->setFlags(it->flags() | Qt::ItemIsEnabled);
-
-                        AutocompleteView *v = new AutocompleteView();
-                        v->Type = 2;
-                        v->Text = "No project";
-                        v->ProjectAndTaskLabel = "";
-                        v->TaskID = 0;
-                        v->ProjectID = 0;
-                        cl->display(v);
-                        it->setSizeHint(QSize(it->sizeHint().width(), h));
-
-                        noProjectAdded = true;
-                        itemCount++;
-                    }
+                if (count() > itemCount) {
+                    it = item(itemCount);
+                    cl = static_cast<AutocompleteCellWidget *>(
+                        itemWidget(it));
                 }
 
-                // Add Client name
-                if (view->Type == 2 && view->ClientID != lastCID)
+                if (!it) {
+                    it = new QListWidgetItem();
+                    cl = new AutocompleteCellWidget();
+
+                    addItem(it);
+                    setItemWidget(it, cl);
+                }
+                it->setHidden(false);
+                it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
+
+                AutocompleteView *v = new AutocompleteView();
+                v->Type = 11;
+                v->Text = types[view->Type];
+                cl->display(v);
+                it->setSizeHint(QSize(it->sizeHint().width(), h));
+
+                lastType = view->Type;
+
+                itemCount++;
+
+                // Add 'No project' item
+                if (view->Type == 2 && currentFilter.length() == 0
+                        && !noProjectAdded)
                 {
+                    QListWidgetItem *it = 0;
+                    AutocompleteCellWidget *cl = 0;
+
+                    if (count() > itemCount) {
+                        it = item(itemCount);
+                        cl = static_cast<AutocompleteCellWidget *>(
+                            itemWidget(it));
+                    }
+
+                    if (!it) {
+                        it = new QListWidgetItem();
+                        cl = new AutocompleteCellWidget();
+
+                        addItem(it);
+                        setItemWidget(it, cl);
+                    }
+                    it->setHidden(false);
+                    it->setFlags(it->flags() | Qt::ItemIsEnabled);
+
+                    AutocompleteView *v = new AutocompleteView();
+                    v->Type = 2;
+                    v->Text = "No project";
+                    v->ProjectAndTaskLabel = "";
+                    v->TaskID = 0;
+                    v->ProjectID = 0;
+                    cl->display(v);
+                    it->setSizeHint(QSize(it->sizeHint().width(), h));
+
+                    noProjectAdded = true;
+                    itemCount++;
+                }
+            }
+
+            // Add Client name
+            if (view->Type == 2 && view->ClientID != lastCID)
+            {
+                QListWidgetItem *it = 0;
+                AutocompleteCellWidget *cl = 0;
+
+                if (count() > itemCount) {
+                    it = item(itemCount);
+                    cl = static_cast<AutocompleteCellWidget *>(
+                        itemWidget(it));
+                }
+
+                if (!it) {
+                    it = new QListWidgetItem();
+                    cl = new AutocompleteCellWidget();
+
+                    addItem(it);
+                    setItemWidget(it, cl);
+                }
+                it->setHidden(false);
+                it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
+
+                AutocompleteView *v = new AutocompleteView();
+                v->Type = 12;
+                v->Text = view->ClientLabel.count() > 0 ? view->ClientLabel : "No client";
+                cl->display(v);
+                it->setSizeHint(QSize(it->sizeHint().width(), h));
+                lastCID = view->ClientID;
+
+                itemCount++;
+            }
+
+            // In case we filter task and project is not filtered
+            if (currentFilter.length() > 0 && view->Type == 1
+                    && view->ProjectID != lastPID) {
+
+                // Also add Client name if needed
+                if (view->ClientID != lastCID) {
                     QListWidgetItem *it = 0;
                     AutocompleteCellWidget *cl = 0;
 
@@ -226,78 +254,6 @@ bool AutocompleteDropdownList::filterItems(QString filter) {
                     itemCount++;
                 }
 
-                // In case we filter task and project is not filtered
-                if (currentFilter.length() > 0 && view->Type == 1
-                        && view->ProjectID != lastPID) {
-
-                    // Also add Client name if needed
-                    if (view->ClientID != lastCID) {
-                        QListWidgetItem *it = 0;
-                        AutocompleteCellWidget *cl = 0;
-
-                        if (count() > itemCount) {
-                            it = item(itemCount);
-                            cl = static_cast<AutocompleteCellWidget *>(
-                                itemWidget(it));
-                        }
-
-                        if (!it) {
-                            it = new QListWidgetItem();
-                            cl = new AutocompleteCellWidget();
-
-                            addItem(it);
-                            setItemWidget(it, cl);
-                        }
-                        it->setHidden(false);
-                        it->setFlags(it->flags() & ~Qt::ItemIsEnabled);
-
-                        AutocompleteView *v = new AutocompleteView();
-                        v->Type = 12;
-                        v->Text = view->ClientLabel.count() > 0 ? view->ClientLabel : "No client";
-                        cl->display(v);
-                        it->setSizeHint(QSize(it->sizeHint().width(), h));
-                        lastCID = view->ClientID;
-
-                        itemCount++;
-                    }
-
-                    QListWidgetItem *it = 0;
-                    AutocompleteCellWidget *cl = 0;
-
-                    if (count() > itemCount) {
-                        it = item(itemCount);
-                        cl = static_cast<AutocompleteCellWidget *>(
-                            itemWidget(it));
-                    }
-
-                    if (!it) {
-                        it = new QListWidgetItem();
-                        cl = new AutocompleteCellWidget();
-
-                        addItem(it);
-                        setItemWidget(it, cl);
-                    }
-                    it->setHidden(false);
-                    it->setFlags(it->flags() | Qt::ItemIsEnabled);
-
-                    AutocompleteView *v = new AutocompleteView();
-                    v->Type = 2;
-                    v->Text = view->ProjectLabel;
-                    v->ProjectLabel = view->ProjectLabel;
-                    v->ProjectColor = view->ProjectColor;
-                    v->ProjectID = view->ProjectID;
-                    v->Description = view->Description;
-                    v->ClientLabel = view->ClientLabel;
-                    v->ProjectAndTaskLabel = view->ProjectAndTaskLabel;
-                    v->TaskID = 0;
-                    cl->display(v);
-                    it->setSizeHint(QSize(it->sizeHint().width(), h));
-                    lastPID = view->ProjectID;
-
-                    itemCount++;
-                }
-
-
                 QListWidgetItem *it = 0;
                 AutocompleteCellWidget *cl = 0;
 
@@ -317,23 +273,59 @@ bool AutocompleteDropdownList::filterItems(QString filter) {
                 it->setHidden(false);
                 it->setFlags(it->flags() | Qt::ItemIsEnabled);
 
-                cl->display(view);
+                AutocompleteView *v = new AutocompleteView();
+                v->Type = 2;
+                v->Text = view->ProjectLabel;
+                v->ProjectLabel = view->ProjectLabel;
+                v->ProjectColor = view->ProjectColor;
+                v->ProjectID = view->ProjectID;
+                v->Description = view->Description;
+                v->ClientLabel = view->ClientLabel;
+                v->ProjectAndTaskLabel = view->ProjectAndTaskLabel;
+                v->TaskID = 0;
+                cl->display(v);
                 it->setSizeHint(QSize(it->sizeHint().width(), h));
-
-                if (view->Type == 2) {
-                    lastPID = view->ProjectID;
-                }
+                lastPID = view->ProjectID;
 
                 itemCount++;
             }
-        }
-        int c = count();
-        while (c > itemCount) {
+
+
             QListWidgetItem *it = 0;
-            it = item(c-1);
-            it->setHidden(true);
-            c--;
+            AutocompleteCellWidget *cl = 0;
+
+            if (count() > itemCount) {
+                it = item(itemCount);
+                cl = static_cast<AutocompleteCellWidget *>(
+                    itemWidget(it));
+            }
+
+            if (!it) {
+                it = new QListWidgetItem();
+                cl = new AutocompleteCellWidget();
+
+                addItem(it);
+                setItemWidget(it, cl);
+            }
+            it->setHidden(false);
+            it->setFlags(it->flags() | Qt::ItemIsEnabled);
+
+            cl->display(view);
+            it->setSizeHint(QSize(it->sizeHint().width(), h));
+
+            if (view->Type == 2) {
+                lastPID = view->ProjectID;
+            }
+
+            itemCount++;
         }
+    }
+    int c = count();
+    while (c > itemCount) {
+        QListWidgetItem *it = 0;
+        it = item(c-1);
+        it->setHidden(true);
+        c--;
     }
 
     render_m_.unlock();


### PR DESCRIPTION
Please check the code. From my point of view, it's better to keep the consistency by filling the list each time it is requested.

The code is not the greatest at this moment, from my point of view. I hence propose rewriting autocomplete to QItemView instead of QItemWidget (along with the changes to the underlying data model), especially for the ability to utilize QAbstractItemModel and QSortFilterProxyModel. 

It is easier to control how the items are filtered with that approach and also how many items get to be displayed. 