### PR TITLE
Collect analytics about app window sizes

### DIFF
--- a/src/Rectangle.cc
+++ b/src/Rectangle.cc
@@ -13,7 +13,7 @@ namespace toggl {
 
 std::string Rectangle::str() const {
     std::stringstream ss;
-    ss << "{" << width << "}x{" << height << "}";
+    ss << width << "x" << height;
     return ss.str();
 }
     

--- a/src/Rectangle.cc
+++ b/src/Rectangle.cc
@@ -1,0 +1,24 @@
+//
+//  Rectangle.c
+//  TogglDesktopLibrary
+//
+//  Created by Nghia Tran on 11/22/18.
+//  Copyright © 2018 Toggl. All rights reserved.
+//
+
+#include "Rectangle.h"
+#include <sstream>
+
+namespace toggl {
+
+std::string Rectangle::actionStr() const {
+    std::stringstream ss;
+    ss << "winsize-{"
+        << width
+        << "}x{"
+        << height
+        << "}";
+    return ss.str();
+}
+    
+}

--- a/src/Rectangle.cc
+++ b/src/Rectangle.cc
@@ -11,13 +11,9 @@
 
 namespace toggl {
 
-std::string Rectangle::actionStr() const {
+std::string Rectangle::str() const {
     std::stringstream ss;
-    ss << "winsize-{"
-        << width
-        << "}x{"
-        << height
-        << "}";
+    ss << "{" << width << "}x{" << height << "}";
     return ss.str();
 }
     

--- a/src/Rectangle.h
+++ b/src/Rectangle.h
@@ -16,13 +16,13 @@ namespace toggl {
 
 class Rectangle {
     private:
-        Poco::UInt64 width;
-        Poco::UInt64 height;
+        const Poco::UInt64 width;
+        const Poco::UInt64 height;
 
     public:
-        Rectangle(Poco::UInt64 w=0, Poco::UInt64 h=0);
+        Rectangle(const Poco::UInt64 w, const Poco::UInt64 h): width(w), height(h) {}
 
-        std::string actionStr() const;
+        std::string str() const;
     };
 }
 

--- a/src/Rectangle.h
+++ b/src/Rectangle.h
@@ -1,0 +1,29 @@
+//
+//  Rectangle.h
+//  TogglDesktopLibrary
+//
+//  Created by Nghia Tran on 11/22/18.
+//  Copyright © 2018 Toggl. All rights reserved.
+//
+
+#ifndef Rectangle_h
+#define Rectangle_h
+
+#include <string>
+#include "Poco/Types.h"
+
+namespace toggl {
+
+class Rectangle {
+    private:
+        Poco::UInt64 width;
+        Poco::UInt64 height;
+
+    public:
+        Rectangle(Poco::UInt64 w=0, Poco::UInt64 h=0);
+
+        std::string actionStr() const;
+    };
+}
+
+#endif /* Rectangle_h */

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -47,9 +47,10 @@ void Analytics::TrackOs(const std::string client_id,
 }
 
 void Analytics::TrackWindowSize(const std::string client_id,
+                                const std::string os,
                                 const toggl::Rectangle rect) {
     std::stringstream ss;
-    ss << "winsize-"<< rect.str();
+    ss << os << "/mainsize-" << rect.str();
 
     Track(client_id, "stats", ss.str());
 }

--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -46,6 +46,14 @@ void Analytics::TrackOs(const std::string client_id,
     Track(client_id, "os", ss.str());
 }
 
+void Analytics::TrackWindowSize(const std::string client_id,
+                                const toggl::Rectangle rect) {
+    std::stringstream ss;
+    ss << "winsize-"<< rect.str();
+
+    Track(client_id, "stats", ss.str());
+}
+
 void Analytics::TrackSettings(const std::string client_id,
                               const bool record_timeline,
                               const Settings settings,

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -51,6 +51,7 @@ class Analytics : public Poco::TaskManager {
         const bool was_using_autocomplete);
 
     void TrackWindowSize(const std::string client_id,
+                         const std::string os,
                          const toggl::Rectangle rect);
 
  private:

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -10,6 +10,7 @@
 #include "Poco/LocalDateTime.h"
 #include "./proxy.h"
 #include "./settings.h"
+#include "./Rectangle.h"
 
 namespace toggl {
 
@@ -48,6 +49,9 @@ class Analytics : public Poco::TaskManager {
     void TrackAutocompleteUsage(
         const std::string client_id,
         const bool was_using_autocomplete);
+
+    void TrackWindowSize(const std::string client_id,
+                         const toggl::Rectangle rect);
 
  private:
     Poco::LocalDateTime settings_sync_date;

--- a/src/context.cc
+++ b/src/context.cc
@@ -5551,4 +5551,12 @@ void on_websocket_message(
     ctx->LoadUpdateFromJSONString(json);
 }
 
+void Context::TrackWindowSize(const Poco::Int64 width,
+                              const Poco::Int64 height) {
+    if ("production" == environment_) {
+        auto rect = toggl::Rectangle(width, height);
+        analytics_.TrackWindowSize(db_->AnalyticsClientID(), rect);
+    }
+}
+
 }  // namespace toggl

--- a/src/context.cc
+++ b/src/context.cc
@@ -1576,6 +1576,17 @@ const std::string Context::installerPlatform() {
     return ss.str();
 }
 
+const std::string Context::shortOSName() {
+    if (POCO_OS_LINUX == POCO_OS) {
+        return "linux";
+    } else if (POCO_OS_WINDOWS_NT == POCO_OS) {
+        return "win";
+    } else if (POCO_OS_MAC_OS_X == POCO_OS) {
+        return "mac";
+    }
+    return "unknown";
+}
+
 void Context::TimelineUpdateServerSettings() {
     logger().debug("TimelineUpdateServerSettings");
 
@@ -5555,6 +5566,7 @@ void Context::TrackWindowSize(const Poco::Int64 width,
                               const Poco::Int64 height) {
     if ("production" == environment_) {
         analytics_.TrackWindowSize(db_->AnalyticsClientID(),
+                                   shortOSName(),
                                    toggl::Rectangle(width, height));
     }
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -5554,8 +5554,8 @@ void on_websocket_message(
 void Context::TrackWindowSize(const Poco::Int64 width,
                               const Poco::Int64 height) {
     if ("production" == environment_) {
-        auto rect = toggl::Rectangle(width, height);
-        analytics_.TrackWindowSize(db_->AnalyticsClientID(), rect);
+        analytics_.TrackWindowSize(db_->AnalyticsClientID(),
+                                   toggl::Rectangle(width, height));
     }
 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -457,6 +457,7 @@ class Context : public TimelineDatasource {
 
     static const std::string installerPlatform();
     static const std::string linuxPlatformName();
+    static const std::string shortOSName();
 
     Poco::Logger &logger() const;
 

--- a/src/context.h
+++ b/src/context.h
@@ -443,6 +443,9 @@ class Context : public TimelineDatasource {
 
     error PullCountries();
 
+    void TrackWindowSize(const Poco::Int64 width,
+                         const Poco::Int64 height);
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		74EB0F1817F9A2600046ABC1 /* https_client.h in Headers */ = {isa = PBXBuildFile; fileRef = 74EB0F1617F9A2600046ABC1 /* https_client.h */; };
 		74F7CDDB18199FA300630BD0 /* window_change_recorder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 74F7CDD918199FA300630BD0 /* window_change_recorder.cc */; };
 		74F7CDDC18199FA300630BD0 /* window_change_recorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F7CDDA18199FA300630BD0 /* window_change_recorder.h */; };
+		BA2DA11C21A6864D0027B7A5 /* Rectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = BA2DA11A21A6864D0027B7A5 /* Rectangle.h */; };
+		BA2DA11D21A6864D0027B7A5 /* Rectangle.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11B21A6864D0027B7A5 /* Rectangle.cc */; };
 		C5DA1F9117F18CB6001C4565 /* libssl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DA1F9017F18CB6001C4565 /* libssl.a */; };
 		C5DA1F9317F18CBB001C4565 /* libcrypto.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DA1F9217F18CBB001C4565 /* libcrypto.a */; };
 		C5DA1FAB17F18D7B001C4565 /* database.cc in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FA417F18D7B001C4565 /* database.cc */; };
@@ -183,6 +185,8 @@
 		74EB0F1617F9A2600046ABC1 /* https_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = https_client.h; path = ../../../https_client.h; sourceTree = "<group>"; };
 		74F7CDD918199FA300630BD0 /* window_change_recorder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = window_change_recorder.cc; path = ../../../window_change_recorder.cc; sourceTree = "<group>"; };
 		74F7CDDA18199FA300630BD0 /* window_change_recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = window_change_recorder.h; path = ../../../window_change_recorder.h; sourceTree = "<group>"; };
+		BA2DA11A21A6864D0027B7A5 /* Rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Rectangle.h; path = ../../../Rectangle.h; sourceTree = "<group>"; };
+		BA2DA11B21A6864D0027B7A5 /* Rectangle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Rectangle.cc; path = ../../../Rectangle.cc; sourceTree = "<group>"; };
 		C55DA59C17F06A3B00B42178 /* TogglDesktopLibrary.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = TogglDesktopLibrary.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		C55DA5A017F06A3B00B42178 /* Kopsik-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Kopsik-Prefix.pch"; sourceTree = "<group>"; };
 		C55DA5A117F06A3B00B42178 /* KopsikProj.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = KopsikProj.xcconfig; sourceTree = "<group>"; };
@@ -355,6 +359,8 @@
 				C55DA5A117F06A3B00B42178 /* KopsikProj.xcconfig */,
 				C55DA5A217F06A3B00B42178 /* KopsikTarget.xcconfig */,
 				C55DA59F17F06A3B00B42178 /* Supporting Files */,
+				BA2DA11A21A6864D0027B7A5 /* Rectangle.h */,
+				BA2DA11B21A6864D0027B7A5 /* Rectangle.cc */,
 			);
 			name = lib;
 			path = Kopsik;
@@ -389,6 +395,7 @@
 				743024151AEFA819006DC911 /* autotracker.h in Headers */,
 				748B7DA81AC5963B00FE01D2 /* model_change.h in Headers */,
 				74B587C218BBC77E00E9F6CE /* workspace.h in Headers */,
+				BA2DA11C21A6864D0027B7A5 /* Rectangle.h in Headers */,
 				74CAAD1F181860F7001B77BB /* timeline_notifications.h in Headers */,
 				74B587BF18BBC77E00E9F6CE /* user.h in Headers */,
 				748B7DA61AC5963B00FE01D2 /* custom_error_handler.h in Headers */,
@@ -514,6 +521,7 @@
 				748B7DAB1AC5963B00FE01D2 /* settings.cc in Sources */,
 				74B587CF18BBC77E00E9F6CE /* batch_update_result.cc in Sources */,
 				7484A2AB18887BEE0025A88B /* context.cc in Sources */,
+				BA2DA11D21A6864D0027B7A5 /* Rectangle.cc in Sources */,
 				74699F6B1A67053600691986 /* analytics.cc in Sources */,
 				7458ED291A355746007B529E /* idle.cc in Sources */,
 				74B587CD18BBC77E00E9F6CE /* time_entry.cc in Sources */,

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -141,6 +141,7 @@
     <ClInclude Include="..\..\..\migrations.h" />
     <ClInclude Include="..\..\..\netconf.h" />
     <ClInclude Include="..\..\..\obm_action.h" />
+    <ClInclude Include="..\..\..\Rectangle.h" />
     <ClInclude Include="..\..\..\toggl_api_private.h" />
     <ClInclude Include="..\..\..\project.h" />
     <ClInclude Include="..\..\..\proxy.h" />
@@ -216,6 +217,7 @@
     <ClCompile Include="..\..\..\migrations.cc" />
     <ClCompile Include="..\..\..\netconf.cc" />
     <ClCompile Include="..\..\..\obm_action.cc" />
+    <ClCompile Include="..\..\..\Rectangle.cc" />
     <ClCompile Include="..\..\..\settings.cc" />
     <ClCompile Include="..\..\..\timeline_event.cc" />
     <ClCompile Include="..\..\..\toggl_api.cc" />

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj.filters
@@ -216,6 +216,9 @@
     <ClInclude Include="..\..\..\help_article.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\Rectangle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -435,6 +438,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\help_article.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Rectangle.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1340,3 +1340,12 @@ bool_t toggl_get_mini_timer_visible(
 void toggl_load_more(void* context) {
     app(context)->LoadMore();
 }
+
+void track_window_size(void *context,
+                       const uint64_t width,
+                       const uint64_t height) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackWindowSize(width, height);
+}

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -996,6 +996,10 @@ extern "C" {
 
     TOGGL_EXPORT void toggl_load_more(void* context);
 
+    TOGGL_EXPORT void track_window_size(void *context,
+                                        const uint64_t width,
+                                        const uint64_t height);
+
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -15,6 +15,7 @@
 #import "MenuItemTags.h"
 #import "DisplayCommand.h"
 #include <Carbon/Carbon.h>
+#import "TrackingService.h"
 
 @interface MainWindowController ()
 @property (nonatomic, strong) IBOutlet LoginViewController *loginViewController;
@@ -87,6 +88,9 @@ extern void *ctx;
 	[attrTitle fixAttributesInRange:range];
 	[self.closeTroubleBoxButton setAttributedTitle:attrTitle];
 	self.troubleBoxDefaultHeight = self.troubleBox.frame.size.height;
+
+    // Tracking the size of window after loaded
+    [self trackWindowSize];
 }
 
 - (void)addErrorBoxConstraint
@@ -284,4 +288,12 @@ extern void *ctx;
 	return self.timeEntryListViewController.timeEntrypopover.shown;
 }
 
+-(void)trackWindowSize
+{
+    if (self.window == nil)
+    {
+        return;
+    }
+    [[TrackingService sharedInstance] trackWindowSize:self.window.frame.size];
+}
 @end

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		95DBF8CC18BF7A910021FB41 /* offline_off.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8CA18BF7A910021FB41 /* offline_off.pdf */; };
 		95DBF8CD18BF7A910021FB41 /* offline_on.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8CB18BF7A910021FB41 /* offline_on.pdf */; };
 		95DBF8D718C48B300021FB41 /* logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8D618C48B300021FB41 /* logo.png */; };
