### PR TITLE
Clear Old User Notifications

### DIFF
--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		95DBF8CD18BF7A910021FB41 /* offline_on.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8CB18BF7A910021FB41 /* offline_on.pdf */; };
 		95DBF8D718C48B300021FB41 /* logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 95DBF8D618C48B300021FB41 /* logo.png */; };
 		BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11F21A691FF0027B7A5 /* TrackingService.m */; };
+		BAC6850921B6822A00B6C9D7 /* UserNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = BAC6850821B6822A00B6C9D7 /* UserNotificationCenter.m */; };
 		BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
 		C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FBD17F1B08A001C4565 /* MainWindowController.m */; };
@@ -558,6 +559,8 @@
 		95DBF8D618C48B300021FB41 /* logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = logo.png; sourceTree = "<group>"; };
 		BA2DA11E21A691FF0027B7A5 /* TrackingService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackingService.h; sourceTree = "<group>"; };
 		BA2DA11F21A691FF0027B7A5 /* TrackingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrackingService.m; sourceTree = "<group>"; };
+		BAC6850721B6822A00B6C9D7 /* UserNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserNotificationCenter.h; sourceTree = "<group>"; };
+		BAC6850821B6822A00B6C9D7 /* UserNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserNotificationCenter.m; sourceTree = "<group>"; };
 		BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTextField+Ext.h"; sourceTree = "<group>"; };
 		BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextField+Ext.m"; sourceTree = "<group>"; };
 		C5CB7F0217F43EE100A2AEB1 /* TimeEntryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeEntryCell.h; sourceTree = "<group>"; };
@@ -707,6 +710,7 @@
 		69FC17FA17E6534400B96425 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				BAC684F721B6820400B6C9D7 /* UserNotification */,
 				BAF87DDB21A3E1E700624EBE /* Extension */,
 				3C6B246F203E01B70063FC08 /* AutoComplete */,
 				3C068C681C22F25000874B9A /* MKColorWellCustom.h */,
@@ -1025,6 +1029,15 @@
 			);
 			name = MASShortcut;
 			path = ../../../../third_party/MASShortcut;
