### PR TITLE
Entry Edit Popover should be attached to selected item

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
@@ -1553,12 +1553,12 @@ extern void *ctx;
 
 - (BOOL)isExpanded
 {
-    return self.accessibilityExpanded;
+	return self.accessibilityExpanded;
 }
 
 - (void)setExpanded:(BOOL)expanded
 {
-    self.accessibilityExpanded = expanded;
+	self.accessibilityExpanded = expanded;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -262,6 +262,19 @@ extern void *ctx;
 													  makeIfNecessary  :NO];
 	[rowView setEmphasized:NO];
 	[rowView setSelected:NO];
+
+	if (self.timeEntrypopover.shown) {
+		NSView *selectedView = [self getSelectedEntryCell:self.lastSelectedRowIndex];
+
+		if (selectedView) {
+			NSRect positionRect = [self.timeEntriesTableView convertRect:selectedView.bounds fromView:selectedView];
+			if ([selectedView isKindOfClass:[TimeEntryCellWithHeader class]]) {
+				positionRect.origin.y += 46;
+				positionRect.size.height -= 46;
+			}
+			self.timeEntrypopover.positioningRect = positionRect;
+		}
+	}
 }
 
 - (void)resetEditPopover:(NSNotification *)notification
@@ -287,12 +300,27 @@ extern void *ctx;
 	if (cmd.open)
 	{
 		self.timeEntrypopover.contentViewController = self.timeEntrypopoverViewController;
-		NSRect positionRect = [self.view bounds];
 		self.runningEdit = (cmd.timeEntry.duration_in_seconds < 0);
 
-		[self.timeEntrypopover showRelativeToRect:positionRect
-										   ofView:self.view
-									preferredEdge:NSMaxXEdge];
+		NSView *selectedView = [self getSelectedEntryCell:self.lastSelectedRowIndex];
+
+		if (selectedView) {
+			NSRect positionRect = [self.timeEntriesTableView convertRect:selectedView.bounds fromView:selectedView];
+			if ([selectedView isKindOfClass:[TimeEntryCellWithHeader class]]) {
+				positionRect.origin.y += 46;
+				positionRect.size.height -= 46;
+			}
+			[self.timeEntrypopover showRelativeToRect:positionRect
+											   ofView:self.timeEntriesTableView
+										preferredEdge:NSMaxXEdge];
+		} else {
+			[self.timeEntrypopover showRelativeToRect:self.view.bounds
+											   ofView:self.view
+										preferredEdge:NSMaxXEdge];
+		}
+
+
+
 		BOOL onLeft = (self.view.window.frame.origin.x > self.timeEntryPopupEditView.window.frame.origin.x);
 		[self.timeEntryEditViewController setDragHandle:onLeft];
 		[self.timeEntryEditViewController setInsertionPointColor];

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -243,7 +243,7 @@ extern void *ctx;
 		[self.timeEntriesTableView scrollPoint:scrollOrigin];
 	}
 
-	// Adjust the position of arrow of Popover
+    // Adjust the position of arrow of Popover
 	[self adjustPositionOfPopover];
 
     // If row was focused before reload we restore that state
@@ -270,28 +270,34 @@ extern void *ctx;
 	[rowView setSelected:NO];
 }
 
