### PR TITLE
Idle Detector Notification

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -248,13 +248,15 @@ BOOL onTop = NO;
 		 }
 	 }];
 
-	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
-														   selector:@selector(receiveSleepNote:)
-															   name:NSWorkspaceWillSleepNotification object:nil];
-
-	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
-														   selector:@selector(receiveWakeNote:)
-															   name:NSWorkspaceDidWakeNotification object:nil];
+    NSDistributedNotificationCenter* distCenter = [NSDistributedNotificationCenter defaultCenter];
+    [distCenter addObserver:self
+                   selector:@selector(onScreenLockedNotification:)
+                       name:@"com.apple.screenIsLocked"
+                     object:nil];
+    [distCenter addObserver:self
+                   selector:@selector(onScreenUnlockedNotification:)
+                       name:@"com.apple.screenIsUnlocked"
+                     object:nil];
 
 	[[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 
@@ -448,15 +450,15 @@ BOOL onTop = NO;
 	NSLog(@"didDeliverNotification %@", notification);
 }
 
-- (void)receiveSleepNote:(NSNotification *)note
+- (void)onScreenLockedNotification:(NSNotification *)note
 {
-	NSLog(@"receiveSleepNote: %@", [note name]);
+	NSLog(@"onScreenLockedNotification: %@", [note name]);
 	toggl_set_sleep(ctx);
 }
 
-- (void)receiveWakeNote:(NSNotification *)note
+- (void)onScreenUnlockedNotification:(NSNotification *)note
 {
-	NSLog(@"receiveWakeNote: %@", [note name]);
+	NSLog(@"onScreenUnlockedNotification: %@", [note name]);
 	toggl_set_wake(ctx);
 }
 


### PR DESCRIPTION
### 📒 Description
According to our user's reports (https://github.com/toggl/toggldesktop/issues/1368, https://github.com/toggl/toggldesktop/issues/1884, https://github.com/toggl/toggldesktop/issues/2534), there was a mysterious reason why the idle detector doesn't detect correctly about a total time.

###  🐞What causes the bug
https://github.com/toggl/toggldesktop/blob/4bdd1c2664db25af0bf9e5b7bd3f9d6ce27c57d1/src/ui/osx/TogglDesktop/test2/AppDelegate.m#L251-L257
We're observing both NSWorkspaceWillSleepNotification and NSWorkspaceDidWakeNotification in order to calculate the idle time. 

However, if the laptop is wake/sleep or power nap many time, it results in the IdleDetector will reset the total time.

### ⛑ Solution
- Introduce `com.apple.screenIsLocked` and `com.apple.screenIsUnlocked` notifications to determine if the user actually opens the app as well as by-pass the PowerNap.

- Additionally, Lock and Unlock notifications are only fired once regardless of how many Wake/Sleep/PowerWake are.

As a result, the total idle time is remaining. 

### 🕶️ Types of change apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Remove NSWorkspaceWillSleepNotification and NSWorkspaceDidWakeNotification
- [x] Adopt `com.apple.screenIsLocked` and `com.apple.screenIsUnlocked`

### 👫 Relationships
Closes #1368
Closes #1884 
Closes #2534 

### ⚒ How to reproduce 
1. Checkout master branch
2. Open Toggl, override Idle time to 1 min (easy to catch the bug 🐞)
3. Start any task
4. Close your Macbook (lid)
=> At this time, NSWorkspaceWillSleepNotification fires
5. Wait 2 min and open the lid, but don't login yet. (This step look like the Macbook is woke by Apple Nap)
=> NSWorkspaceDidWakeNotification fires
=> This time, Toggl starts calculating the idle time.
6. Close the lid again, or just waiting until the mapbook sleeps automatically
=> NSWorkspaceWillSleepNotification starts again in fresh turn.
7. Open the lib, and actually log-in to Desktop.
8. Toggl present your idle time, but it's `lesser` than the expected total time.
9. User reports time idle time is incorrect.

### 🔎 Review hints
1. Do same steps in How to reproduce
2. The expected outcome should be that the idle time is correct. 

### 📦 Playground 
Minimal [app](https://github.com/NghiaTranUIT/SleepWakeNotification) to playaround with Sleep/Wake/Lock/Unlock Notification.

#### Result
- `NSWorkspaceWillSleepNotification` and `NSWorkspaceDidWakeNotification` are called twice
- `com.apple.screenIsLocked` and `com.apple.screenIsUnlocked` are called once regardless of how many time the computer is Wake or Sleep.

```
2018-12-06 13:24:45.345451+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemWillSleep
2018-12-06 13:24:45.346702+0700 SleepWakeObjc[7102:9786233] receiveSleepNote: NSWorkspaceWillSleepNotification
2018-12-06 13:24:45.835739+0700 SleepWakeObjc[7102:9786233] onScreenLocked: com.apple.screenIsLocked
messageType e0000320, arg 00000000
2018-12-06 13:24:47.817737+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemWillPowerOn
messageType e0000300, arg 00000000
2018-12-06 13:24:48.109480+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemHasPoweredOn
2018-12-06 13:24:48.110880+0700 SleepWakeObjc[7102:9786233] receiveWakeNote: NSWorkspaceDidWakeNotification
messageType e0000280, arg 083f0062
2018-12-06 13:24:53.808736+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemWillSleep
2018-12-06 13:24:53.811063+0700 SleepWakeObjc[7102:9786233] receiveSleepNote: NSWorkspaceWillSleepNotification
messageType e0000320, arg 00000000
2018-12-06 13:24:57.548786+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemWillPowerOn
messageType e0000300, arg 00000000
2018-12-06 13:24:57.833532+0700 SleepWakeObjc[7102:9786233] kIOMessageSystemHasPoweredOn
2018-12-06 13:24:57.834756+0700 SleepWakeObjc[7102:9786233] receiveWakeNote: NSWorkspaceDidWakeNotification
2018-12-06 13:24:59.341747+0700 SleepWakeObjc[7102:9786233] onScreenUnlocked: com.apple.screenIsUnlocked
```