+		BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11F21A691FF0027B7A5 /* TrackingService.m */; };
 		BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
 		C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FBD17F1B08A001C4565 /* MainWindowController.m */; };
@@ -552,6 +553,8 @@
 		95DBF8CA18BF7A910021FB41 /* offline_off.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = offline_off.pdf; sourceTree = "<group>"; };
 		95DBF8CB18BF7A910021FB41 /* offline_on.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = offline_on.pdf; sourceTree = "<group>"; };
 		95DBF8D618C48B300021FB41 /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
+		BA2DA11E21A691FF0027B7A5 /* TrackingService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackingService.h; sourceTree = "<group>"; };
+		BA2DA11F21A691FF0027B7A5 /* TrackingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrackingService.m; sourceTree = "<group>"; };
 		BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTextField+Ext.h"; sourceTree = "<group>"; };
 		BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextField+Ext.m"; sourceTree = "<group>"; };
 		C5CB7F0217F43EE100A2AEB1 /* TimeEntryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeEntryCell.h; sourceTree = "<group>"; };
@@ -811,6 +814,8 @@
 				3CE1CABF1C774F2B00D0ADD5 /* LoadMoreCell.h */,
 				3CE1CAC01C774F2B00D0ADD5 /* LoadMoreCell.m */,
 				3C0158EF1C7B414E00FE63AA /* LoadMoreCell.xib */,
