### PR TITLE
Typo in Check For Update item menu

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -29,7 +30,7 @@
                                     <action selector="onViewChangelogMenuItem:" target="494" id="gfS-by-tbT"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Check for update.." id="fZK-ps-0cd">
+                            <menuItem title="Check for update..." id="fZK-ps-0cd">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="checkForUpdates:" target="L4h-36-cEH" id="s3V-9r-CqY"/>

--- a/src/ui/osx/TogglDesktop/test2/et.lproj/MainMenu.strings
+++ b/src/ui/osx/TogglDesktop/test2/et.lproj/MainMenu.strings
@@ -130,8 +130,8 @@
 /* Class = "NSMenuItem"; title = "Show"; ObjectID = "er4-3b-wWC"; */
 "er4-3b-wWC.title" = "Kuva";
 
-/* Class = "NSMenuItem"; title = "Check for update.."; ObjectID = "fZK-ps-0cd"; */
-"fZK-ps-0cd.title" = "Otsi uuendusi..";
+/* Class = "NSMenuItem"; title = "Check for update..."; ObjectID = "fZK-ps-0cd"; */
+"fZK-ps-0cd.title" = "Otsi uuendusi...";
 
 /* Class = "NSMenu"; title = "Timer"; ObjectID = "fl1-3L-kSt"; */
 "fl1-3L-kSt.title" = "Taimer";


### PR DESCRIPTION
### 📒 Description
It's just a tiny PR to fix the typo issue on "Check for update..." item menu

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add 1 fullstop in Check for Update...
- [x] Fix typo in Localization file.

### 👫 Relationships
Close #2722 

### 🔎 Review hints
- The title is correct, which is **Check for update...**
