### PR TITLE
Time Reminder issue

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1830,8 +1830,12 @@ error Context::SetSettingsOnTop(const bool on_top) {
 }
 
 error Context::SetSettingsReminder(const bool reminder) {
-    return applySettingsSaveResultToUI(
+    error err = applySettingsSaveResultToUI(
         db()->SetSettingsReminder(reminder));
+    if (err == noError) {
+        resetLastTrackingReminderTime();
+    }
+    return err;
 }
 
 error Context::SetSettingsPomodoro(const bool pomodoro) {

--- a/src/context.h
+++ b/src/context.h
@@ -505,6 +505,7 @@ class Context : public TimelineDatasource {
                                 TimeEntry *te,
                                 const std::string focused_field_name);
     void displayReminder();
+    void resetLastTrackingReminderTime();
 
     void displayPomodoro();
 


### PR DESCRIPTION
### 📒 Description
Whenever we update the time reminder value in Reference, it's critical to reset the last tracking time.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Reset `last_tracking_reminder_time_` whenever we update the reminder value.
- [x] Introduce helper `resetLastTrackingReminderTime` to respect DRY.
- [x] Windows version works well.

### 👫 Relationships
Closes #2692 

### 🔎 Review hints
- Checkout master and this PR, then follow "Steps to replicate" in the ticket
- If it's gone => 💯 