### PR TITLE
Enable/Disable Command+Q depend on the state of Setting's dock_icon

### DIFF
--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		95DBF8CD18BF7A910021FB41 /* offline_on.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8CB18BF7A910021FB41 /* offline_on.pdf */; };
 		95DBF8D718C48B300021FB41 /* logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8D618C48B300021FB41 /* logo.png */; };
 		BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */; };
+		BAF87DF321A3F59D00624EBE /* AppDelegate+Shortcut.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DF221A3F59D00624EBE /* AppDelegate+Shortcut.m */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
 		C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FBD17F1B08A001C4565 /* MainWindowController.m */; };
 		C5DA1FC017F1B08A001C4565 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5DA1FBE17F1B08A001C4565 /* MainWindowController.xib */; };
@@ -554,6 +555,8 @@
 		95DBF8D618C48B300021FB41 /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
 		BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTextField+Ext.h"; sourceTree = "<group>"; };
 		BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextField+Ext.m"; sourceTree = "<group>"; };
+		BAF87DF121A3F59D00624EBE /* AppDelegate+Shortcut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AppDelegate+Shortcut.h"; sourceTree = "<group>"; };
+		BAF87DF221A3F59D00624EBE /* AppDelegate+Shortcut.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "AppDelegate+Shortcut.m"; sourceTree = "<group>"; };
 		C5CB7F0217F43EE100A2AEB1 /* TimeEntryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeEntryCell.h; sourceTree = "<group>"; };
 		C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TimeEntryCell.m; sourceTree = "<group>"; };
 		C5DA1FB817F19647001C4565 /* Kopsik.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = Kopsik.dylib; path = ../../../lib/osx/build/Kopsik.dylib; sourceTree = "<group>"; };
@@ -1020,6 +1023,8 @@
 		BAF87DDB21A3E1E700624EBE /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				BAF87DF121A3F59D00624EBE /* AppDelegate+Shortcut.h */,
+				BAF87DF221A3F59D00624EBE /* AppDelegate+Shortcut.m */,
 				BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */,
 				BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */,
 			);
@@ -1373,6 +1378,7 @@
 				BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */,
 				3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */,
 				746947FA1AF3FE3E0024BED7 /* AutotrackerRuleItem.m in Sources */,
+				BAF87DF321A3F59D00624EBE /* AppDelegate+Shortcut.m in Sources */,
 				74E3CDCA17FBABE400C3ADD3 /* BugsnagEvent.m in Sources */,
 				74FE0D5C18E260A000ECFED2 /* MASShortcut+Monitoring.m in Sources */,
 				3C6B2487203E01D90063FC08 /* AutoCompleteInput.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate+Shortcut.h
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate+Shortcut.h
@@ -1,0 +1,27 @@
+//
+//  AppDelegate+Shortcut.h
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 11/20/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "AppDelegate.h"
+
+@class Settings;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AppDelegate(Shortcut)
+
+/**
+ Handle all shortcut of the app depend on specific Setting
+
+ @param setting Settings model
+ */
+-(void) handleShortcutForSetting:(Settings *) setting;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate+Shortcut.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate+Shortcut.m
@@ -1,0 +1,20 @@
+//
+//  AppDelegate+Shortcut.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 11/20/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import "AppDelegate+Shortcut.h"
+#import "Settings.h"
+
+@implementation AppDelegate(Shortcut)
+
+-(void) handleShortcutForSetting:(Settings *) setting
+{
+    // Enable Command+Q if the Dock is visible
+    // Otherwise, disable it if Dock is invisible -> We have to quit explicitly in Status Menu
+    self.quitMenuItem.keyEquivalent = setting.dock_icon ?  @"q" : @"";
+}
+@end

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.h
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.h
@@ -13,6 +13,8 @@
 @property (strong) NSStatusItem *statusItem;
 @property (strong) NSImage *activeAppIcon;
 @property (retain, nonatomic) Reachability *reach;
+@property (weak, readonly) NSMenuItem *quitMenuItem;
+
 - (IBAction)onPreferencesMenuItem:(id)sender;
 - (IBAction)onAboutMenuItem:(id)sender;
 - (IBAction)onSyncMenuItem:(id)sender;

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -31,6 +31,7 @@
 #import "CountryViewItem.h"
 #import "idler.h"
 #import "toggl_api.h"
+#import "AppDelegate+Shortcut.h"
 
 @interface AppDelegate ()
 @property (nonatomic, strong) IBOutlet MainWindowController *mainWindowController;
@@ -39,6 +40,7 @@
 @property (nonatomic, strong) IBOutlet IdleNotificationWindowController *idleNotificationWindowController;
 @property (nonatomic, strong) IBOutlet FeedbackWindowController *feedbackWindowController;
 @property (nonatomic, strong) IBOutlet ConsoleViewController *consoleWindowController;
+@property (weak) IBOutlet NSMenuItem *quitMenuItem;
 
 // Remember some app state
 @property TimeEntryViewItem *lastKnownRunningTimeEntry;
@@ -676,6 +678,9 @@ BOOL unsupportedOS = NO;
 		NSLog(@"Hiding dock icon.");
 		TransformProcessType(&psn, kProcessTransformToUIElementApplication);
 	}
+
+    // Handle shortcut
+    [self handleShortcutForSetting:cmd.settings];
 
 	// Stay on top
 	if (cmd.settings.on_top)

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -268,7 +269,11 @@
                 </menuItem>
             </items>
         </menu>
-        <customObject id="494" customClass="AppDelegate"/>
+        <customObject id="494" customClass="AppDelegate">
+            <connections>
+                <outlet property="quitMenuItem" destination="136" id="TMh-ap-U0Q"/>
+            </connections>
+        </customObject>
         <customObject id="420" customClass="NSFontManager"/>
         <segmentedControl verticalHuggingPriority="750" id="1458">
             <rect key="frame" x="0.0" y="0.0" width="164" height="23"/>


### PR DESCRIPTION
## ❓ What's this?
According to previous [discussion](https://github.com/toggl/toggldesktop/issues/1776#issuecomment-439827698) (#1776), we expect that:
1. `Cmd + Q` to quit the app if the Dock is visible 
2. Disable `Cmd + Q` if the Dock is hidden.

This PR is the elegant solution to tackle this problem 💁‍♂️

 ## 💾 How is it done?
- We explicitly enable / disable the `Command + Q` shortcut, which relies on the state of `Setting's dock_icon`.
- If it's ON, we set a shortcut (Cmd+Q) for `QuitMenuItem`
- Otherwise, we disable it. Consequently, the user must quit the app by selecting on Status Menu.

 ## 🤯 Changelogs
- [x] Introduce `AppDelegate(Shortcut)` extension to handle shortcut appropriately. In the future, if we would like to add more shortcut, it's potential place to do it.
- [x] Set OUTLET of `QuitItemMenu` to `AppDelegate`.
- [x] Enable / Disable the shortcut whenever the Setting is changed from `kDisplaySettings` notification.

 ## 👫 Relationships
Closes #1776 

 ## 🔎 Review hints
- Enable "Show Dock Icon" in Preferences, then trying to quit (Cmd+Q) => App quit => Correct 💯
- Disable "Show Dock Icon" => Unable to quit (Cmd+Q) the app until selecting on Status Menu => Correct 💯