### PR TITLE
Strange jump in Entry List when the datasource is reloaded

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -188,7 +188,6 @@ extern void *ctx;
 			scrollOrigin.y = self.timeEntriesTableView.bounds.size.height - scrollOrigin.y;
 		}
 	}
-	long delta = (cmd.timeEntries.count + 1 - viewitems.count) * 56;
 	@synchronized(viewitems)
 	{
 		[viewitems removeAllObjects];
@@ -235,7 +234,7 @@ extern void *ctx;
 		if (self.timeEntriesTableView.isFlipped)
 		{
         // calculate new flipped coordinates, height includes the new row
-			scrollOrigin.y = self.timeEntriesTableView.bounds.size.height - scrollOrigin.y - delta;
+			scrollOrigin.y = self.timeEntriesTableView.bounds.size.height - scrollOrigin.y;
 		}
 		[self.timeEntriesTableView scrollPoint:scrollOrigin];
 	}


### PR DESCRIPTION
### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Remove incorrect `delta` variable, which is the root of problem.

### 👫 Relationships
Closes #2671 
Closes #2702 

### 🔎 Review hints
- Check out master and this PR and follow "Replication Steps" in #2702, then checking the result.
