### PR TITLE
Trim all leading & trailing space in Description

### DIFF
--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -23,6 +23,7 @@
 #include "Poco/Logger.h"
 #include "Poco/NumberParser.h"
 #include "Poco/Timestamp.h"
+#include "toggl_api_private.h"
 
 namespace toggl {
 
@@ -197,8 +198,9 @@ void TimeEntry::SetStop(const Poco::UInt64 value) {
 }
 
 void TimeEntry::SetDescription(const std::string value) {
-    if (description_ != value) {
-        description_ = value;
+    const std::string trimValue = trim_whitespace(value);
+    if (description_ != trimValue) {
+        description_ = trimValue;
         SetDirty();
     }
 }

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -204,6 +204,19 @@ std::string to_string(const char_t *s) {
 #endif
 }
 
+std::string trim_whitespace(const std::string str)
+{
+    const std::string& whitespace = " \t";
+    const auto strBegin = str.find_first_not_of(whitespace);
+    if (strBegin == std::string::npos)
+        return ""; // no content
+
+    const auto strEnd = str.find_last_not_of(whitespace);
+    const auto strRange = strEnd - strBegin + 1;
+
+    return str.substr(strBegin, strRange);
+}
+
 char_t *copy_string(const std::string s) {
 #if defined(_WIN32) || defined(WIN32)
     std::wstring ws;

--- a/src/toggl_api_private.h
+++ b/src/toggl_api_private.h
@@ -33,6 +33,17 @@ int compare_string(const char_t *s1, const char_t *s2);
 char_t *copy_string(const std::string s);
 std::string to_string(const char_t *s);
 
+/**
+ Trim all leading and trailing whitespace from the string. Don't trim on middle of word.
+ Ex: const std::string foo = "    too much   space  ";
+ const std::string text = trim(foo);
+ // Text = "too much   space"
+
+ @param str The string need to be trimmed
+ @return The string after trimming the leading and trailing whitespace
+ */
+std::string trim_whitespace(const std::string str);
+
 TogglGenericView *generic_to_view_item(
     const toggl::view::Generic c);
 


### PR DESCRIPTION
## ❓ What's this?
Remove leading and trailing whitespace in Description 

## 💾 How is it done?
- Override the setter of Description of `TimeEntry` in library and trim all leading & trailing whitespace.
- Trim whitespace in macOS UI.

## 🤯 Changelogs 
- [x] Introduce `trim_whitespace` in `toggl_api_private.h`
- [x] Override the setter of Description of `TimeEntry` in library and trim all leading & trailing whitespace.
- [x] Override the setter/getter of Description property in `TimeEntryViewItem` and `AutocompleteItem`
## 👫 Relationships
Closes toggl/toggldesktop#2369

## 🔎 Review hints
- Try to enter "          " in Description Label in `TimeEntryEditViewController` and `TimerEditViewController` => If the text is become "" and show `(no description)` => OK 💯