### PR TITLE
Added popup notice about not supported OS X version (mac), closes #2502

### DIFF
--- a/src/ui/osx/TogglDesktop/AboutWindowController.m
+++ b/src/ui/osx/TogglDesktop/AboutWindowController.m
@@ -12,6 +12,11 @@
 #import "DisplayCommand.h"
 #import "Utils.h"
 #import "Sparkle.h"
+#import "UnsupportedNotice.h"
+
+@interface AboutWindowController ()
+@property BOOL unsupportedOS;
+@end
 
 @implementation AboutWindowController
 
@@ -39,6 +44,9 @@ extern void *ctx;
 	self.updateChannelComboBox.stringValue = [NSString stringWithUTF8String:str];
 	free(str);
 
+	NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
+	self.unsupportedOS = (osVersion.majorVersion == 10 && osVersion.minorVersion < 15);
+
 	if ([self updateCheckEnabled])
 	{
 		self.updateChannelComboBox.hidden = NO;
@@ -55,6 +63,12 @@ extern void *ctx;
 
 - (BOOL)updateCheckEnabled
 {
+	if (self.unsupportedOS)
+	{
+		[[UnsupportedNotice sharedInstance] showNotice];
+		return NO;
+	}
+
 	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
 
 	return [infoDict[@"KopsikCheckForUpdates"] boolValue];

--- a/src/ui/osx/TogglDesktop/AboutWindowController.m
+++ b/src/ui/osx/TogglDesktop/AboutWindowController.m
@@ -14,10 +14,6 @@
 #import "Sparkle.h"
 #import "UnsupportedNotice.h"
 
-@interface AboutWindowController ()
-@property BOOL unsupportedOS;
-@end
-
 @implementation AboutWindowController
 
 extern void *ctx;
@@ -44,9 +40,6 @@ extern void *ctx;
 	self.updateChannelComboBox.stringValue = [NSString stringWithUTF8String:str];
 	free(str);
 
-	NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
-	self.unsupportedOS = (osVersion.majorVersion == 10 && osVersion.minorVersion < 15);
-
 	if ([self updateCheckEnabled])
 	{
 		self.updateChannelComboBox.hidden = NO;
@@ -63,9 +56,8 @@ extern void *ctx;
 
 - (BOOL)updateCheckEnabled
 {
-	if (self.unsupportedOS)
+	if (![[UnsupportedNotice sharedInstance] validateOSVersion])
 	{
-		[[UnsupportedNotice sharedInstance] showNotice];
 		return NO;
 	}
 

--- a/src/ui/osx/TogglDesktop/AboutWindowController.m
+++ b/src/ui/osx/TogglDesktop/AboutWindowController.m
@@ -56,11 +56,6 @@ extern void *ctx;
 
 - (BOOL)updateCheckEnabled
 {
-	if (![[UnsupportedNotice sharedInstance] validateOSVersion])
-	{
-		return NO;
-	}
-
 	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
 
 	return [infoDict[@"KopsikCheckForUpdates"] boolValue];
@@ -68,6 +63,10 @@ extern void *ctx;
 
 - (void)checkForUpdates
 {
+	if (![[UnsupportedNotice sharedInstance] validateOSVersion])
+	{
+		return;
+	}
 	if (![self updateCheckEnabled])
 	{
 		return;

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		3C1E013F19D2DAE300DBF9A5 /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 3C1E013E19D2DAE300DBF9A5 /* dsa_pub.pem */; };
 		3C2645A61A2F2AE0007DC17F /* start_button.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 3C2645A41A2F2AE0007DC17F /* start_button.pdf */; };
 		3C2645A71A2F2AE0007DC17F /* stop_button.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 3C2645A51A2F2AE0007DC17F /* stop_button.pdf */; };
+		3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C2F239C21A7B43300CBE6BC /* UnsupportedNotice.m */; };
 		3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C3AF64D20ACC6280088A3A6 /* CountryViewItem.m */; };
 		3C4237171A9F612E00643059 /* toggl-logo-white.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 3C4237151A9F612E00643059 /* toggl-logo-white.pdf */; };
 		3C4237181A9F612E00643059 /* toggl-desktop-bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 3C4237161A9F612E00643059 /* toggl-desktop-bg.png */; };
@@ -336,6 +337,8 @@
 		3C1E013E19D2DAE300DBF9A5 /* dsa_pub.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dsa_pub.pem; sourceTree = "<group>"; };
 		3C2645A41A2F2AE0007DC17F /* start_button.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = start_button.pdf; sourceTree = "<group>"; };
 		3C2645A51A2F2AE0007DC17F /* stop_button.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = stop_button.pdf; sourceTree = "<group>"; };
+		3C2F239B21A7B43300CBE6BC /* UnsupportedNotice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnsupportedNotice.h; sourceTree = "<group>"; };
+		3C2F239C21A7B43300CBE6BC /* UnsupportedNotice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnsupportedNotice.m; sourceTree = "<group>"; };
 		3C3AF64C20ACC6280088A3A6 /* CountryViewItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CountryViewItem.h; sourceTree = "<group>"; };
 		3C3AF64D20ACC6280088A3A6 /* CountryViewItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CountryViewItem.m; sourceTree = "<group>"; };
 		3C4237151A9F612E00643059 /* toggl-logo-white.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "toggl-logo-white.pdf"; sourceTree = "<group>"; };
@@ -811,6 +814,8 @@
 				3CE1CABF1C774F2B00D0ADD5 /* LoadMoreCell.h */,
 				3CE1CAC01C774F2B00D0ADD5 /* LoadMoreCell.m */,
 				3C0158EF1C7B414E00FE63AA /* LoadMoreCell.xib */,
