### PR TITLE
Use a stacked widget instead of showing and hiding vertically (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -6,12 +6,10 @@
 
 #include "./toggl.h"
 
-LoginWidget::LoginWidget(QWidget *parent) : QWidget(parent),
+LoginWidget::LoginWidget(QStackedWidget *parent) : QWidget(parent),
 ui(new Ui::LoginWidget),
 oauth2(new OAuth2(this)) {
     ui->setupUi(this);
-
-    setVisible(false);
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
@@ -43,6 +41,10 @@ LoginWidget::~LoginWidget() {
     delete ui;
 }
 
+void LoginWidget::display() {
+    qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
+}
+
 void LoginWidget::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
         on_login_clicked();
@@ -54,7 +56,6 @@ void LoginWidget::mousePressEvent(QMouseEvent* event) {
 }
 
 void LoginWidget::displayOverlay(const int64_t type) {
-    setVisible(false);
 }
 
 void LoginWidget::displayLogin(
@@ -62,11 +63,10 @@ void LoginWidget::displayLogin(
     const uint64_t user_id) {
 
     if (open) {
-        setVisible(true);
+        display();
         ui->email->setFocus();
     }
     if (user_id) {
-        setVisible(false);
         ui->password->clear();
     }
 }
@@ -75,9 +75,6 @@ void LoginWidget::displayTimeEntryList(
     const bool open,
     QVector<TimeEntryView *> list,
     const bool) {
-    if (open) {
-        setVisible(false);
-    }
 }
 
 void LoginWidget::on_login_clicked() {

--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 #include <QVector>
+#include <QStackedWidget>
 
 #include <stdint.h>
 
@@ -20,8 +21,10 @@ class LoginWidget : public QWidget {
     Q_OBJECT
 
  public:
-    explicit LoginWidget(QWidget *parent = 0);
+    explicit LoginWidget(QStackedWidget *parent = nullptr);
     ~LoginWidget();
+
+    void display();
 
  protected:
     virtual void keyPressEvent(QKeyEvent *event);

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -16,6 +16,7 @@
 #include <QMessageBox>  // NOLINT
 #include <QSettings>  // NOLINT
 #include <QVBoxLayout>  // NOLINT
+#include <QStackedWidget>  // NOLINT
 #include <QStatusBar>  // NOLINT
 #include <QPushButton>  // NOLINT
 
@@ -61,15 +62,18 @@ MainWindowController::MainWindowController(
 
     ui->menuBar->setVisible(true);
 
-    QVBoxLayout *verticalLayout = new QVBoxLayout();
-    verticalLayout->addWidget(new ErrorViewController());
-    verticalLayout->addWidget(new OverlayWidget());
-    verticalLayout->addWidget(new LoginWidget());
-    verticalLayout->addWidget(new TimeEntryListWidget());
-    verticalLayout->addWidget(new TimeEntryEditorWidget());
+    QStackedWidget *stacked = new QStackedWidget;
+    stacked->addWidget(new OverlayWidget(stacked));
+    stacked->addWidget(new LoginWidget(stacked));
+    stacked->addWidget(new TimeEntryEditorWidget(stacked));
+    stacked->addWidget(new TimeEntryListWidget(stacked));
+    QVBoxLayout *verticalLayout = new QVBoxLayout;
     verticalLayout->setContentsMargins(0, 0, 0, 0);
     verticalLayout->setSpacing(0);
+    verticalLayout->addWidget(new ErrorViewController());
+    verticalLayout->addWidget(stacked);
     centralWidget()->setLayout(verticalLayout);
+
 
     readSettings();
 

--- a/src/ui/linux/TogglDesktop/overlaywidget.cpp
+++ b/src/ui/linux/TogglDesktop/overlaywidget.cpp
@@ -2,12 +2,11 @@
 #include "ui_overlaywidget.h"
 #include "./toggl.h"
 
-OverlayWidget::OverlayWidget(QWidget *parent) :
+OverlayWidget::OverlayWidget(QStackedWidget *parent) :
     QWidget(parent),
     ui(new Ui::OverlayWidget)
 {
     ui->setupUi(this);
-    setVisible(false);
     current_type = -1;
 
     ui->bottomText->setCursor(Qt::PointingHandCursor);
@@ -25,6 +24,10 @@ OverlayWidget::OverlayWidget(QWidget *parent) :
 OverlayWidget::~OverlayWidget()
 {
     delete ui;
+}
+
+void OverlayWidget::display() {
+    qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
 }
 
 void OverlayWidget::displayOverlay(const int64_t type) {
@@ -60,7 +63,7 @@ void OverlayWidget::displayOverlay(const int64_t type) {
     ui->topText->setText(top);
     ui->actionButton->setText(button);
     ui->bottomText->setText(bottom);
-    setVisible(true);
+    display();
 }
 
 void OverlayWidget::displayLogin(
@@ -68,7 +71,6 @@ void OverlayWidget::displayLogin(
     const uint64_t user_id) {
 
     if (open || user_id) {
-        setVisible(false);
     }
 }
 
@@ -76,9 +78,6 @@ void OverlayWidget::displayTimeEntryList(
     const bool open,
     QVector<TimeEntryView *> list,
     const bool) {
-    if (open) {
-        setVisible(false);
-    }
 }
 
 void OverlayWidget::on_actionButton_clicked()

--- a/src/ui/linux/TogglDesktop/overlaywidget.h
+++ b/src/ui/linux/TogglDesktop/overlaywidget.h
@@ -2,6 +2,7 @@
 #define OVERLAYWIDGET_H
 
 #include <QWidget>
+#include <QStackedWidget>
 #include <stdint.h>
 #include "./timeentryview.h"
 
@@ -14,8 +15,9 @@ class OverlayWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit OverlayWidget(QWidget *parent = 0);
+    explicit OverlayWidget(QStackedWidget *parent = nullptr);
     ~OverlayWidget();
+    void display();
 
 private:
     Ui::OverlayWidget *ui;

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -13,7 +13,7 @@
 #include "./timeentryview.h"
 #include "./toggl.h"
 
-TimeEntryEditorWidget::TimeEntryEditorWidget(QWidget *parent) : QWidget(parent),
+TimeEntryEditorWidget::TimeEntryEditorWidget(QStackedWidget *parent) : QWidget(parent),
 ui(new Ui::TimeEntryEditorWidget),
 guid(""),
 timeEntryAutocompleteNeedsUpdate(false),
@@ -41,8 +41,6 @@ previousTagList("") {
     ui->project->installEventFilter(this);
 
     toggleNewClientMode(false);
-
-    setVisible(false);
 
     ui->addNewProject->setText(
         "<a href=\"#add_new_project\">Add new project</a>");
@@ -86,6 +84,10 @@ TimeEntryEditorWidget::~TimeEntryEditorWidget() {
 void TimeEntryEditorWidget::setSelectedColor(QString color) {
     QString style = "font-size:72px;" + color;
     ui->colorButton->setStyleSheet(style);
+}
+
+void TimeEntryEditorWidget::display() {
+    qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
 }
 
 void TimeEntryEditorWidget::displayClientSelect(
@@ -176,13 +178,11 @@ void TimeEntryEditorWidget::displayLogin(
     const bool open,
     const uint64_t user_id) {
     if (open || !user_id) {
-        setVisible(false);
         timer->stop();
     }
 }
 
 void TimeEntryEditorWidget::aboutToDisplayTimeEntryList() {
-    setVisible(false);
     timer->stop();
 }
 
@@ -203,7 +203,7 @@ void TimeEntryEditorWidget::displayTimeEntryEditor(
 
     if (open) {
         // Show the dialog first, hide items later (to preserve size)
-        setVisible(true);
+        display();
 
         // Reset adding new project
         ui->newProject->setVisible(false);

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -7,6 +7,7 @@
 #include <QVector>
 #include <QTimer>
 #include <QListWidgetItem>
+#include <QStackedWidget>
 
 #include <stdint.h>
 #include "./colorpicker.h"
@@ -23,9 +24,11 @@ class TimeEntryEditorWidget : public QWidget {
     Q_OBJECT
 
  public:
-    explicit TimeEntryEditorWidget(QWidget *parent = 0);
+    explicit TimeEntryEditorWidget(QStackedWidget *parent = nullptr);
     ~TimeEntryEditorWidget();
     void setSelectedColor(QString color);
+
+    void display();
 
  private:
     Ui::TimeEntryEditorWidget *ui;

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -7,11 +7,10 @@
 #include "./timerwidget.h"
 #include "./timeentrycellwidget.h"
 
-TimeEntryListWidget::TimeEntryListWidget(QWidget *parent) : QWidget(parent),
-ui(new Ui::TimeEntryListWidget) {
+TimeEntryListWidget::TimeEntryListWidget(QStackedWidget *parent) : QWidget(parent),
+ui(new Ui::TimeEntryListWidget){
     ui->setupUi(this);
 
-    setVisible(false);
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
@@ -32,9 +31,12 @@ TimeEntryListWidget::~TimeEntryListWidget() {
     delete ui;
 }
 
+void TimeEntryListWidget::display() {
+    qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
+}
+
 void TimeEntryListWidget::displayOverlay(
     const int64_t type) {
-    setVisible(false);
 }
 
 void TimeEntryListWidget::displayLogin(
@@ -43,7 +45,6 @@ void TimeEntryListWidget::displayLogin(
 
     if (open || !user_id) {
         ui->list->clear();
-        setVisible(false);
     }
 }
 
@@ -54,7 +55,7 @@ void TimeEntryListWidget::displayTimeEntryList(
 
     int size = list.size();
     if (open) {
-        setVisible(true);
+        display();
     }
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     render_m_.lock();
@@ -105,9 +106,6 @@ void TimeEntryListWidget::displayTimeEntryEditor(
     const bool open,
     TimeEntryView *view,
     const QString focused_field_name) {
-    if (open) {
-        setVisible(false);
-    }
 }
 
 void TimeEntryListWidget::showLoadMoreButton(int size) {

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 #include <QVector>
 #include <QMutex>
+#include <QStackedWidget>
 
 #include <stdint.h>
 
@@ -19,8 +20,10 @@ class TimeEntryListWidget : public QWidget {
     Q_OBJECT
 
  public:
-    explicit TimeEntryListWidget(QWidget *parent = 0);
+    explicit TimeEntryListWidget(QStackedWidget *parent = nullptr);
     ~TimeEntryListWidget();
+
+    void display();
 
  private slots:  // NOLINT
 


### PR DESCRIPTION
This a part of my efforts of bringing the notifications in the line.

At this moment, the different views in the main window are laid out in one single layout and different parts (like TimeEntryList and TimeEntryEdit) get shown/hidden depending on the backend requests. This was not very easy to maintain because with the addition of more views, the programmer would have to check all the other views and make them hide when his new view goes into place.

QStackedWidget takes care of this as it's a widget wrapper that can contain multiple widgets and display only a single one of them at a time as requested. That means now with the addition of a new view, one would have to only request the QStackedWidget to display his new view and the currently shown one gets hidden without any extra effort.

As a nice bonus, everything seems much faster and more fluid when switching between views