### PR TITLE
Fix bug: Can't select app on Expose mode if app is "Always on Top" mode

### DIFF
--- a/src/ui/osx/TogglDesktop/MainWindowController.h
+++ b/src/ui/osx/TogglDesktop/MainWindowController.h
@@ -9,6 +9,17 @@
 #import <Cocoa/Cocoa.h>
 #import "toggl_api.h"
 
+/**
+ The level of window.
+
+ - WindowModeAlwaysOnTop: Always in top (NSFloatingWindowLevel)
+ - WindowModeDefault: Normal behavior (NSNormalWindowLevel)
+ */
+typedef NS_ENUM(NSUInteger, WindowMode) {
+    WindowModeAlwaysOnTop,
+    WindowModeDefault,
+};
+
 @interface MainWindowController : NSWindowController
 @property IBOutlet NSView *contentView;
 @property IBOutlet NSTextField *errorLabel;
@@ -17,4 +28,6 @@
 @property (strong) IBOutlet NSView *mainView;
 @property (strong) IBOutlet NSTextField *onlineStatusTextField;
 - (BOOL)isEditOpened;
+-(void)setWindowMode:(WindowMode) mode;
+
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -296,4 +296,18 @@ extern void *ctx;
     }
     [[TrackingService sharedInstance] trackWindowSize:self.window.frame.size];
 }
+
+-(void)setWindowMode:(WindowMode) mode
+{
+    switch (mode)
+    {
+        case WindowModeAlwaysOnTop:
+            [self.window setLevel:NSFloatingWindowLevel];
+            self.window.collectionBehavior = NSWindowCollectionBehaviorManaged;
+            break;
+        case WindowModeDefault:
+            [self.window setLevel:NSNormalWindowLevel];
+            break;
+    }
+}
 @end

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -318,7 +318,7 @@ BOOL onTop = NO;
 	if (self.mainWindowController.window.level == NSFloatingWindowLevel)
 	{
 		onTop = YES;
-		[self.mainWindowController.window setLevel:NSNormalWindowLevel];
+        [self.mainWindowController setWindowMode:WindowModeDefault];
 	}
 }
 
@@ -326,7 +326,7 @@ BOOL onTop = NO;
 {
 	if (onTop)
 	{
-		[self.mainWindowController.window setLevel:NSFloatingWindowLevel];
+        [self.mainWindowController setWindowMode:WindowModeAlwaysOnTop];
 		onTop = NO;
 	}
 }
@@ -667,11 +667,11 @@ BOOL onTop = NO;
 	// Stay on top
 	if (cmd.settings.on_top)
 	{
-		[self.mainWindowController.window setLevel:NSFloatingWindowLevel];
+        [self.mainWindowController setWindowMode:WindowModeAlwaysOnTop];
 	}
 	else
 	{
-		[self.mainWindowController.window setLevel:NSNormalWindowLevel];
+        [self.mainWindowController setWindowMode:WindowModeDefault];
 	}
 
 	onTop = cmd.settings.on_top;


### PR DESCRIPTION
## ❓ What's this?
There is a user reported that there is no way to select the app in Expose mode (pressing F3) or move to new space.

 ## 💾 How is it done?
- Override `NSWindowCollectionBehaviorManaged` of [CollectionBehavior](https://developer.apple.com/documentation/appkit/nswindow/collectionbehavior/1419505-managed) whenever the level of window applies `NSFloatingWindowLevel ` 

 ## 🤯 Changelogs 
- Modularize the fix by introducing `WindowMode` enum and `setWindowMode` method in `MainWindowController` in order to remove duplication code.
- Override `NSWindowCollectionBehaviorManaged` if we enable Floating mode.

 ## 👫 Relationships
Closes #2056 

 ## 🔎 Review hints
- Toggle ON/OFF the "Always on Top" mode and try to move the window to new space or select on Expose mode (F3)