### PR TITLE
Fix the "Implicit declaration of function 'toggl_fullsync' is invalid in C99"

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/OverlayViewController.m
+++ b/src/ui/osx/TogglDesktop/test2/OverlayViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "OverlayViewController.h"
+#import "toggl_api.h"
 
 @interface OverlayViewController ()
 @property int currentType;


### PR DESCRIPTION
## ❓ What's this?
Fix the `Implicit declaration of function on C99` warning.

## 🤯 Changelogs 
- [x] Import `toggle_api.h` to OverlayViewController.m.

## 👫 Relationships
Closes toggl/toggldesktop#2629

## 🔎 Review hints
- Run the build and check the warnings is gone.