+			sourceTree = "<group>";
+		};
+		BAC684F721B6820400B6C9D7 /* UserNotification */ = {
+			isa = PBXGroup;
+			children = (
+				BAC6850721B6822A00B6C9D7 /* UserNotificationCenter.h */,
+				BAC6850821B6822A00B6C9D7 /* UserNotificationCenter.m */,
+			);
+			name = UserNotification;
 			sourceTree = "<group>";
 		};
 		BAF87DDB21A3E1E700624EBE /* Extension */ = {
@@ -1366,6 +1379,7 @@
 				747B74871A0AD28200BB3791 /* ConsoleViewController.m in Sources */,
 				3C6B2488203E01D90063FC08 /* AutoCompleteTable.m in Sources */,
 				74AA9472180909F50000539F /* GTMHTTPFetchHistory.m in Sources */,
+				BAC6850921B6822A00B6C9D7 /* UserNotificationCenter.m in Sources */,
 				74E3CDC617FBABE400C3ADD3 /* Bugsnag.m in Sources */,
 				745126B619A28AA600390F47 /* Reachability.m in Sources */,
 				74C1579B183BA5DA00550613 /* AutocompleteDataSource.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -32,6 +32,7 @@
 #import "UnsupportedNotice.h"
 #import "idler.h"
 #import "toggl_api.h"
+#import "UserNotificationCenter.h"
 
 @interface AppDelegate ()
 @property (nonatomic, strong) IBOutlet MainWindowController *mainWindowController;
@@ -1573,76 +1574,20 @@ void on_login(const bool_t open, const uint64_t user_id)
 
 void on_reminder(const char *title, const char *informative_text)
 {
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-
-	// http://stackoverflow.com/questions/11676017/nsusernotification-not-showing-action-button
-	[notification setValue:@YES forKey:@"_showsButtons"];
-
-	[notification setTitle:[NSString stringWithUTF8String:title]];
-	[notification setInformativeText:[NSString stringWithUTF8String:informative_text]];
-	[notification setDeliveryDate:[NSDate dateWithTimeInterval:0 sinceDate:[NSDate date]]];
-
-	notification.userInfo = @{ @"reminder": @"YES" };
-
-	notification.hasActionButton = YES;
-	notification.actionButtonTitle = @"Track";
-	notification.otherButtonTitle = @"Close";
-
-	NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-	[center scheduleNotification:notification];
-
-	// Remove reminder after 45 seconds
-	[center performSelector:@selector(removeDeliveredNotification:)
-				 withObject:notification
-				 afterDelay:45];
+    [[UserNotificationCenter share] scheduleReminderWithTitle:[NSString stringWithUTF8String:title]
+                                              informativeText:[NSString stringWithUTF8String:informative_text]];
 }
 
 void on_pomodoro(const char *title, const char *informative_text)
 {
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-
-	// http://stackoverflow.com/questions/11676017/nsusernotification-not-showing-action-button
-	[notification setValue:@YES forKey:@"_showsButtons"];
-
-	[notification setTitle:[NSString stringWithUTF8String:title]];
-	[notification setInformativeText:[NSString stringWithUTF8String:informative_text]];
-	[notification setDeliveryDate:[NSDate dateWithTimeInterval:0 sinceDate:[NSDate date]]];
-
-	notification.userInfo = @{ @"pomodoro": @"YES" };
-
-	notification.hasActionButton = YES;
-	notification.actionButtonTitle = @"Continue";
-	notification.otherButtonTitle = @"Close";
-
-	NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-	[center scheduleNotification:notification];
-
-	// Play sound
-	[[NSSound soundNamed:@"Glass"] play];
+    [[UserNotificationCenter share] schedulePomodoroWithTitle:[NSString stringWithUTF8String:title]
+                                              informativeText:[NSString stringWithUTF8String:informative_text]];
 }
 
 void on_pomodoro_break(const char *title, const char *informative_text)
 {
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-
-	// http://stackoverflow.com/questions/11676017/nsusernotification-not-showing-action-button
-	[notification setValue:@YES forKey:@"_showsButtons"];
-
-	[notification setTitle:[NSString stringWithUTF8String:title]];
-	[notification setInformativeText:[NSString stringWithUTF8String:informative_text]];
-	[notification setDeliveryDate:[NSDate dateWithTimeInterval:0 sinceDate:[NSDate date]]];
-
-	notification.userInfo = @{ @"pomodoro_break": @"YES" };
-
-	notification.hasActionButton = YES;
-	notification.actionButtonTitle = @"Continue";
-	notification.otherButtonTitle = @"Close";
-
-	NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-	[center scheduleNotification:notification];
-
-	// Play sound
-	[[NSSound soundNamed:@"Glass"] play];
+    [[UserNotificationCenter share] schedulePomodoroBreakWithTitle:[NSString stringWithUTF8String:title]
+                                                   informativeText:[NSString stringWithUTF8String:informative_text]];
 }
 
 void on_url(const char *url)
@@ -1725,26 +1670,9 @@ void on_autotracker_notification(const char_t *project_name,
 								 const uint64_t project_id,
 								 const uint64_t task_id)
 {
-	NSUserNotification *notification = [[NSUserNotification alloc] init];
-
-	// http://stackoverflow.com/questions/11676017/nsusernotification-not-showing-action-button
-	[notification setValue:@YES forKey:@"_showsButtons"];
-
-	notification.title = @"Toggl Desktop Autotracker";
-	notification.informativeText = [NSString stringWithFormat:@"Track %@?",
-									[NSString stringWithUTF8String:project_name]];
-	notification.hasActionButton = YES;
-	notification.actionButtonTitle = @"Start";
-	notification.otherButtonTitle = @"Close";
-	notification.userInfo = @{
-		@"autotracker": @"YES",
-		@"project_id": [NSNumber numberWithLong:project_id],
-		@"task_id": [NSNumber numberWithLong:task_id]
-	};
-	notification.deliveryDate = [NSDate dateWithTimeInterval:0 sinceDate:[NSDate date]];
-
-	NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-	[center scheduleNotification:notification];
+    [[UserNotificationCenter share] scheduleAutoTrackerWithProjectName:[NSString stringWithUTF8String:project_name]
+                                                             projectID:[NSNumber numberWithLong:project_id]
+                                                                taskID:[NSNumber numberWithLong:task_id]];
 }
 
 void on_promotion(const int64_t promotion_type)

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
@@ -12,15 +12,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UserNotificationCenter : NSObject
 
--(instancetype) share;
++(instancetype) share;
 
--(void) deliveryReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+-(void) scheduleReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
 
--(void) deliveryPomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+-(void) schedulePomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
 
--(void) deliveryPomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+-(void) schedulePomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
 
--(void) deliveryAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSString *) projectID taskID:(NSString *) taskID;
+-(void) scheduleAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSNumber *) projectID taskID:(NSNumber *) taskID;
 
 @end
 

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
@@ -1,0 +1,27 @@
+//
+//  UserNotificationCenter.h
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 12/4/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UserNotificationCenter : NSObject
+
+-(instancetype) share;
+
+-(void) deliveryReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+
+-(void) deliveryPomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+
+-(void) deliveryPomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText;
+
+-(void) deliveryAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSString *) projectID taskID:(NSString *) taskID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
@@ -1,0 +1,117 @@
+//
+//  UserNotificationCenter.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 12/4/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import "UserNotificationCenter.h"
+
+@interface UserNotificationCenter()
+@property (strong, nonatomic) NSUserNotificationCenter *center;
+@end
+
+@implementation UserNotificationCenter
+
+-(instancetype) share {
+    static UserNotificationCenter *instance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[UserNotificationCenter alloc] init];
+    });
+    return instance;
+}
+
+-(instancetype)init {
+    self = [super init];
+    if (self) {
+        self.center = [NSUserNotificationCenter defaultUserNotificationCenter];
+    }
+    return self;
+}
+
+-(NSUserNotification *) defaultUserNotificationWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+    [notification setTitle:title];
+    [notification setInformativeText:informativeText];
+
+    // http://stackoverflow.com/questions/11676017/nsusernotification-not-showing-action-button
+    [notification setValue:@YES forKey:@"_showsButtons"];
+    [notification setDeliveryDate:[NSDate dateWithTimeInterval:0 sinceDate:[NSDate date]]];
+
+    return notification;
+}
+
+-(void) deliveryNotification:(NSUserNotification *) notification {
+    [self.center scheduleNotification:notification];
+}
+
+-(void) deliveryReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
+                                                              informativeText:informativeText];
+
+    notification.userInfo = @{ @"reminder": @"YES" };
+    notification.hasActionButton = YES;
+    notification.actionButtonTitle = @"Track";
+    notification.otherButtonTitle = @"Close";
+
+    // Delivery
+    [self deliveryNotification:notification];
+
+    // Remove reminder after 45 seconds
+    [self.center performSelector:@selector(removeDeliveredNotification:)
+                 withObject:notification
+                 afterDelay:45];
+}
+
+-(void) deliveryPomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
+                                                              informativeText:informativeText];
+
+    notification.userInfo = @{ @"pomodoro": @"YES" };
+    notification.hasActionButton = YES;
+    notification.actionButtonTitle = @"Continue";
+    notification.otherButtonTitle = @"Close";
+
+    // Delivery
+    [self deliveryNotification:notification];
+
+    // Play sound
+    [[NSSound soundNamed:@"Glass"] play];
+}
+
+-(void) deliveryPomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
+                                                              informativeText:informativeText];
+
+    notification.userInfo = @{ @"pomodoro_break": @"YES" };
+    notification.hasActionButton = YES;
+    notification.actionButtonTitle = @"Continue";
+    notification.otherButtonTitle = @"Close";
+
+    // Delivery
+    [self deliveryNotification:notification];
+
+    // Play sound
+    [[NSSound soundNamed:@"Glass"] play];
+}
+
+-(void) deliveryAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSNumber *) projectID taskID:(NSNumber *) taskID {
+    NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"Toggl Desktop Autotracker"
+                                                              informativeText:[NSString stringWithFormat:@"Track %@?", projectName]];
+
+    notification.hasActionButton = YES;
+    notification.actionButtonTitle = @"Start";
+    notification.otherButtonTitle = @"Close";
+    notification.userInfo = @{
+                              @"autotracker": @"YES",
+                              @"project_id": projectID,
+                              @"task_id": taskID
+                              };
+
+    // Delivery
+    [self deliveryNotification:notification];
+}
+
+@end

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
@@ -47,6 +47,14 @@
     [self.center scheduleNotification:notification];
 }
 
+-(void)removeAllDeliveredNotificationsWithType:(NSString *) type {
+    for (NSUserNotification *notification in self.center.deliveredNotifications) {
+        if ([notification.userInfo objectForKey:type]) {
+            [self.center removeDeliveredNotification:notification];
+        }
+    }
+}
+
 -(void) scheduleReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
     NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
                                                               informativeText:informativeText];
@@ -57,6 +65,7 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
+    [self removeAllDeliveredNotificationsWithType:@"reminder"];
     [self scheduleNotification:notification];
 
     // Remove reminder after 45 seconds
@@ -75,6 +84,7 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
+    [self removeAllDeliveredNotificationsWithType:@"pomodoro"];
     [self scheduleNotification:notification];
 
     // Play sound
@@ -91,6 +101,7 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
+    [self removeAllDeliveredNotificationsWithType:@"pomodoro_break"];
     [self scheduleNotification:notification];
 
     // Play sound
@@ -111,6 +122,7 @@
                               };
 
     // Delivery
+    [self removeAllDeliveredNotificationsWithType:@"autotracker"];
     [self scheduleNotification:notification];
 }
 

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
@@ -14,7 +14,7 @@
 
 @implementation UserNotificationCenter
 
--(instancetype) share {
++(instancetype)share {
     static UserNotificationCenter *instance;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -31,7 +31,7 @@
     return self;
 }
 
--(NSUserNotification *) defaultUserNotificationWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+-(NSUserNotification *)defaultUserNotificationWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
     [notification setTitle:title];
     [notification setInformativeText:informativeText];
@@ -43,11 +43,11 @@
     return notification;
 }
 
--(void) deliveryNotification:(NSUserNotification *) notification {
+-(void)scheduleNotification:(NSUserNotification *) notification {
     [self.center scheduleNotification:notification];
 }
 
--(void) deliveryReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+-(void) scheduleReminderWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
     NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
                                                               informativeText:informativeText];
 
@@ -57,7 +57,7 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
-    [self deliveryNotification:notification];
+    [self scheduleNotification:notification];
 
     // Remove reminder after 45 seconds
     [self.center performSelector:@selector(removeDeliveredNotification:)
@@ -65,7 +65,7 @@
                  afterDelay:45];
 }
 
--(void) deliveryPomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+-(void)schedulePomodoroWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
     NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
                                                               informativeText:informativeText];
 
@@ -75,13 +75,13 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
-    [self deliveryNotification:notification];
+    [self scheduleNotification:notification];
 
     // Play sound
     [[NSSound soundNamed:@"Glass"] play];
 }
 
--(void) deliveryPomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
+-(void)schedulePomodoroBreakWithTitle:(NSString *) title informativeText:(NSString *) informativeText {
     NSUserNotification *notification = [self defaultUserNotificationWithTitle:title
                                                               informativeText:informativeText];
 
@@ -91,13 +91,13 @@
     notification.otherButtonTitle = @"Close";
 
     // Delivery
-    [self deliveryNotification:notification];
+    [self scheduleNotification:notification];
 
     // Play sound
     [[NSSound soundNamed:@"Glass"] play];
 }
 
--(void) deliveryAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSNumber *) projectID taskID:(NSNumber *) taskID {
+-(void)scheduleAutoTrackerWithProjectName:(NSString *) projectName projectID:(NSNumber *) projectID taskID:(NSNumber *) taskID {
     NSUserNotification *notification = [self defaultUserNotificationWithTitle:@"Toggl Desktop Autotracker"
                                                               informativeText:[NSString stringWithFormat:@"Track %@?", projectName]];
 
@@ -111,7 +111,7 @@
                               };
 
     // Delivery
-    [self deliveryNotification:notification];
+    [self scheduleNotification:notification];
 }
 
 @end


### PR DESCRIPTION
### 📒 Description
There are flood of user notifications if user's computer stays long time.

This PR introduces the new logic to remove/clear `specific` type of delivered notifications before scheduling a the new one.

It also introduce `UserNotificationCenter`, which is in charge of delivery all macOS notifications ⚒. 

### 🕶️ Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (Modularize appropriately the old codebase without modifying the original logic )

### 🤯 List of changes
- [x] Introduce the removal notifications logic (mac)
- [x] Well-organized with UserNotificationCenter (mac)
- [x] Able to remove specific type of notifications rather than wiping out all things 👍
- [x] Introduce the removal notifications logic (windows) (wpf-notifyicon is already supported ⚒)

### 👫 Relationships
Closes #2498 

### 🔎 Review hints
1. Edit `Context::displayReminder()` by reducing the waiting time.
2. Check if old Reminder is remove before presenting new one.
3. Different type notification should be remaining (ex: Pomodoro).