+				3C2F239B21A7B43300CBE6BC /* UnsupportedNotice.h */,
+				3C2F239C21A7B43300CBE6BC /* UnsupportedNotice.m */,
 			);
 			name = ui;
 			path = test2;
@@ -1405,6 +1410,7 @@
 				7423393C1829B99C00063FA9 /* IdleNotificationWindowController.m in Sources */,
 				7430750418204EFB009019CB /* AboutWindowController.m in Sources */,
 				74D1D27217EB72D900E709B0 /* TimerEditViewController.m in Sources */,
+				3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */,
 				741104BF18C7682700BC7A49 /* NSTextFieldWithBackground.m in Sources */,
 				74E3CDCE17FBABE400C3ADD3 /* BugsnagNotifier.m in Sources */,
 				74F8FBA318313FA6000F09EE /* NSTextFieldClickable.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -93,7 +93,6 @@
 void *ctx;
 BOOL manualMode = NO;
 BOOL onTop = NO;
-BOOL unsupportedOS = NO;
 
 - (void)applicationWillFinishLaunching:(NSNotification *)not
 {
@@ -103,9 +102,6 @@ BOOL unsupportedOS = NO;
 	self.showMenuBarTimer = NO;
 
 	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-
-	NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
-	unsupportedOS = (osVersion.majorVersion == 10 && osVersion.minorVersion < 15);
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
@@ -348,11 +344,11 @@ BOOL unsupportedOS = NO;
 
 - (BOOL)updateCheckEnabled
 {
-	if (unsupportedOS)
+	if (![[UnsupportedNotice sharedInstance] validateOSVersion])
 	{
-		[[UnsupportedNotice sharedInstance] showNotice];
 		return NO;
 	}
+
 	if (self.scriptPath)
 	{
 		return NO;

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.h
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.h
@@ -12,8 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UnsupportedNotice : NSAlert
 
+@property (nonatomic, assign, readonly) BOOL unsupportedOS;
+
 + (instancetype)sharedInstance;
 
+- (BOOL)validateOSVersion;
 - (void)showNotice;
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.h
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.h
@@ -1,0 +1,21 @@
+//
+//  UnsupportedNotice.h
+//  TogglDesktop
+//
+//  Created by Indrek Vändrik on 23/11/2018.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UnsupportedNotice : NSAlert
+
++ (instancetype)sharedInstance;
+
+- (void)showNotice;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
@@ -25,7 +25,7 @@
 {
 	NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
 
-	return (osVersion.majorVersion == 10 && osVersion.minorVersion < 15);
+	return (osVersion.majorVersion == 10 && osVersion.minorVersion < 11);
 }
 
 - (instancetype)init

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
@@ -21,6 +21,34 @@
 	return instance;
 }
 
+- (BOOL)unsupportedOS
+{
+	NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
+
+	return (osVersion.majorVersion == 10 && osVersion.minorVersion < 15);
+}
+
+- (instancetype)init
+{
+	self = [super init];
+	if (self)
+	{
+		[self addButtonWithTitle:@"OK"];
+		[self setAlertStyle:NSWarningAlertStyle];
+	}
+
+	return self;
+}
+
+- (BOOL)validateOSVersion
+{
+	if (self.unsupportedOS)
+	{
+		[self showNotice];
+	}
+	return !self.unsupportedOS;
+}
+
 - (void)showNotice
 {
 	NSDate *today = [NSDate date];
@@ -39,8 +67,6 @@
 
 	[self setMessageText:title];
 	[self setInformativeText:text];
-	[self addButtonWithTitle:@"OK"];
-	[self setAlertStyle:NSWarningAlertStyle];
 	[self runModal];
 
 	if (result != NSOrderedAscending)

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
@@ -1,0 +1,52 @@
+//
+//  UnsupportedNotice.m
+//  TogglDesktop
+//
+//  Created by Indrek Vändrik on 23/11/2018.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import "UnsupportedNotice.h"
+
+@implementation UnsupportedNotice
+
++ (instancetype)sharedInstance
+{
+	static UnsupportedNotice *instance;
+	static dispatch_once_t onceToken;
+
+	dispatch_once(&onceToken, ^{
+					  instance = [[UnsupportedNotice alloc] init];
+				  });
+	return instance;
+}
+
+- (void)showNotice
+{
+	NSDate *today = [NSDate date];
+	NSDate *deadline = [NSDate dateWithString:@"2019-01-01 00:00:00 +0000"];
+	NSComparisonResult result = [today compare:deadline];
+
+	NSString *title = [NSString stringWithFormat:@"Mac OS X version not supported"];
+	NSString *text = @"";
+
+	if (result == NSOrderedAscending)
+	{
+		text = @"Toggl Desktop will stop working with your current version of OS X from the 1st of January 2019.\n\n";
+	}
+
+	text = [text stringByAppendingString:@"Please upgrade your system to macOS 10.11 or later to continue using Toggl Desktop."];
+
+	[self setMessageText:title];
+	[self setInformativeText:text];
+	[self addButtonWithTitle:@"OK"];
+	[self setAlertStyle:NSWarningAlertStyle];
+	[self runModal];
+
+	if (result != NSOrderedAscending)
+	{
+		[[NSApplication sharedApplication] terminate:self];
+	}
+}
+
+@end


### PR DESCRIPTION
### What it does?
Detects version of Mac OS X and when the version is older than 10.11 shows the user an alert on app startup and when updater wants to check for a new version. Also when the date is later than 1st of January 2019, it closes the app immediately after the alert is closed.

### How to test?
You probably need to change the version number that is used to detect `unsupportedOS` and then change the deadline date in `UnsupportedNotice` class

When you start the app or open up About window the app should show the popup with the info.

### References
Closes #2502 