--(void) adjustPositionOfPopover {
-	if (!self.timeEntrypopover.shown) {
+- (void)adjustPositionOfPopover {
+	if (!self.timeEntrypopover.shown)
+	{
 		return;
 	}
-	if (self.lastSelectedGUID == nil) {
+	if (self.lastSelectedGUID == nil)
+	{
 		return;
 	}
 
-	// Get new selected index depend on last GUID
+    // Get new selected index depend on last GUID
 	NSInteger newSelectedRow = -1;
-	for (NSInteger i = 0; i < viewitems.count; i++) {
+	for (NSInteger i = 0; i < viewitems.count; i++)
+	{
 		id item = viewitems[i];
-		if ([item isKindOfClass:[TimeEntryViewItem class]]) {
-			TimeEntryViewItem *viewItem = (TimeEntryViewItem *) item;
-			if ([viewItem.GUID isEqualToString:self.lastSelectedGUID]) {
+		if ([item isKindOfClass:[TimeEntryViewItem class]])
+		{
+			TimeEntryViewItem *viewItem = (TimeEntryViewItem *)item;
+			if ([viewItem.GUID isEqualToString:self.lastSelectedGUID])
+			{
 				newSelectedRow = i;
 				break;
 			}
 		}
 	}
 
-	if (newSelectedRow >= 0) {
+	if (newSelectedRow >= 0)
+	{
 		NSRect positionRect = [self positionRectOfSelectedRowAtIndex:newSelectedRow];
 		self.timeEntrypopover.positioningRect = positionRect;
 	}
@@ -325,12 +331,13 @@ extern void *ctx;
 		NSView *ofView = self.view;
 		CGRect positionRect = [self positionRectOfSelectedRowAtIndex:self.lastSelectedRowIndex];
 
-		if (self.selectedEntryCell && [self.selectedEntryCell isKindOfClass:[TimeEntryCell class]]) {
-			self.lastSelectedGUID = ((TimeEntryCell *) self.selectedEntryCell).GUID;
+		if (self.selectedEntryCell && [self.selectedEntryCell isKindOfClass:[TimeEntryCell class]])
+		{
+			self.lastSelectedGUID = ((TimeEntryCell *)self.selectedEntryCell).GUID;
 			ofView = self.timeEntriesTableView;
 		}
 
-		// Show popover
+        // Show popover
 		[self.timeEntrypopover showRelativeToRect:positionRect
 										   ofView:ofView
 									preferredEdge:NSMaxXEdge];
@@ -343,19 +350,21 @@ extern void *ctx;
 	}
 }
 
--(CGRect) positionRectOfSelectedRowAtIndex:(NSInteger) index {
+- (CGRect)positionRectOfSelectedRowAtIndex:(NSInteger)index {
 	NSView *selectedView = [self getSelectedEntryCell:index];
 	NSRect positionRect = self.view.bounds;
 
-	if (selectedView) {
+	if (selectedView)
+	{
 		positionRect = [self.timeEntriesTableView convertRect:selectedView.bounds
-															fromView:selectedView];
-		if ([selectedView isKindOfClass:[TimeEntryCellWithHeader class]]) {
+													 fromView:selectedView];
+		if ([selectedView isKindOfClass:[TimeEntryCellWithHeader class]])
+		{
 			positionRect.origin.y += kTimeEntryCellWithHeaderHeight;
 			positionRect.size.height -= kTimeEntryCellWithHeaderHeight;
 		}
 	}
-	return  positionRect;
+	return positionRect;
 }
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification
@@ -779,7 +788,7 @@ extern void *ctx;
 		[session enumerateDraggingItemsWithOptions:NSDraggingItemEnumerationConcurrent
 										   forView:tableView
 										   classes:[NSArray arrayWithObject:[NSPasteboardItem class]]
-									 searchOptions:[NSDictionary<NSPasteboardReadingOptionKey,id> dictionary]
+									 searchOptions:[NSDictionary<NSPasteboardReadingOptionKey, id> dictionary]
 										usingBlock:^(NSDraggingItem *draggingItem, NSInteger idx, BOOL *stop)
 		 {
              // prepare context

--- a/src/ui/osx/TogglDesktop/Utils.m
+++ b/src/ui/osx/TogglDesktop/Utils.m
@@ -108,7 +108,7 @@ extern void *ctx;
 						 stringWithFormat:@"Another copy of %@ is already running.",
 						 [[NSBundle mainBundle]
 						  objectForInfoDictionaryKey:(NSString *)kCFBundleNameKey]];
-        [NSAlert alloc];
+		[NSAlert alloc];
 		[[NSAlert alertWithMessageText:msg
 			 informativeTextWithFormat:@"This copy will now quit."] runModal];
 

--- a/src/ui/osx/TogglDesktop/test2/NSAlert+Utils.h
+++ b/src/ui/osx/TogglDesktop/test2/NSAlert+Utils.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSAlert (Utils)
 
-+(NSAlert *) alertWithMessageText:(NSString *)message informativeTextWithFormat:(NSString *)format, ...;
++ (NSAlert *)alertWithMessageText:(NSString *)message informativeTextWithFormat:(NSString *)format, ...;
 
 @end
 

--- a/src/ui/osx/TogglDesktop/test2/NSAlert+Utils.m
+++ b/src/ui/osx/TogglDesktop/test2/NSAlert+Utils.m
@@ -10,11 +10,13 @@
 
 @implementation NSAlert (Utils)
 
-+(NSAlert *) alertWithMessageText:(NSString *)message informativeTextWithFormat:(NSString *)format, ... {
-    NSAlert *alert = [[NSAlert alloc] init];
-    alert.messageText = message;
-    alert.informativeText = format;
-    return alert;
++ (NSAlert *)alertWithMessageText:(NSString *)message informativeTextWithFormat:(NSString *)format, ...
+{
+	NSAlert *alert = [[NSAlert alloc] init];
+
+	alert.messageText = message;
+	alert.informativeText = format;
+	return alert;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/NSCustomComboBox.m
+++ b/src/ui/osx/TogglDesktop/test2/NSCustomComboBox.m
@@ -40,12 +40,12 @@
 
 - (BOOL)isExpanded
 {
-    return self.accessibilityExpanded;
+	return self.accessibilityExpanded;
 }
 
 - (void)setExpanded:(BOOL)expanded
 {
-    self.accessibilityExpanded = expanded;
+	self.accessibilityExpanded = expanded;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.h
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.h
@@ -16,7 +16,7 @@
 @property (nonatomic, strong) IBOutlet NSImageView *billableFlag;
 @property (nonatomic, strong) IBOutlet NSImageView *tagFlag;
 @property (nonatomic, strong) IBOutlet NSTextField *durationTextField;
-@property (strong) NSString *GUID;
+@property (nonatomic, copy) NSString *GUID;
 @property (strong) NSString *GroupName;
 @property BOOL Group;
 @property BOOL GroupOpen;

--- a/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
+++ b/src/ui/osx/TogglDesktop/test2/UnsupportedNotice.m
@@ -8,7 +8,7 @@
 
 #import "UnsupportedNotice.h"
 
-@interface UnsupportedNotice()
+@interface UnsupportedNotice ()
 @property (strong, nonatomic) NSDateFormatter *dateFormatter;
 @end
 
@@ -40,9 +40,9 @@
 		[self addButtonWithTitle:@"OK"];
 		[self setAlertStyle:NSWarningAlertStyle];
 
-        self.dateFormatter = [[NSDateFormatter alloc] init];
-        self.dateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
-        self.dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+		self.dateFormatter = [[NSDateFormatter alloc] init];
+		self.dateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
+		self.dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 	}
 
 	return self;
@@ -60,7 +60,7 @@
 - (void)showNotice
 {
 	NSDate *today = [NSDate date];
-    NSDate *deadline = [self.dateFormatter dateFromString:@"2019-01-01 00:00:00"];
+	NSDate *deadline = [self.dateFormatter dateFromString:@"2019-01-01 00:00:00"];
 	NSComparisonResult result = [today compare:deadline];
 
 	NSString *title = [NSString stringWithFormat:@"Mac OS X version not supported"];


### PR DESCRIPTION
### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Edit Popover should be presented with correct position, which is calculated by selected item.
- Whenever the list reloads and the popover opens => Update arrow position again, which replies on the last GUID.

### 👫 Relationships
Close #2061 

### 🔎 Review hints
- Checkout master and this PR to see the difference by following the `Step to replicate` in main ticket.