### PR TITLE
Fix invalid IBAction connection in TimeEntryEditViewController

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
@@ -28,7 +28,6 @@
                 <outlet property="projectAutoCompleteInput" destination="Z6v-zC-TTo" id="eSi-rz-NIa"/>
                 <outlet property="projectNameTextField" destination="2Pz-WE-b3h" id="K15-Cv-8rM"/>
                 <outlet property="projectOpenButton" destination="wb9-Zz-BWb" id="Vac-9v-ddD"/>
-                <outlet property="projectOpenButtonClicked" destination="wb9-Zz-BWb" id="izh-s3-6Z2"/>
                 <outlet property="projectPublicCheckbox" destination="b5J-U3-cc3" id="qbw-vP-7Yw"/>
                 <outlet property="projectSelectBox" destination="6Sh-4d-bKb" id="gbr-B6-ncX"/>
                 <outlet property="resizeHandle" destination="oCY-bD-X7j" id="jvV-pq-l2V"/>


### PR DESCRIPTION
## ❓ What's this?
There is an IBAction warning in the `TimeEntryEditViewController`

 ## 💾 How is it done?
- Double check and remove the invalid connection.

 ## 🤯 Changelogs 
- Remove the invalid connection `projectOpenButtonClicked` in `TimeEntryEditViewController.xib`

 ## 👫 Relationships
Closes #2648 

 ## 🔎 Review hints
- Build app, and check if the log is gone or not.