+				BA2DA11E21A691FF0027B7A5 /* TrackingService.h */,
+				BA2DA11F21A691FF0027B7A5 /* TrackingService.m */,
 			);
 			name = ui;
 			path = test2;
@@ -1413,6 +1418,7 @@
 				74E3CDC817FBABE400C3ADD3 /* BugsnagConfiguration.m in Sources */,
 				743D782A182791FA00978BCC /* idler.c in Sources */,
 				74AA9473180909F50000539F /* GTMOAuth2Authentication.m in Sources */,
+				BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */,
 				3C6B2486203E01D90063FC08 /* AutoCompleteTableCell.m in Sources */,
 				3CE30E022052BD8B00AF2E2A /* AutoCompleteTableContainer.m in Sources */,
 				3C0A571D1C22E12E00301D77 /* MKColorWell+Bindings.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/TrackingService.h
+++ b/src/ui/osx/TogglDesktop/test2/TrackingService.h
@@ -1,0 +1,21 @@
+//
+//  TrackingService.h
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 11/22/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TrackingService : NSObject
+
++(instancetype) sharedInstance;
+
+-(void)trackWindowSize:(NSSize) size;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/TrackingService.m
+++ b/src/ui/osx/TogglDesktop/test2/TrackingService.m
@@ -1,0 +1,32 @@
+//
+//  TrackingService.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 11/22/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import "TrackingService.h"
+#import "toggl_api.h"
+
+@implementation TrackingService
+
+extern void *ctx;
+
++(instancetype) sharedInstance
+{
+    static TrackingService *instance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[TrackingService alloc] init];
+    });
+    return instance;
+}
+
+-(void)trackWindowSize:(NSSize) size
+{
+    track_window_size(ctx,
+                      @(size.width).integerValue,
+                      @(size.height).integerValue);
+}
+@end

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -577,6 +577,11 @@ public static partial class Toggl
         toggl_set_sleep(ctx);
     }
 
+    public static void TrackWindowSize(Size size)
+    {
+        track_window_size(ctx, Convert.ToUInt64(size.Width), Convert.ToUInt64(size.Height));
+    }
+
     public static void SetWake()
     {
         toggl_set_wake(ctx);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -579,7 +579,7 @@ public static partial class Toggl
 
     public static void TrackWindowSize(Size size)
     {
-        track_window_size(ctx, Convert.ToUInt64(size.Width), Convert.ToUInt64(size.Height));
+        track_window_size(ctx, (ulong)size.Width, (ulong)size.Height);
     }
 
     public static void SetWake()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1341,6 +1341,12 @@ public static partial class Toggl
         IntPtr context);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void track_window_size(
+        IntPtr context,
+        UInt64 width,
+        UInt64 height);
+
+        [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void toggl_set_wake(
         IntPtr context);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -79,6 +79,7 @@ namespace TogglDesktop
             this.idleDetectionTimer.Tick += this.onIdleDetectionTimerTick;
 
             this.finalInitialisation();
+            this.trackingWindowSize();
         }
 
         #region properties
@@ -261,6 +262,16 @@ namespace TogglDesktop
             {
                 this.shutdown(0);
             }
+        }
+
+        private void trackingWindowSize()
+        {
+            var currentWindow = this.childWindows.First();
+            if (currentWindow == null)
+            {
+                return;
+            }
+            Toggl.TrackWindowSize(new System.Windows.Size(currentWindow.Width, currentWindow.Height));
         }
 
         #endregion


### PR DESCRIPTION
## ❓ What's this?
A feature to track the size of window when app starts.

 ## 💾 How is it done?
- Implement the tracking logic in `Analytics`, `Context` and `Rectangle`
- Tracking Window Size when the `MainWindowController` didLoad.

 ## 🤯 Changelogs 
- [x] Implement the `Analytics::TrackWindowSize` func with category = `stats` and action = `winsize-{w}x{h}`
- [x] Introduce Rectangle to handle `Rectangle::str()` appropriately.
- [x] Implement `Context::TrackWindowSize(` and execute if it's production env
- [x] Introduce `TrackingService` in macOS app
- [x] [macOS] Track the size of window when `MainWindowController` didLoad.
- [x] [Window] Track the size of window.

 ## 👫 Relationships
Closes #2644

 ## 🔎 Review hints
- Switch app to Production
- Build and run Toggl MacOS, then checking the record in the Google Analytic page when app opens
- or put a breakpoint in `Analytics::TrackWindowSize` to see if it executes when app opens