### PR TITLE
Fix most linux warnings

### DIFF
--- a/src/ui/linux/TogglDesktop/clickablelabel.cpp
+++ b/src/ui/linux/TogglDesktop/clickablelabel.cpp
@@ -11,6 +11,7 @@ ClickableLabel::~ClickableLabel() {
 }
 
 void ClickableLabel::mousePressEvent(QMouseEvent * event) {
+    Q_UNUSED(event);
     QWidget* parentObject = this->parentWidget();
 
     while (parentObject->objectName().compare("TimeEntryCellWidget") != 0) {

--- a/src/ui/linux/TogglDesktop/colorpicker.cpp
+++ b/src/ui/linux/TogglDesktop/colorpicker.cpp
@@ -55,8 +55,8 @@ void ColorPicker::setColors(QVector<char *> list) {
 }
 
 void ColorPicker::color_clicked() {
-    QString color = ((QPushButton*)sender())->styleSheet();
-    TimeEntryEditorWidget *p =(TimeEntryEditorWidget*)parent();
+    QString color = (qobject_cast<QPushButton*>(sender()))->styleSheet();
+    TimeEntryEditorWidget *p = qobject_cast<TimeEntryEditorWidget*>(parent());
     p->setSelectedColor(color);
     close();
 }

--- a/src/ui/linux/TogglDesktop/errorviewcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/errorviewcontroller.cpp
@@ -47,12 +47,14 @@ void ErrorViewController::displayError(
 
 void ErrorViewController::displayOnlineState(
     int64_t state) {
+    Q_UNUSED(state);
     // FIXME: need separate online state label
 }
 
 void ErrorViewController::displayLogin(
     const bool open,
     const uint64_t user_id) {
+    Q_UNUSED(open);
     uid = user_id;
     if (user_id && isVisible() && loginError) {
         loginError = false;

--- a/src/ui/linux/TogglDesktop/idlenotificationdialog.cpp
+++ b/src/ui/linux/TogglDesktop/idlenotificationdialog.cpp
@@ -94,7 +94,7 @@ void IdleNotificationDialog::displayIdleNotification(
 }
 
 void IdleNotificationDialog::timeout() {
-    Display *display = XOpenDisplay(NULL);
+    Display *display = XOpenDisplay(nullptr);
     if (!display) {
         return;
     }

--- a/src/ui/linux/TogglDesktop/idlenotificationdialog.cpp
+++ b/src/ui/linux/TogglDesktop/idlenotificationdialog.cpp
@@ -68,6 +68,7 @@ void IdleNotificationDialog::on_discardTimeAndContinueButton_clicked() {
 void IdleNotificationDialog::displaySettings(
     const bool open,
     SettingsView *settings) {
+    Q_UNUSED(open);
     if (settings->UseIdleDetection && !timer->isActive()) {
         timer->start(1000);
     } else if (!settings->UseIdleDetection && timer->isActive()) {

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -14,12 +14,6 @@ oauth2(new OAuth2(this)) {
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
 
-    connect(TogglApi::instance, SIGNAL(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)),  // NOLINT
-            this, SLOT(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)));  // NOLINT
-
-    connect(TogglApi::instance, SIGNAL(displayOverlay(int64_t)),  // NOLINT
-            this, SLOT(displayOverlay(int64_t)));  // NOLINT
-
     connect(TogglApi::instance, SIGNAL(setCountries(QVector<CountryView * >)),  // NOLINT
             this, SLOT(setCountries(QVector<CountryView * >)));  // NOLINT
 
@@ -55,9 +49,6 @@ void LoginWidget::mousePressEvent(QMouseEvent* event) {
     setFocus();
 }
 
-void LoginWidget::displayOverlay(const int64_t type) {
-}
-
 void LoginWidget::displayLogin(
     const bool open,
     const uint64_t user_id) {
@@ -69,12 +60,6 @@ void LoginWidget::displayLogin(
     if (user_id) {
         ui->password->clear();
     }
-}
-
-void LoginWidget::displayTimeEntryList(
-    const bool open,
-    QVector<TimeEntryView *> list,
-    const bool) {
 }
 
 void LoginWidget::on_login_clicked() {

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -46,6 +46,7 @@ void LoginWidget::keyPressEvent(QKeyEvent* event) {
 }
 
 void LoginWidget::mousePressEvent(QMouseEvent* event) {
+    Q_UNUSED(event);
     setFocus();
 }
 
@@ -70,6 +71,7 @@ void LoginWidget::on_login_clicked() {
 }
 
 void LoginWidget::on_googleLogin_linkActivated(const QString &link) {
+    Q_UNUSED(link);
     oauth2->startLogin(true);
 }
 
@@ -121,6 +123,7 @@ void LoginWidget::setCountries(
 
 void LoginWidget::on_viewchangelabel_linkActivated(const QString &link)
 {
+    Q_UNUSED(link);
     if (signupVisible) {
         ui->signupFrame->hide();
         ui->loginFrame->show();

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -26,7 +26,7 @@ oauth2(new OAuth2(this)) {
 
     signupVisible = true;
     countriesLoaded = false;
-    selectedCountryId = -1;
+    selectedCountryId = UINT64_MAX;
 
     on_viewchangelabel_linkActivated("");;
 }
@@ -91,7 +91,7 @@ bool LoginWidget::validateFields(const bool signup) {
         return false;
     }
     if (signup) {
-        if (selectedCountryId == -1) {
+        if (selectedCountryId == UINT64_MAX) {
             ui->countryComboBox->setFocus();
             TogglApi::instance->displayError(QString("Please select Country before signing up"), true);
             return false;
@@ -144,7 +144,7 @@ void LoginWidget::on_viewchangelabel_linkActivated(const QString &link)
 void LoginWidget::on_countryComboBox_currentIndexChanged(int index)
 {
     if (index == 0) {
-        selectedCountryId = -1;
+        selectedCountryId = UINT64_MAX;
         return;
     }
     QVariant data = ui->countryComboBox->currentData();

--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -33,16 +33,9 @@ class LoginWidget : public QWidget {
  private slots:  // NOLINT
     void on_login_clicked();
 
-    void displayOverlay(const int64_t type);
-
     void displayLogin(
         const bool open,
         const uint64_t user_id);
-
-    void displayTimeEntryList(
-        const bool open,
-        QVector<TimeEntryView *> list,
-        const bool show_load_more_button);
 
     void on_googleLogin_linkActivated(const QString &link);
 

--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -60,7 +60,7 @@ class LoginWidget : public QWidget {
     bool signupVisible;
 
     bool countriesLoaded;
-    int64_t selectedCountryId;
+    uint64_t selectedCountryId;
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_LOGINWIDGET_H_

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -30,7 +30,7 @@ class TogglApplication : public SingleApplication {
 bool TogglApplication::notify(QObject *receiver, QEvent *event) {
     try {
         return SingleApplication::notify(receiver, event);
-    } catch(std::exception e) {
+    } catch(std::exception &e) {
         TogglApi::notifyBugsnag("std::exception", e.what(),
                                 receiver->objectName());
     } catch(...) {

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) try {
 
     parser.process(a);
 
-    MainWindowController w(0,
+    MainWindowController w(nullptr,
                            parser.value(logPathOption),
                            parser.value(dbPathOption),
                            parser.value(scriptPathOption));

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -24,19 +24,21 @@ class TogglApplication : public SingleApplication {
     TogglApplication(int &argc, char **argv)  // NOLINT
         : SingleApplication(argc, argv) {}
 
-    virtual bool notify(QObject *receiver, QEvent *event) {
-        try {
-            return SingleApplication::notify(receiver, event);
-        } catch(std::exception e) {
-            TogglApi::notifyBugsnag("std::exception", e.what(),
-                                    receiver->objectName());
-        } catch(...) {
-            TogglApi::notifyBugsnag("unspecified", "exception",
-                                    receiver->objectName());
-        }
-        return true;
-    }
+    virtual bool notify(QObject *receiver, QEvent *event);
 };
+
+bool TogglApplication::notify(QObject *receiver, QEvent *event) {
+    try {
+        return SingleApplication::notify(receiver, event);
+    } catch(std::exception e) {
+        TogglApi::notifyBugsnag("std::exception", e.what(),
+                                receiver->objectName());
+    } catch(...) {
+        TogglApi::notifyBugsnag("unspecified", "exception",
+                                receiver->objectName());
+    }
+    return true;
+}
 
 int main(int argc, char *argv[]) try {
     Bugsnag::apiKey = "aa13053a88d5133b688db0f25ec103b7";

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -34,24 +34,24 @@ MainWindowController::MainWindowController(
     QString scriptPath)
     : QMainWindow(parent),
   ui(new Ui::MainWindowController),
-  togglApi(new TogglApi(0, logPathOverride, dbPathOverride)),
+  togglApi(new TogglApi(nullptr, logPathOverride, dbPathOverride)),
   tracking(false),
   loggedIn(false),
-  actionEmail(0),
-  actionNew(0),
-  actionContinue(0),
-  actionStop(0),
-  actionSync(0),
-  actionLogout(0),
-  actionClear_Cache(0),
-  actionSend_Feedback(0),
-  actionReports(0),
+  actionEmail(nullptr),
+  actionNew(nullptr),
+  actionContinue(nullptr),
+  actionStop(nullptr),
+  actionSync(nullptr),
+  actionLogout(nullptr),
+  actionClear_Cache(nullptr),
+  actionSend_Feedback(nullptr),
+  actionReports(nullptr),
   preferencesDialog(new PreferencesDialog(this)),
   aboutDialog(new AboutDialog(this)),
   feedbackDialog(new FeedbackDialog(this)),
   idleNotificationDialog(new IdleNotificationDialog(this)),
-  trayIcon(0),
-  reminderPopup(0),
+  trayIcon(nullptr),
+  reminderPopup(nullptr),
   pomodoro(false),
   reminder(false),
   script(scriptPath),
@@ -136,7 +136,7 @@ MainWindowController::MainWindowController(
 
 MainWindowController::~MainWindowController() {
     delete togglApi;
-    togglApi = 0;
+    togglApi = nullptr;
 
     delete ui;
 }
@@ -390,7 +390,7 @@ void MainWindowController::connectMenuAction(
 }
 
 void MainWindowController::onActionNew() {
-    TogglApi::instance->start("", "", 0, 0, 0, false);
+    TogglApi::instance->start("", "", 0, 0, nullptr, false);
 }
 
 void MainWindowController::onActionContinue() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -257,6 +257,7 @@ void MainWindowController::displayLogin(
 
 void MainWindowController::displayRunningTimerState(
     TimeEntryView *te) {
+    Q_UNUSED(te);
     tracking = true;
     enableMenuActions();
     if (reminder) {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -51,11 +51,11 @@ MainWindowController::MainWindowController(
   feedbackDialog(new FeedbackDialog(this)),
   idleNotificationDialog(new IdleNotificationDialog(this)),
   trayIcon(0),
-  reminder(false),
+  reminderPopup(0),
   pomodoro(false),
+  reminder(false),
   script(scriptPath),
-  ui_started(false),
-  reminderPopup(0) {
+  ui_started(false) {
     TogglApi::instance->setEnvironment(APP_ENVIRONMENT);
 
     ui->setupUi(this);

--- a/src/ui/linux/TogglDesktop/overlaywidget.cpp
+++ b/src/ui/linux/TogglDesktop/overlaywidget.cpp
@@ -82,6 +82,7 @@ void OverlayWidget::on_actionButton_clicked()
 
 void OverlayWidget::on_bottomText_linkActivated(const QString &link)
 {
+    Q_UNUSED(link);
     if (current_type == 0) {
         TogglApi::instance->fullSync();
     }

--- a/src/ui/linux/TogglDesktop/overlaywidget.cpp
+++ b/src/ui/linux/TogglDesktop/overlaywidget.cpp
@@ -14,9 +14,6 @@ OverlayWidget::OverlayWidget(QStackedWidget *parent) :
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
 
-    connect(TogglApi::instance, SIGNAL(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)),  // NOLINT
-            this, SLOT(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)));  // NOLINT
-
     connect(TogglApi::instance, SIGNAL(displayOverlay(int64_t)),  // NOLINT
             this, SLOT(displayOverlay(int64_t)));  // NOLINT
 }
@@ -72,12 +69,6 @@ void OverlayWidget::displayLogin(
 
     if (open || user_id) {
     }
-}
-
-void OverlayWidget::displayTimeEntryList(
-    const bool open,
-    QVector<TimeEntryView *> list,
-    const bool) {
 }
 
 void OverlayWidget::on_actionButton_clicked()

--- a/src/ui/linux/TogglDesktop/overlaywidget.h
+++ b/src/ui/linux/TogglDesktop/overlaywidget.h
@@ -21,7 +21,7 @@ public:
 
 private:
     Ui::OverlayWidget *ui;
-    int current_type;
+    int64_t current_type;
 
 private slots:  // NOLINT
 

--- a/src/ui/linux/TogglDesktop/overlaywidget.h
+++ b/src/ui/linux/TogglDesktop/overlaywidget.h
@@ -31,11 +31,6 @@ private slots:  // NOLINT
        const bool open,
        const uint64_t user_id);
 
-   void displayTimeEntryList(
-       const bool open,
-       QVector<TimeEntryView *> list,
-       const bool show_load_more_button);
-
    void on_actionButton_clicked();
    void on_bottomText_linkActivated(const QString &link);
    void on_topText_linkActivated(const QString &link);

--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -270,6 +270,7 @@ void PreferencesDialog::keyPressEvent(QKeyEvent *event) {
 }
 
 void PreferencesDialog::keyReleaseEvent(QKeyEvent *event) {
+    Q_UNUSED(event);
     saveCurrentShortcut();
 }
 
@@ -293,6 +294,7 @@ bool PreferencesDialog::setProxySettings() {
 }
 
 void PreferencesDialog::on_useProxy_clicked(bool checked) {
+    Q_UNUSED(checked);
     setProxySettings();
 }
 

--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -288,7 +288,7 @@ void PreferencesDialog::saveCurrentShortcut() {
 bool PreferencesDialog::setProxySettings() {
     return TogglApi::instance->setProxySettings(ui->useProxy->isChecked(),
             ui->proxyHost->text(),
-            ui->proxyPort->text().toInt(),
+            ui->proxyPort->text().toULongLong(),
             ui->proxyUsername->text(),
             ui->proxyPassword->text());
 }
@@ -300,22 +300,22 @@ void PreferencesDialog::on_useProxy_clicked(bool checked) {
 
 void PreferencesDialog::on_idleMinutes_editingFinished() {
     TogglApi::instance->setSettingsIdleMinutes(
-        ui->idleMinutes->text().toInt());
+        ui->idleMinutes->text().toULongLong());
 }
 
 void PreferencesDialog::on_reminderMinutes_editingFinished() {
     TogglApi::instance->setSettingsReminderMinutes(
-        ui->reminderMinutes->text().toInt());
+        ui->reminderMinutes->text().toULongLong());
 }
 
 void PreferencesDialog::on_pomodoroMinutes_editingFinished() {
     TogglApi::instance->setSettingsPomodoroMinutes(
-        ui->pomodoroMinutes->text().toInt());
+        ui->pomodoroMinutes->text().toULongLong());
 }
 
 void PreferencesDialog::on_pomodoroBreakMinutes_editingFinished() {
     TogglApi::instance->setSettingsPomodoroBreakMinutes(
-        ui->pomodoroBreakMinutes->text().toInt());
+        ui->pomodoroBreakMinutes->text().toULongLong());
 }
 
 void PreferencesDialog::on_useSystemProxySettings_clicked(bool checked) {

--- a/src/ui/linux/TogglDesktop/singleapplication.cpp
+++ b/src/ui/linux/TogglDesktop/singleapplication.cpp
@@ -9,9 +9,9 @@
 
 SingleApplication::SingleApplication(int &argc, char **argv)
     : QApplication(argc, argv)
-, w(0)
+, w(nullptr)
 , is_running_(false)
-, local_server_(0) {
+, local_server_(nullptr) {
     server_name_ = QFileInfo(
         QCoreApplication::applicationFilePath()).fileName();
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -7,11 +7,11 @@
 
 TimeEntryCellWidget::TimeEntryCellWidget() : QWidget(0),
 ui(new Ui::TimeEntryCellWidget),
-guid(""),
 description(""),
 project(""),
-groupName(""),
-group(false) {
+guid(""),
+group(false),
+groupName("") {
     ui->setupUi(this);
 }
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -5,7 +5,7 @@
 
 #include "./toggl.h"
 
-TimeEntryCellWidget::TimeEntryCellWidget() : QWidget(0),
+TimeEntryCellWidget::TimeEntryCellWidget() : QWidget(nullptr),
 ui(new Ui::TimeEntryCellWidget),
 description(""),
 project(""),

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -366,10 +366,12 @@ void TimeEntryEditorWidget::on_addNewProject_clicked() {
 
 void TimeEntryEditorWidget::on_newProjectWorkspace_currentIndexChanged(
     int index) {
+    Q_UNUSED(index);
     displayClientSelect(clientSelectUpdate);
 }
 
 void TimeEntryEditorWidget::on_description_currentIndexChanged(int index) {
+    Q_UNUSED(index);
     QVariant data = ui->description->currentData();
     if (data.canConvert<AutocompleteView *>()) {
         AutocompleteView *view = data.value<AutocompleteView *>();
@@ -405,6 +407,7 @@ void TimeEntryEditorWidget::on_description_activated(const QString &arg1) {
 }
 
 void TimeEntryEditorWidget::on_project_activated(int index) {
+    Q_UNUSED(index);
     QVariant data = ui->project->currentData();
     if (data.canConvert<AutocompleteView *>()) {
         AutocompleteView *view = data.value<AutocompleteView *>();
@@ -459,6 +462,7 @@ void TimeEntryEditorWidget::timeout() {
 }
 
 void TimeEntryEditorWidget::on_tags_itemClicked(QListWidgetItem *item) {
+    Q_UNUSED(item);
     QStringList tags;
     for (int i = 0; i < ui->tags->count(); i++) {
         QListWidgetItem *widgetItem = ui->tags->item(i);

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -22,8 +22,8 @@ timeEntryAutocompleteNeedsUpdate(false),
 projectAutocompleteNeedsUpdate(false),
 workspaceSelectNeedsUpdate(false),
 clientSelectNeedsUpdate(false),
-timer(new QTimer(this)),
 colorPicker(new ColorPicker(this)),
+timer(new QTimer(this)),
 duration(0),
 previousTagList("") {
     ui->setupUi(this);

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -18,12 +18,6 @@ ui(new Ui::TimeEntryListWidget) {
     connect(TogglApi::instance, SIGNAL(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)),  // NOLINT
             this, SLOT(displayTimeEntryList(bool,QVector<TimeEntryView*>,bool)));  // NOLINT
 
-    connect(TogglApi::instance, SIGNAL(displayTimeEntryEditor(bool,TimeEntryView*,QString)),  // NOLINT
-            this, SLOT(displayTimeEntryEditor(bool,TimeEntryView*,QString)));  // NOLINT
-
-    connect(TogglApi::instance, SIGNAL(displayOverlay(int64_t)),  // NOLINT
-            this, SLOT(displayOverlay(int64_t)));  // NOLINT
-
     ui->blankView->setVisible(false);
 }
 
@@ -33,10 +27,6 @@ TimeEntryListWidget::~TimeEntryListWidget() {
 
 void TimeEntryListWidget::display() {
     qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
-}
-
-void TimeEntryListWidget::displayOverlay(
-    const int64_t type) {
 }
 
 void TimeEntryListWidget::displayLogin(
@@ -100,12 +90,6 @@ void TimeEntryListWidget::displayTimeEntryList(
 
     render_m_.unlock();
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-}
-
-void TimeEntryListWidget::displayTimeEntryEditor(
-    const bool open,
-    TimeEntryView *view,
-    const QString focused_field_name) {
 }
 
 void TimeEntryListWidget::showLoadMoreButton(int size) {

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -117,5 +117,6 @@ void TimeEntryListWidget::showLoadMoreButton(int size) {
 }
 
 void TimeEntryListWidget::on_blankView_linkActivated(const QString &link) {
+    Q_UNUSED(link);
     TogglApi::instance->openInBrowser();
 }

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -53,8 +53,8 @@ void TimeEntryListWidget::displayTimeEntryList(
     for (int i = 0; i < size; i++) {
         TimeEntryView *te = list.at(i);
 
-        QListWidgetItem *item = 0;
-        TimeEntryCellWidget *cell = 0;
+        QListWidgetItem *item = nullptr;
+        TimeEntryCellWidget *cell = nullptr;
 
         if (ui->list->count() > i) {
             item = ui->list->item(i);
@@ -93,8 +93,8 @@ void TimeEntryListWidget::displayTimeEntryList(
 }
 
 void TimeEntryListWidget::showLoadMoreButton(int size) {
-    QListWidgetItem *item = 0;
-    TimeEntryCellWidget *cell = 0;
+    QListWidgetItem *item = nullptr;
+    TimeEntryCellWidget *cell = nullptr;
 
     if (ui->list->count() > size) {
         item = ui->list->item(size);

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -27,8 +27,6 @@ class TimeEntryListWidget : public QWidget {
 
  private slots:  // NOLINT
 
-    void displayOverlay(const int64_t type);
-
     void displayLogin(
         const bool open,
         const uint64_t user_id);
@@ -37,11 +35,6 @@ class TimeEntryListWidget : public QWidget {
         const bool open,
         QVector<TimeEntryView *> list,
         const bool show_load_more_button);
-
-    void displayTimeEntryEditor(
-        const bool open,
-        TimeEntryView *view,
-        const QString focused_field_name);
 
     void showLoadMoreButton(int size);
 

--- a/src/ui/linux/TogglDesktop/timeentryview.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryview.cpp
@@ -60,5 +60,5 @@ QVector<TimeEntryView *> TimeEntryView::importAll(
 
 const QString TimeEntryView::lastUpdate() {
     return QString("Last update ") +
-           QDateTime::fromTime_t(UpdatedAt).toString();
+           QDateTime::fromTime_t(static_cast<uint>(UpdatedAt)).toString();
 }

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -14,9 +14,9 @@ TimerWidget::TimerWidget(QWidget *parent) : QWidget(parent),
 ui(new Ui::TimerWidget),
 timer(new QTimer(this)),
 duration(0),
-timeEntryAutocompleteNeedsUpdate(false),
+project(""),
 tagsHolder(""),
-project("") {
+timeEntryAutocompleteNeedsUpdate(false) {
     ui->setupUi(this);
 
     connect(TogglApi::instance, SIGNAL(displayStoppedTimerState()),

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -219,6 +219,7 @@ void TimerWidget::timeout() {
 }
 
 void TimerWidget::on_description_currentIndexChanged(int index) {
+    Q_UNUSED(index);
     QVariant data = ui->description->currentData();
     if (data.canConvert<AutocompleteView *>()) {
         AutocompleteView *view = data.value<AutocompleteView *>();

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -65,7 +65,7 @@ void on_display_login(
         TogglApi::instance->aboutToDisplayLogin();
     }
     TogglApi::instance->displayLogin(open, user_id);
-    Bugsnag::user.id = user_id;
+    Bugsnag::user.id = QString("%1").arg(user_id);
 }
 
 void on_display_pomodoro(

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -22,7 +22,7 @@
 #include "./settingsview.h"
 #include "./bugsnag.h"
 
-TogglApi *TogglApi::instance = 0;
+TogglApi *TogglApi::instance = nullptr;
 
 QString TogglApi::Project = QString("project");
 QString TogglApi::Duration = QString("duration");
@@ -213,7 +213,7 @@ TogglApi::TogglApi(
     QString dbPathOverride)
     : QObject(parent)
 , shutdown(false)
-, ctx(0) {
+, ctx(nullptr) {
     QString version = QApplication::applicationVersion();
     ctx = toggl_context_init("linux_native_app",
                              version.toStdString().c_str());
@@ -286,9 +286,9 @@ TogglApi::TogglApi(
 
 TogglApi::~TogglApi() {
     toggl_context_clear(ctx);
-    ctx = 0;
+    ctx = nullptr;
 
-    instance = 0;
+    instance = nullptr;
 }
 
 bool TogglApi::notifyBugsnag(
@@ -538,7 +538,7 @@ QString TogglApi::start(
                              duration.toStdString().c_str(),
                              task_id,
                              project_id,
-                             0 /* project guid */,
+                             nullptr /* project guid */,
                              tags /* tags */,
                              false);
     QString res("");


### PR DESCRIPTION
### 📒 Description
Code cleanup and warning fixup in the Linux app

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
* Removed unused (empty) methods
* Marked unused arguments with Q_UNUSED
* Reordered the initialization of class members (this actually matters in C++)
* Changed 0 and NULL to nullptr
* Moved a virtual method out of the class definition - this probably wasn't really an issue but why let the compiler complain about that, right
* Catch exceptions by reference, not value (to avoid casting and copying)
* Used static_cast and qobject_cast instead of C-style casts
* Fixed signed/unsigned number conversions

### 👫 Relationships
Fixes #2674

### 🔎 Review hints
There should be no changes except less warnings when building.

