### PR TITLE
Sync fix

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4220,7 +4220,7 @@ error Context::CreateCompressedTimelineBatchForUpload(TimelineBatch *batch) {
         }
 
         user_->CompressTimeline();
-        error err = save();
+        error err = save(false);
         if (err != noError) {
             return displayError(err);
         }
@@ -4251,7 +4251,7 @@ error Context::StartTimelineEvent(TimelineEvent *event) {
         if (user_ && user_->RecordTimeline()) {
             event->SetUID(static_cast<unsigned int>(user_->ID()));
             user_->related.TimelineEvents.push_back(event);
-            return displayError(save());
+            return displayError(save(false));
         }
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
@@ -4273,7 +4273,7 @@ error Context::MarkTimelineBatchAsUploaded(
             return noError;
         }
         user_->MarkTimelineBatchAsUploaded(events);
-        return displayError(save());
+        return displayError(save(false));
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1070,11 +1070,9 @@ void Context::onSync(Poco::Util::TimerTask& task) {  // NOLINT
     last_sync_started_ = time(0);
 
     // Always sync asyncronously with syncerActivity
-    if (!trigger_sync_) {
-        trigger_sync_ = true;
-        if (!syncer_.isRunning()) {
-            syncer_.start();
-        }
+    trigger_sync_ = true;
+    if (!syncer_.isRunning()) {
+        syncer_.start();
     }
 }
 
@@ -1130,11 +1128,9 @@ void Context::onPushChanges(Poco::Util::TimerTask& task) {  // NOLINT
     logger().debug("onPushChanges executing");
 
     // Always sync asyncronously with syncerActivity
-    if (!trigger_push_) {
-        trigger_push_ = true;
-        if (!syncer_.isRunning()) {
-            syncer_.start();
-        }
+    trigger_push_ = true;
+    if (!syncer_.isRunning()) {
+        syncer_.start();
     }
 }
 


### PR DESCRIPTION
### 📒 Description
Fixes the syncer. The issue was that when the app would go offline it would not go online as the syncer thread was stopped when sync failed (because of being offline) and it was never restarted.

### 🕶️ Types of changes
- **Bug fix** (a non-breaking change which fixes an issue) 

### 🤯 List of changes
- With every sync triggering, we check if the syncer thread is running and start it if it's not. 

### 👫 Relationships
Closes #2685
Closes #2639

### 🔎 Review hints

- Start Toggl Desktop
- Turn off internet connection
- Do some actions so the app detects the missing connection and shows offline message in the bottom of the app
- Turn on internet connection
- Do some actions in app or just trigger Sync from menubar icon menu
- App should now declare itself online and remove the offline message from the bottom bar. All sync should work as expected


