### PR TITLE
Focus on Description TextField in default mode (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -342,6 +342,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	[self.durationTextField setTextColor:[ConvertHexColor hexCodeToNSColor:kInactiveTimerColor]];
 	[self.tagFlag setHidden:YES];
 	[self.billableFlag setHidden:YES];
+	[self.view.window makeFirstResponder:self.autoCompleteInput];
 }
 
 - (NSMutableAttributedString *)setProjectClientLabel:(TimeEntryViewItem *)view_item


### PR DESCRIPTION
### 📒 Description
Tiny change to guarantee that the Description TextField always is focused after stopping a previous timer.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Focus on Description TextField when rendering in default mode.

### 👫 Relationships
Closes #2091 

### 🔎 Review hints
- Checkout master and this PR to determine whether this issue is gone 💯 