### PR TITLE
Fix time entry editor tab order (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -7,6 +7,8 @@
 #include <QDebug>  // NOLINT
 #include <QMessageBox>  // NOLINT
 #include <QKeyEvent> // NOLINT
+#include <QTimer> // NOLINT
+#include <QLineEdit> // NOLINT
 
 #include "./autocompleteview.h"
 #include "./genericview.h"
@@ -43,9 +45,6 @@ previousTagList("") {
     toggleNewClientMode(false);
 
     setVisible(false);
-
-    ui->addNewProject->setText(
-        "<a href=\"#add_new_project\">Add new project</a>");
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
@@ -352,16 +351,13 @@ void TimeEntryEditorWidget::on_deleteButton_clicked() {
     }
 }
 
-void TimeEntryEditorWidget::on_addNewProject_linkActivated(
-    const QString &link) {
-
+void TimeEntryEditorWidget::on_addNewProject_clicked() {
     bool hasMultipleWorkspaces = ui->newProjectWorkspace->count() > 1;
     ui->newProjectWorkspace->setVisible(hasMultipleWorkspaces);
     ui->newProjectWorkspaceLabel->setVisible(hasMultipleWorkspaces);
 
-    ui->addNewProject->setVisible(false);
     ui->newProject->setVisible(true);
-    ui->newProjectName->setFocus();
+    ui->addNewProject->setVisible(false);
 
     if (!hasMultipleWorkspaces) {
         ui->newProjectWorkspace->setCurrentIndex(0);
@@ -479,24 +475,26 @@ void TimeEntryEditorWidget::on_tags_itemClicked(QListWidgetItem *item) {
 
 void TimeEntryEditorWidget::toggleNewClientMode(const bool visible) {
     // First hide stuff, to avoid expanding
-    ui->cancelNewClientLabel->setVisible(false);
-    ui->addNewClientLabel->setVisible(false);
+    ui->cancelNewClient->setVisible(false);
+    ui->addNewClient->setVisible(false);
     ui->newProjectClient->setVisible(false);
     ui->newClientName->setVisible(false);
     ui->addClientButton->setVisible(false);
 
     // No display whats needed
-    ui->cancelNewClientLabel->setVisible(visible);
-    ui->addNewClientLabel->setVisible(!visible);
+    ui->cancelNewClient->setVisible(visible);
+    ui->addNewClient->setVisible(!visible);
     ui->newProjectClient->setVisible(!visible);
     ui->newClientName->setVisible(visible);
     ui->addClientButton->setVisible(visible);
 
+    ui->newProjectClient->setFocus();
+    ui->newClientName->setFocus();
+
     ui->newClientName->setText("");
 }
 
-void TimeEntryEditorWidget::on_addNewClientLabel_linkActivated(
-    const QString &link) {
+void TimeEntryEditorWidget::on_addNewClient_clicked() {
     toggleNewClientMode(true);
 }
 
@@ -523,8 +521,7 @@ void TimeEntryEditorWidget::on_addClientButton_clicked() {
     toggleNewClientMode(false);
 }
 
-void TimeEntryEditorWidget::on_cancelNewClientLabel_linkActivated(
-    const QString &link) {
+void TimeEntryEditorWidget::on_cancelNewClient_clicked() {
     toggleNewClientMode(false);
 }
 

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -92,7 +92,7 @@ class TimeEntryEditorWidget : public QWidget {
 
     void on_doneButton_clicked();
     void on_deleteButton_clicked();
-    void on_addNewProject_linkActivated(const QString &link);
+    void on_addNewProject_clicked();
     void on_newProjectWorkspace_currentIndexChanged(int index);
     void on_description_currentIndexChanged(int index);
     void on_description_activated(const QString &arg1);
@@ -103,9 +103,9 @@ class TimeEntryEditorWidget : public QWidget {
     void on_dateEdit_editingFinished();
     void on_billable_clicked(bool checked);
     void on_tags_itemClicked(QListWidgetItem *item);
-    void on_addNewClientLabel_linkActivated(const QString &link);
+    void on_addNewClient_clicked();
     void on_addClientButton_clicked();
-    void on_cancelNewClientLabel_linkActivated(const QString &link);
+    void on_cancelNewClient_clicked();
     void on_colorButton_clicked();
 };
 

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>346</width>
-    <height>545</height>
+    <height>581</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,29 +77,15 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QLabel" name="addNewProject">
-        <property name="font">
-         <font>
-          <pointsize>-1</pointsize>
-         </font>
-        </property>
+       <widget class="QPushButton" name="addNewProject">
         <property name="styleSheet">
-         <string notr="true">font-size:12px;</string>
+         <string notr="true">padding:1;text-align:right;color:palette(link);text-decoration:underline</string>
         </property>
         <property name="text">
-         <string>&lt;a href=&quot;#&quot;&gt;Add new project&lt;/a&gt;</string>
+         <string>Add new project</string>
         </property>
-        <property name="textFormat">
-         <enum>Qt::RichText</enum>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="openExternalLinks">
-         <bool>false</bool>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::TextBrowserInteraction</set>
+        <property name="flat">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -307,38 +293,28 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="addNewClientLabel">
-              <property name="font">
-               <font>
-                <pointsize>-1</pointsize>
-               </font>
+             <widget class="QPushButton" name="addNewClient">
+              <property name="styleSheet">
+               <string notr="true">padding:1px;text-align:right;color:palette(link);text-decoration:underline</string>
               </property>
               <property name="text">
-               <string>&lt;a href=&quot;#&quot;&gt;Add new client&lt;/a&gt;</string>
+               <string>Add new client</string>
               </property>
-              <property name="textFormat">
-               <enum>Qt::RichText</enum>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <property name="flat">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="cancelNewClientLabel">
-              <property name="font">
-               <font>
-                <pointsize>-1</pointsize>
-               </font>
+             <widget class="QPushButton" name="cancelNewClient">
+              <property name="styleSheet">
+               <string notr="true">padding:1px;text-align:right;color:palette(link);text-decoration:underline</string>
               </property>
               <property name="text">
-               <string>&lt;a href=&quot;#&quot;&gt;cancel&lt;/a&gt;</string>
+               <string>Cancel</string>
               </property>
-              <property name="textFormat">
-               <enum>Qt::RichText</enum>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <property name="flat">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -791,7 +767,16 @@
  <tabstops>
   <tabstop>description</tabstop>
   <tabstop>project</tabstop>
+  <tabstop>addNewProject</tabstop>
+  <tabstop>newProjectName</tabstop>
+  <tabstop>colorButton</tabstop>
   <tabstop>publicProject</tabstop>
+  <tabstop>newProjectWorkspace</tabstop>
+  <tabstop>newProjectClient</tabstop>
+  <tabstop>newClientName</tabstop>
+  <tabstop>addClientButton</tabstop>
+  <tabstop>addNewClient</tabstop>
+  <tabstop>cancelNewClient</tabstop>
   <tabstop>duration</tabstop>
   <tabstop>start</tabstop>
   <tabstop>stop</tabstop>
@@ -800,10 +785,6 @@
   <tabstop>billable</tabstop>
   <tabstop>doneButton</tabstop>
   <tabstop>deleteButton</tabstop>
-  <tabstop>newProjectWorkspace</tabstop>
-  <tabstop>newProjectClient</tabstop>
-  <tabstop>newClientName</tabstop>
-  <tabstop>addClientButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This is a fix for #2381.
The gist is: 
* All of the QLabels with URL links were changed to flat QPushButtons that were made to look like a hyperlink through the use of stylesheets. This was done to make them selectable via tabbing.
* The tab order has been changed to reflect the physical order of the elements
* When elements are hidden or shown by user action, sometimes focus has to be forced onto the element that should logically be shown - especially in the case of adding a new client - focus moves back up to the input field or the combobox.