### PR TITLE
[WIP] Add compile-time switches to choose between prod and dev servers (lib)

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -72,11 +72,11 @@ Context::Context(const std::string app_name, const std::string app_version)
 , next_update_timeline_settings_at_(0)
 , next_wake_at_(0)
 , time_entry_editor_guid_("")
-, environment_("production")
+, environment_(APP_ENVIRONMENT)
 , idle_(&ui_)
 , last_sync_started_(0)
 , sync_interval_seconds_(0)
-, update_check_disabled_(false)
+, update_check_disabled_(UPDATE_CHECK_DISABLED)
 , trigger_sync_(false)
 , trigger_push_(false)
 , quit_(false)
@@ -92,8 +92,10 @@ Context::Context(const std::string app_name, const std::string app_version)
         Poco::Net::HTTPSStreamFactory::registerFactory();
     }
 
+#ifndef TOGGL_PRODUCTION_BUILD
     urls::SetUseStagingAsBackend(
         app_version.find("7.0.0") != std::string::npos);
+#endif
 
     Poco::ErrorHandler::set(&error_handler_);
     Poco::Net::initializeSSL();

--- a/src/context.h
+++ b/src/context.h
@@ -27,6 +27,18 @@
 #include "Poco/Timestamp.h"
 #include "Poco/Util/Timer.h"
 
+#ifdef TOGGL_ALLOW_UPDATE_CHECK
+# define UPDATE_CHECK_DISABLED false
+#else
+# define UPDATE_CHECK_DISABLED true
+#endif
+
+#if defined(TOGGL_PRODUCTION_BUILD) && !defined(APP_ENVIRONMENT)
+# define APP_ENVIRONMENT "production"
+#elif !defined(APP_ENVIRONMENT)
+# define APP_ENVIRONMENT "development"
+#endif
+
 namespace toggl {
 
 class Database;


### PR DESCRIPTION
### 📒 Description
This possibly breaks build bots, need to investigate Windows and Mac. Also, README on how to do a release has to be changed.

However, it also makes building the app a bit simpler because we don't have to tweak the stuff by hand, it will now be a simple compile-time switch in Makefile, QMake, VS or in CMake

When building the library, one can now specify:
* `-DTOGGL_PRODUCTION_BUILD=1` for a production build
* `-DTOGGL_ALLOW_UPDATE_CHECK=1` to allow the app to self-update
Not defining these variables makes the lib do the opposite.

### 🕶️ Types of changes
- **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
Let production/development build type be defined by a single commandline switch when building

### 👫 Relationships
Makes stuff easier for #2687

### 🔎 Review hints
Check Mac and Windows builds and if buildbots can handle this instead of commenting out pieces of code "by hand". - I may do this myself tomorrow when I try to reach the buildbots again (or at least the Linux one).
