### PR TITLE
Stop running timer if OS shutdowns or sleep

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -225,6 +225,9 @@ void GoogleAnalyticsSettingsEvent::runTask() {
     setActionBool("pomodoro_break-", settings.pomodoro_break);
     makeReq();
 
+    setActionBool("stop_entry_on_shutdown_sleep-", settings.stop_entry_on_shutdown_sleep);
+    makeReq();
+
     if (settings.pomodoro_break) {
         setActionInt("pomodoro_break_minutes-",
                      settings.pomodoro_break_minutes);

--- a/src/context.cc
+++ b/src/context.cc
@@ -3772,8 +3772,15 @@ Client *Context::CreateClient(
 }
 
 void Context::SetSleep() {
-    logger().debug("SetSleep");
-    idle_.SetSleep();
+
+    // Stop running entry if need
+    const bool isHandled = handleStopRunningEntry();
+
+    // Set Sleep as usual
+    if (!isHandled) {
+        logger().debug("SetSleep");
+        idle_.SetSleep();
+    }
 }
 
 error Context::OpenReportsInBrowser() {
@@ -4005,11 +4012,18 @@ void Context::SetOnline() {
 }
 
 void Context::osShutdown() {
+    handleStopRunningEntry();
+}
+
+const bool Context::handleStopRunningEntry() {
+
+    // Skip if this feature is not enable
     if (!settings_.stop_entry_on_shutdown_sleep) {
-        return;
+        return false;
     }
 
-    Stop(false);
+    // Stop running entry
+    return Stop(false) == noError;
 }
 
 void Context::displayReminder() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1848,6 +1848,11 @@ error Context::SetSettingsPomodoroBreak(const bool pomodoro_break) {
         db()->SetSettingsPomodoroBreak(pomodoro_break));
 }
 
+error Context::SetSettingsStopEntryOnShutdownSleep(const bool stop_entry) {
+    return applySettingsSaveResultToUI(
+        db()->SetSettingsStopEntryOnShutdownSleep(stop_entry));
+}
+
 error Context::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsIdleMinutes(idle_minutes));
@@ -3997,6 +4002,14 @@ void Context::SetOnline() {
     ss << "Next sync at "
        << Formatter::Format8601(next_sync_at_);
     logger().debug(ss.str());
+}
+
+void Context::osShutdown() {
+    if (!settings_.stop_entry_on_shutdown_sleep) {
+        return;
+    }
+
+    Stop(false);
 }
 
 void Context::displayReminder() {

--- a/src/context.h
+++ b/src/context.h
@@ -146,6 +146,8 @@ class Context : public TimelineDatasource {
 
     error SetSettingsPomodoroBreak(const bool pomodoro_break);
 
+    error SetSettingsStopEntryOnShutdownSleep(const bool stop_entry);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool focus_on_shortcut);
@@ -395,6 +397,8 @@ class Context : public TimelineDatasource {
     void SetSleep();
 
     void SetWake();
+
+    void osShutdown();
 
     void SetOnline();
 

--- a/src/context.h
+++ b/src/context.h
@@ -688,6 +688,8 @@ class Context : public TimelineDatasource {
     std::map<std::string, bool_t> entry_groups;
 
     bool overlay_visible_;
+
+    const bool handleStopRunningEntry();
 };
 
 void on_websocket_message(

--- a/src/database.cc
+++ b/src/database.cc
@@ -450,7 +450,7 @@ error Database::LoadSettings(Settings *settings) {
                   "remind_fri, remind_sat, remind_sun, autotrack, "
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
-                  "pomodoro_break, pomodoro_break_minutes "
+                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),
@@ -480,6 +480,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->pomodoro_minutes),
                   into(settings->pomodoro_break),
                   into(settings->pomodoro_break_minutes),
+                  into(settings->stop_entry_on_shutdown_sleep),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {
@@ -837,6 +838,10 @@ error Database::SetSettingsPomodoro(const bool &pomodoro) {
 
 error Database::SetSettingsPomodoroBreak(const bool &pomodoro_break) {
     return setSettingsValue("pomodoro_break", pomodoro_break);
+}
+
+error Database::SetSettingsStopEntryOnShutdownSleep(const bool &stop_entry) {
+    return setSettingsValue("stop_entry_on_shutdown_sleep", stop_entry);
 }
 
 error Database::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {

--- a/src/database.h
+++ b/src/database.h
@@ -108,6 +108,8 @@ class Database {
 
     error SetSettingsPomodoroBreak(const bool &pomodoro_break);
 
+    error SetSettingsStopEntryOnShutdownSleep(const bool &stop_entry);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool &focus_on_shortcut);

--- a/src/gui.h
+++ b/src/gui.h
@@ -234,7 +234,8 @@ class Settings {
     , Pomodoro(false)
     , PomodoroMinutes(0)
     , PomodoroBreak(false)
-    , PomodoroBreakMinutes(0) {}
+    , PomodoroBreakMinutes(0)
+    , StopEntryOnShutdownSleep(false) {}
 
     bool UseProxy;
     std::string ProxyHost;
@@ -268,6 +269,7 @@ class Settings {
     bool PomodoroBreak;
     uint64_t PomodoroMinutes;
     uint64_t PomodoroBreakMinutes;
+    bool StopEntryOnShutdownSleep;
 
     bool operator == (const Settings& other) const;
 };

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1292,6 +1292,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.stop_entry_on_shutdown_sleep",
+        "ALTER TABLE settings "
+        "ADD COLUMN stop_entry_on_shutdown_sleep INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <map>
+#include <functional>
 
 #include "./timeline_event.h"
 #include "./types.h"

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -35,6 +35,7 @@ Json::Value Settings::SaveToJSON() const {
     json["pomodoro_minutes"] = Json::UInt64(pomodoro_minutes);
     json["pomodoro_break"] = pomodoro_break;
     json["pomodoro_break_minutes"] = Json::UInt64(pomodoro_break_minutes);
+	json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
     return json;
 }
 
@@ -67,7 +68,8 @@ std::string Settings::String() const {
        << " pomodoro=" << pomodoro
        << " pomodoro_minutes=" << pomodoro_minutes
        << " pomodoro_break=" << pomodoro_break
-       << " pomodoro_break_minutes=" << pomodoro_break_minutes;
+       << " pomodoro_break_minutes=" << pomodoro_break_minutes
+		<< " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep;
     return ss.str();
 }
 
@@ -98,7 +100,8 @@ bool Settings::IsSame(const Settings &other) const {
             && (pomodoro == other.pomodoro)
             && (pomodoro_minutes == other.pomodoro_minutes)
             && (pomodoro_break == other.pomodoro_break)
-            && (pomodoro_break_minutes == other.pomodoro_break_minutes));
+            && (pomodoro_break_minutes == other.pomodoro_break_minutes)
+			&& (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep));
 }
 
 std::string Settings::ModelName() const {

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -35,7 +35,7 @@ Json::Value Settings::SaveToJSON() const {
     json["pomodoro_minutes"] = Json::UInt64(pomodoro_minutes);
     json["pomodoro_break"] = pomodoro_break;
     json["pomodoro_break_minutes"] = Json::UInt64(pomodoro_break_minutes);
-	json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
+    json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
     return json;
 }
 
@@ -69,7 +69,7 @@ std::string Settings::String() const {
        << " pomodoro_minutes=" << pomodoro_minutes
        << " pomodoro_break=" << pomodoro_break
        << " pomodoro_break_minutes=" << pomodoro_break_minutes
-		<< " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep;
+       << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep;
     return ss.str();
 }
 
@@ -101,7 +101,7 @@ bool Settings::IsSame(const Settings &other) const {
             && (pomodoro_minutes == other.pomodoro_minutes)
             && (pomodoro_break == other.pomodoro_break)
             && (pomodoro_break_minutes == other.pomodoro_break_minutes)
-			&& (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep));
+            && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep));
 }
 
 std::string Settings::ModelName() const {

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,7 +22,6 @@ class Settings : public BaseModel {
     , menubar_project(false)
     , dock_icon(false)
     , on_top(false)
-    , stop_entry_on_shutdown_sleep(false)
     , reminder(false)
     , idle_minutes(0)
     , focus_on_shortcut(true)
@@ -44,7 +43,8 @@ class Settings : public BaseModel {
     , pomodoro(false)
     , pomodoro_minutes(0)
     , pomodoro_break(false)
-    , pomodoro_break_minutes(0) {}
+    , pomodoro_break_minutes(0)
+    , stop_entry_on_shutdown_sleep(false) {}
 
     virtual ~Settings() {}
 
@@ -53,7 +53,6 @@ class Settings : public BaseModel {
     bool menubar_project;
     bool dock_icon;
     bool on_top;
-    bool stop_entry_on_shutdown_sleep;
     bool reminder;
     Poco::UInt64 idle_minutes;
     bool focus_on_shortcut;
@@ -76,6 +75,7 @@ class Settings : public BaseModel {
     bool pomodoro_break;
     Poco::UInt64 pomodoro_minutes;
     Poco::UInt64 pomodoro_break_minutes;
+    bool stop_entry_on_shutdown_sleep;
 
     bool IsSame(const Settings &other) const;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,6 +22,7 @@ class Settings : public BaseModel {
     , menubar_project(false)
     , dock_icon(false)
     , on_top(false)
+    , stop_entry_on_shutdown_sleep(false)
     , reminder(false)
     , idle_minutes(0)
     , focus_on_shortcut(true)
@@ -52,7 +53,7 @@ class Settings : public BaseModel {
     bool menubar_project;
     bool dock_icon;
     bool on_top;
-	bool stop_entry_on_shutdown_sleep;
+    bool stop_entry_on_shutdown_sleep;
     bool reminder;
     Poco::UInt64 idle_minutes;
     bool focus_on_shortcut;

--- a/src/settings.h
+++ b/src/settings.h
@@ -52,6 +52,7 @@ class Settings : public BaseModel {
     bool menubar_project;
     bool dock_icon;
     bool on_top;
+	bool stop_entry_on_shutdown_sleep;
     bool reminder;
     Poco::UInt64 idle_minutes;
     bool focus_on_shortcut;

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1032,7 +1032,6 @@ void toggl_os_shutdown(void *context) {
     if (!context) {
         return;
     }
-
     app(context)->osShutdown();
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -162,6 +162,14 @@ bool_t toggl_set_settings_pomodoro_break(
            SetSettingsPomodoroBreak(pomodoro_break);
 }
 
+bool_t toggl_set_settings_stop_entry_on_shutdown_sleep(
+    void *context,
+    const bool_t stop_entry) {
+    return toggl::noError == app(context)->
+           SetSettingsStopEntryOnShutdownSleep(stop_entry);
+}
+
+
 bool_t toggl_set_settings_idle_minutes(
     void *context,
     const uint64_t idle_minutes) {
@@ -1018,6 +1026,14 @@ void toggl_set_wake(void *context) {
         return;
     }
     app(context)->SetWake();
+}
+
+void toggl_os_shutdown(void *context) {
+    if (!context) {
+        return;
+    }
+
+    app(context)->osShutdown();
 }
 
 void toggl_set_online(void *context) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -160,6 +160,7 @@ extern "C" {
         bool_t PomodoroBreak;
         uint64_t PomodoroMinutes;
         uint64_t PomodoroBreakMinutes;
+        bool_t StopEntryOnShutdownSleep;
     } TogglSettingsView;
 
     typedef struct {
@@ -680,6 +681,10 @@ extern "C" {
         void *context,
         const bool_t pomodoro_break);
 
+    TOGGL_EXPORT bool_t toggl_set_settings_stop_entry_on_shutdown_sleep(
+        void *context,
+        const bool_t stop_entry);
+
     TOGGL_EXPORT bool_t toggl_set_settings_idle_minutes(
         void *context,
         const uint64_t idle_minutes);
@@ -883,6 +888,9 @@ extern "C" {
         void *context);
 
     TOGGL_EXPORT void toggl_set_wake(
+        void *context);
+
+    TOGGL_EXPORT void toggl_os_shutdown(
         void *context);
 
     // Notify lib that client is online again.

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -449,7 +449,7 @@ TogglSettingsView *settings_view_item_init(
     view->PomodoroMinutes = settings.pomodoro_minutes;
     view->PomodoroBreak = settings.pomodoro_break;
     view->PomodoroBreakMinutes = settings.pomodoro_break_minutes;
-
+    view->StopEntryOnShutdownSleep = settings.stop_entry_on_shutdown_sleep;
     return view;
 }
 

--- a/src/ui/linux/TogglDesktop/CMakeLists.txt
+++ b/src/ui/linux/TogglDesktop/CMakeLists.txt
@@ -40,6 +40,7 @@ set(BINARY_SOURCE_FILES
     main.cpp
     mainwindowcontroller.cpp
     overlaywidget.cpp
+    powermanagement.cpp
     preferencesdialog.cpp
     settingsview.cpp
     singleapplication.cpp

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -55,6 +55,7 @@ MainWindowController::MainWindowController(
   trayIcon(nullptr),
   pomodoro(false),
   script(scriptPath),
+  powerManagement(new PowerManagement(this)),
   ui_started(false) {
     TogglApi::instance->setEnvironment(APP_ENVIRONMENT);
 

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -119,6 +119,12 @@ MainWindowController::MainWindowController(
 
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(toggleWindow(QSystemTrayIcon::ActivationReason)));
+
+    // OS shutdown or state change
+    connect(qApp, SIGNAL(commitDataRequest(QSessionManager&)),
+            this, SLOT(commitDataRequest()));
+    connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)),
+            this, SLOT(stateChanged(Qt::ApplicationState)));
 }
 
 MainWindowController::~MainWindowController() {
@@ -501,5 +507,23 @@ void MainWindowController::displayUpdate(const QString url) {
 void MainWindowController::runScript() {
     if (TogglApi::instance->runScriptFile(script)) {
         quitApp();
+    }
+}
+
+void MainWindowController::commitDataRequest() {
+    TogglApi::instance->stopEntryOnShutdown();
+}
+
+void MainWindowController::stateChanged(Qt::ApplicationState state) {
+    switch(state) {
+    case Qt::ApplicationSuspended:
+        TogglApi::instance->stopEntryOnShutdown();
+        break;
+    case Qt::ApplicationHidden:
+        break;
+    case Qt::ApplicationInactive:
+        break;
+    case Qt::ApplicationActive:
+        break;
     }
 }

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -119,12 +119,6 @@ MainWindowController::MainWindowController(
 
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(toggleWindow(QSystemTrayIcon::ActivationReason)));
-
-    // OS shutdown or state change
-    connect(qApp, SIGNAL(commitDataRequest(QSessionManager&)),
-            this, SLOT(commitDataRequest()));
-    connect(qApp, SIGNAL(applicationStateChanged(Qt::ApplicationState)),
-            this, SLOT(stateChanged(Qt::ApplicationState)));
 }
 
 MainWindowController::~MainWindowController() {
@@ -507,23 +501,5 @@ void MainWindowController::displayUpdate(const QString url) {
 void MainWindowController::runScript() {
     if (TogglApi::instance->runScriptFile(script)) {
         quitApp();
-    }
-}
-
-void MainWindowController::commitDataRequest() {
-    TogglApi::instance->stopEntryOnShutdown();
-}
-
-void MainWindowController::stateChanged(Qt::ApplicationState state) {
-    switch(state) {
-    case Qt::ApplicationSuspended:
-        TogglApi::instance->stopEntryOnShutdown();
-        break;
-    case Qt::ApplicationHidden:
-        break;
-    case Qt::ApplicationInactive:
-        break;
-    case Qt::ApplicationActive:
-        break;
     }
 }

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -89,9 +89,6 @@ class MainWindowController : public QMainWindow {
     void updateShowHideShortcut();
     void updateContinueStopShortcut();
 
-    void commitDataRequest();
-    void stateChanged(Qt::ApplicationState state);
-
  private:
     Ui::MainWindowController *ui;
 

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -18,6 +18,7 @@
 #include "./feedbackdialog.h"
 #include "./qxtglobalshortcut.h"
 #include "./systemtray.h"
+#include "./powermanagement.h"
 
 namespace Ui {
 class MainWindowController;
@@ -121,6 +122,8 @@ class MainWindowController : public QMainWindow {
     bool pomodoro;
 
     QString script;
+
+    PowerManagement *powerManagement;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -89,6 +89,9 @@ class MainWindowController : public QMainWindow {
     void updateShowHideShortcut();
     void updateContinueStopShortcut();
 
+    void commitDataRequest();
+    void stateChanged(Qt::ApplicationState state);
+
  private:
     Ui::MainWindowController *ui;
 

--- a/src/ui/linux/TogglDesktop/powermanagement.cpp
+++ b/src/ui/linux/TogglDesktop/powermanagement.cpp
@@ -1,0 +1,52 @@
+// Copyright 2019 Toggl Desktop developers.
+
+#include "./powermanagement.h"
+
+#include "./toggl.h"
+
+PowerManagement::PowerManagement(QObject *parent)
+    : QObject(parent)
+    , available(true)
+{
+    login1 = new QDBusInterface("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", QDBusConnection::systemBus(), this);
+
+    getInhibitor();
+
+    available = available && connect(login1, SIGNAL(PrepareForShutdown(bool)), this, SLOT(onPrepareForShutdown(bool)));
+    available = available && connect(login1, SIGNAL(PrepareForSleep(bool)), this, SLOT(onPrepareForSleep(bool)));
+}
+
+bool PowerManagement::isAvailable() const {
+    return available;
+}
+
+void PowerManagement::onPrepareForShutdown(bool shuttingDown) {
+    if (shuttingDown) {
+        TogglApi::instance->stopEntryOnShutdown();
+        clearInhibitor();
+    }
+    else {
+        // can this even happen?
+        getInhibitor();
+    }
+}
+
+void PowerManagement::onPrepareForSleep(bool suspending) {
+    if (suspending) {
+        TogglApi::instance->stopEntryOnShutdown();
+        clearInhibitor();
+    }
+    else {
+        getInhibitor();
+    }
+}
+
+void PowerManagement::getInhibitor() {
+    auto reply = login1->call("Inhibit", "shutdown:sleep", "TogglDesktop", "To stop the timer on shutdown or suspend", "delay");
+    qCritical() << reply << reply.errorMessage();
+    inhibit = qvariant_cast<QDBusUnixFileDescriptor>(reply.arguments().at(0));
+}
+
+void PowerManagement::clearInhibitor() {
+    inhibit = QDBusUnixFileDescriptor();
+}

--- a/src/ui/linux/TogglDesktop/powermanagement.h
+++ b/src/ui/linux/TogglDesktop/powermanagement.h
@@ -1,0 +1,34 @@
+// Copyright 2019 Toggl Desktop developers.
+
+#ifndef POWERMANAGEMENT_H
+#define POWERMANAGEMENT_H
+
+#include <QObject>
+#include <QtDBus/QtDBus>
+
+class PowerManagement : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PowerManagement(QObject *parent = nullptr);
+
+    bool isAvailable() const;
+
+signals:
+
+public slots:
+
+private slots:
+    void onPrepareForShutdown(bool shuttingDown);
+    void onPrepareForSleep(bool suspending);
+
+    void getInhibitor();
+    void clearInhibitor();
+
+private:
+    QDBusInterface *login1;
+    bool available;
+    QDBusUnixFileDescriptor inhibit;
+};
+
+#endif // POWERMANAGEMENT_H

--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -31,7 +31,7 @@ ui(new Ui::PreferencesDialog) {
     connect(ui->dayCheckbox_5, &QCheckBox::clicked, this, &PreferencesDialog::onDayCheckboxClicked);
     connect(ui->dayCheckbox_6, &QCheckBox::clicked, this, &PreferencesDialog::onDayCheckboxClicked);
     connect(ui->dayCheckbox_7, &QCheckBox::clicked, this, &PreferencesDialog::onDayCheckboxClicked);
-
+    connect(ui->stopEntry, &QCheckBox::clicked, this, &PreferencesDialog::onStopEntryCheckboxClicked);
     keyId = 0;
 }
 
@@ -107,6 +107,8 @@ void PreferencesDialog::displaySettings(const bool open,
 
     ui->reminderStartTimeEdit->setTime(settings->RemindStartTime);
     ui->reminderEndTimeEdit->setTime(settings->RemindEndTime);
+
+    ui->stopEntry->setChecked(settings->StopEntryOnShutdownSleep);
 
     QString sh(TogglApi::instance->getShowHideKey());
     if (sh.length() == 0) {
@@ -348,3 +350,6 @@ void PreferencesDialog::on_focusAppOnShortcut_clicked(bool checked) {
     TogglApi::instance->setSettingsFocusOnShortcut(checked);
 }
 
+void PreferencesDialog::onStopEntryCheckboxClicked(bool checked) {
+    TogglApi::instance->setSettingsStopEntryOnShutdown(checked);
+}

--- a/src/ui/linux/TogglDesktop/preferencesdialog.h
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.h
@@ -65,6 +65,7 @@ class PreferencesDialog : public QDialog {
     void keyPressEvent(QKeyEvent *event);
     void keyReleaseEvent(QKeyEvent *event);
     void saveCurrentShortcut();
+    void onStopEntryCheckboxClicked(bool checked);
 
     void updateShowHideShortcut();
     void updateContinueStopShortcut();

--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>451</width>
-    <height>385</height>
+    <height>388</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,6 +27,133 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0,0">
+       <item row="1" column="0" colspan="3">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Pomodoro</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0,0">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="pomodoroTimer">
+            <property name="styleSheet">
+             <string notr="true">color:rgb(85, 85, 85);</string>
+            </property>
+            <property name="text">
+             <string>Pomodoro timer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="pomodoroMinutes">
+            <property name="maximumSize">
+             <size>
+              <width>60</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>25</string>
+            </property>
+            <property name="maxLength">
+             <number>3</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="pomodoroMinutesLabel">
+            <property name="text">
+             <string>minutes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="pomodoroBreakTimer">
+            <property name="styleSheet">
+             <string notr="true">color:rgb(85, 85, 85);</string>
+            </property>
+            <property name="text">
+             <string>Pomodoro break timer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="pomodoroBreakMinutes">
+            <property name="maximumSize">
+             <size>
+              <width>60</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>25</string>
+            </property>
+            <property name="maxLength">
+             <number>3</number>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="pomodoroBreakMinutesLabel">
+            <property name="text">
+             <string>minutes</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="idleMinutes">
+         <property name="maximumSize">
+          <size>
+           <width>60</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>5</string>
+         </property>
+         <property name="maxLength">
+          <number>3</number>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="idleMinutesLabel">
+         <property name="text">
+          <string>minutes</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="idleDetection">
+         <property name="styleSheet">
+          <string notr="true">color:rgb(85, 85, 85);</string>
+         </property>
+         <property name="text">
+          <string>Idle detection</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="recordTimeline">
+         <property name="styleSheet">
+          <string notr="true">color:rgb(85, 85, 85);</string>
+         </property>
+         <property name="text">
+          <string>Record timeline</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0" colspan="3">
         <widget class="QGroupBox" name="shortcutsGroupBox">
          <property name="title">
@@ -122,134 +249,7 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Pomodoro</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0,0">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="pomodoroTimer">
-            <property name="styleSheet">
-             <string notr="true">color:rgb(85, 85, 85);</string>
-            </property>
-            <property name="text">
-             <string>Pomodoro timer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="pomodoroMinutes">
-            <property name="maximumSize">
-             <size>
-              <width>60</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>25</string>
-            </property>
-            <property name="maxLength">
-             <number>3</number>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="pomodoroMinutesLabel">
-            <property name="text">
-             <string>minutes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="pomodoroBreakTimer">
-            <property name="styleSheet">
-             <string notr="true">color:rgb(85, 85, 85);</string>
-            </property>
-            <property name="text">
-             <string>Pomodoro break timer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="pomodoroBreakMinutes">
-            <property name="maximumSize">
-             <size>
-              <width>60</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>25</string>
-            </property>
-            <property name="maxLength">
-             <number>3</number>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="pomodoroBreakMinutesLabel">
-            <property name="text">
-             <string>minutes</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="idleDetection">
-         <property name="styleSheet">
-          <string notr="true">color:rgb(85, 85, 85);</string>
-         </property>
-         <property name="text">
-          <string>Idle detection</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLineEdit" name="idleMinutes">
-         <property name="maximumSize">
-          <size>
-           <width>60</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>5</string>
-         </property>
-         <property name="maxLength">
-          <number>3</number>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QLabel" name="idleMinutesLabel">
-         <property name="text">
-          <string>minutes</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="recordTimeline">
-         <property name="styleSheet">
-          <string notr="true">color:rgb(85, 85, 85);</string>
-         </property>
-         <property name="text">
-          <string>Record timeline</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -261,6 +261,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="stopEntry">
+         <property name="text">
+          <string>Stop running entry on computer sleep/shutdown</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/ui/linux/TogglDesktop/settingsview.h
+++ b/src/ui/linux/TogglDesktop/settingsview.h
@@ -45,6 +45,7 @@ class SettingsView : public QObject {
         result->RemindOnSunday = view->RemindSun;
         result->RemindStartTime = QTime::fromString(view->RemindStarts, "HH:mm");
         result->RemindEndTime = QTime::fromString(view->RemindEnds, "HH:mm");
+        result->StopEntryOnShutdownSleep = view->StopEntryOnShutdownSleep;
         return result;
     }
 
@@ -77,6 +78,7 @@ class SettingsView : public QObject {
     bool RemindOnSunday;
     QTime RemindStartTime;
     QTime RemindEndTime;
+    bool StopEntryOnShutdownSleep;
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_SETTINGSVIEW_H_

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -506,6 +506,14 @@ bool TogglApi::setUpdateChannel(const QString channel) {
     return toggl_set_update_channel(ctx, channel.toStdString().c_str());
 }
 
+bool TogglApi::setSettingsStopEntryOnShutdown(const bool stop_entry) {
+    return toggl_set_settings_stop_entry_on_shutdown_sleep(ctx, stop_entry);
+}
+
+void TogglApi::stopEntryOnShutdown() {
+    toggl_os_shutdown(ctx);
+}
+
 QString TogglApi::updateChannel() {
     char *channel = toggl_get_update_channel(ctx);
     QString res;

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -176,6 +176,9 @@ class TogglApi : public QObject {
         const QTime &remind_starts,
         const QTime &remind_ends);
 
+    void stopEntryOnShutdown();
+    bool setSettingsStopEntryOnShutdown(const bool stop_entry);
+
     void toggleTimelineRecording(
         const bool recordTimeline);
 

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -342,7 +342,7 @@ const int kUseProxyToConnectToToggl = 2;
 	[self.reminderCheckbox setState:[Utils boolToState:settings.reminder]];
 	[self.focusOnShortcutCheckbox setState:[Utils boolToState:settings.focus_on_shortcut]];
 	[self.renderTimeline setState:[Utils boolToState:settings.render_timeline]];
-
+	[self.stopOnShutdownCheckbox setState:[Utils boolToState:settings.stopWhenShutdown]];
 	[self.recordTimelineCheckbox setEnabled:self.user_id != 0];
 	[self.recordTimelineCheckbox setState:[Utils boolToState:settings.timeline_recording_enabled]];
 
@@ -483,9 +483,8 @@ const int kUseProxyToConnectToToggl = 2;
 
 - (IBAction)stopOnShutdownAndSleepOnChange:(NSButtonCell *)sender
 {
-	
+	toggl_set_settings_stop_entry_on_shutdown_sleep(ctx, [Utils stateToBool:[self.stopOnShutdownCheckbox state]]);
 }
-
 
 // NSTableViewDataSource - autotracker rules table
 

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -25,6 +25,8 @@ NSString *const kPreferenceGlobalShortcutStartStop = @"TogglDesktopGlobalShortcu
 @property AutocompleteDataSource *autotrackerProjectAutocompleteDataSource;
 @property AutocompleteDataSource *defaultProjectAutocompleteDataSource;
 @property NSMutableArray *termAutocompleteItems;
+@property (weak) IBOutlet NSButtonCell *stopOnShutdownCheckbox;
+
 @end
 
 @implementation PreferencesWindowController
@@ -478,6 +480,12 @@ const int kUseProxyToConnectToToggl = 2;
 	self.autotrackerTerm.stringValue = @"";
 	self.autotrackerProject.stringValue = @"";
 }
+
+- (IBAction)stopOnShutdownAndSleepOnChange:(NSButtonCell *)sender
+{
+	
+}
+
 
 // NSTableViewDataSource - autotracker rules table
 

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -25,7 +25,7 @@ NSString *const kPreferenceGlobalShortcutStartStop = @"TogglDesktopGlobalShortcu
 @property AutocompleteDataSource *autotrackerProjectAutocompleteDataSource;
 @property AutocompleteDataSource *defaultProjectAutocompleteDataSource;
 @property NSMutableArray *termAutocompleteItems;
-@property (weak) IBOutlet NSButtonCell *stopOnShutdownCheckbox;
+@property (weak) IBOutlet NSButton *stopOnShutdownCheckbox;
 
 @end
 
@@ -481,7 +481,7 @@ const int kUseProxyToConnectToToggl = 2;
 	self.autotrackerProject.stringValue = @"";
 }
 
-- (IBAction)stopOnShutdownAndSleepOnChange:(NSButtonCell *)sender
+- (IBAction)stopOnShutdownAndSleepOnChange:(NSButton *)sender
 {
 	toggl_set_settings_stop_entry_on_shutdown_sleep(ctx, [Utils stateToBool:[self.stopOnShutdownCheckbox state]]);
 }

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -42,6 +42,7 @@
                 <outlet property="reminderMinutesTextField" destination="R9v-BZ-yhR" id="OVt-ic-hzF"/>
                 <outlet property="showHideShortcutView" destination="DLB-Fw-7tX" id="T2o-mF-KXG"/>
                 <outlet property="startStopShortcutView" destination="Ft4-tk-xRA" id="5tb-G5-s2R"/>
+                <outlet property="stopOnShutdownCheckbox" destination="n3k-Br-KIY" id="guw-6w-Kef"/>
                 <outlet property="useIdleDetectionButton" destination="Lgk-gZ-8Ha" id="Erp-FO-vcw"/>
                 <outlet property="usePomodoroBreakButton" destination="BzK-d8-1HF" id="nWi-xj-Mxm"/>
                 <outlet property="usePomodoroButton" destination="Rmf-uW-sZP" id="fZa-h4-WjK"/>
@@ -54,23 +55,23 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="Preferences" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="450" height="435"/>
+            <rect key="contentRect" x="196" y="240" width="450" height="459"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="450" height="435"/>
+                <rect key="frame" x="0.0" y="0.0" width="450" height="459"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView translatesAutoresizingMaskIntoConstraints="NO" id="ZDX-gA-MBn">
-                        <rect key="frame" x="-7" y="-10" width="464" height="443"/>
+                        <rect key="frame" x="-7" y="-10" width="464" height="467"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="3dj-rq-0aF">
                                 <view key="view" id="7qY-5d-VHf">
-                                    <rect key="frame" x="10" y="33" width="444" height="397"/>
+                                    <rect key="frame" x="10" y="33" width="444" height="421"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="Lgk-gZ-8Ha">
-                                            <rect key="frame" x="14" y="318" width="105" height="18"/>
+                                            <rect key="frame" x="14" y="342" width="105" height="18"/>
                                             <buttonCell key="cell" type="check" title="Idle detection" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Z6U-JU-oVS">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -81,7 +82,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nRj-Zh-L5m">
-                                            <rect key="frame" x="288" y="316" width="38" height="22"/>
+                                            <rect key="frame" x="288" y="340" width="38" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="Kvx-Gb-5cr"/>
                                                 <constraint firstAttribute="height" constant="22" id="bc3-GI-FLm"/>
@@ -98,7 +99,7 @@
                                             </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Khj-es-fgU">
-                                            <rect key="frame" x="334" y="319" width="53" height="17"/>
+                                            <rect key="frame" x="334" y="343" width="53" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="Zfu-jF-pu2">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -106,7 +107,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="Rmf-uW-sZP" userLabel="pomodoro timer">
-                                            <rect key="frame" x="14" y="294" width="120" height="18"/>
+                                            <rect key="frame" x="14" y="318" width="120" height="18"/>
                                             <buttonCell key="cell" type="check" title="Pomodoro timer" bezelStyle="regularSquare" imagePosition="left" inset="2" id="2eM-Mq-Qkk">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -117,7 +118,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bCE-Cp-Ipc">
-                                            <rect key="frame" x="288" y="292" width="38" height="22"/>
+                                            <rect key="frame" x="288" y="316" width="38" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="bc4-fl-TDP"/>
                                                 <constraint firstAttribute="height" constant="22" id="ozO-hP-Ur0"/>
@@ -133,7 +134,7 @@
                                             </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ufH-RC-hfd">
-                                            <rect key="frame" x="334" y="295" width="53" height="17"/>
+                                            <rect key="frame" x="334" y="319" width="53" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="uD2-dD-ZQE">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -141,7 +142,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="BzK-d8-1HF" userLabel="pomodoro break timer">
-                                            <rect key="frame" x="14" y="270" width="122" height="18"/>
+                                            <rect key="frame" x="14" y="294" width="122" height="18"/>
                                             <buttonCell key="cell" type="check" title="Pomodoro break" bezelStyle="regularSquare" imagePosition="left" inset="2" id="fa3-Br-Doo">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -152,7 +153,7 @@
                                             </connections>
                                         </button>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rmD-4u-Dda">
-                                            <rect key="frame" x="288" y="268" width="38" height="22"/>
+                                            <rect key="frame" x="288" y="292" width="38" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="L7D-Lz-n3c"/>
                                                 <constraint firstAttribute="height" constant="22" id="mhi-IV-f2K"/>
@@ -168,7 +169,7 @@
                                             </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vM4-Nq-b4v">
-                                            <rect key="frame" x="334" y="271" width="53" height="17"/>
+                                            <rect key="frame" x="334" y="295" width="53" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="MLE-d1-bsN">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -176,7 +177,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K6B-0p-RS0">
-                                            <rect key="frame" x="14" y="377" width="107" height="17"/>
+                                            <rect key="frame" x="14" y="401" width="107" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show/Hide Toggl" id="ZgR-r3-20o">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +185,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="DLB-Fw-7tX" customClass="MASShortcutView">
-                                            <rect key="frame" x="288" y="375" width="140" height="22"/>
+                                            <rect key="frame" x="288" y="399" width="140" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="140" id="ars-NE-9zw"/>
                                                 <constraint firstAttribute="height" constant="22" id="kFH-FJ-b0C"/>
@@ -194,7 +195,7 @@
                                             </connections>
                                         </customView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h4c-1q-AeO">
-                                            <rect key="frame" x="14" y="350" width="126" height="17"/>
+                                            <rect key="frame" x="14" y="374" width="126" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Continue/Stop timer" id="SH4-aB-XUn">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -202,14 +203,14 @@
                                             </textFieldCell>
                                         </textField>
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Ft4-tk-xRA" customClass="MASShortcutView">
-                                            <rect key="frame" x="288" y="348" width="140" height="22"/>
+                                            <rect key="frame" x="288" y="372" width="140" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="22" id="8gq-eJ-P9P"/>
                                                 <constraint firstAttribute="width" constant="140" id="hbh-Ud-GvF"/>
                                             </constraints>
                                         </customView>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="lUE-Lr-nId">
-                                            <rect key="frame" x="14" y="211" width="170" height="18"/>
+                                            <rect key="frame" x="14" y="235" width="170" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show timer on menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="d1o-e3-Xs6">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -220,7 +221,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="V28-KN-5Vi">
-                                            <rect key="frame" x="14" y="246" width="117" height="18"/>
+                                            <rect key="frame" x="14" y="270" width="117" height="18"/>
                                             <buttonCell key="cell" type="check" title="Record timeline" bezelStyle="regularSquare" imagePosition="left" enabled="NO" inset="2" id="yIY-fe-UHc">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -231,7 +232,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="jRq-Fm-A6k">
-                                            <rect key="frame" x="14" y="187" width="181" height="18"/>
+                                            <rect key="frame" x="14" y="211" width="181" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show project on menu bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="CM9-BW-DQq">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -242,7 +243,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="kR2-Ee-viZ">
-                                            <rect key="frame" x="14" y="163" width="118" height="18"/>
+                                            <rect key="frame" x="14" y="187" width="118" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show dock icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="L9v-Ys-EtJ">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -253,7 +254,7 @@
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="n4h-zi-TcC">
-                                            <rect key="frame" x="14" y="139" width="240" height="18"/>
+                                            <rect key="frame" x="14" y="163" width="240" height="18"/>
                                             <buttonCell key="cell" type="check" title="Keep Toggl on top of other windows" bezelStyle="regularSquare" imagePosition="left" inset="2" id="shd-cT-4Jq">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -261,6 +262,16 @@
                                             <connections>
                                                 <action selector="ontopCheckboxChanged:" target="-2" id="nUW-Em-4oo"/>
                                                 <outlet property="nextKeyView" destination="yWA-BY-OMt" id="fhP-6v-d4m"/>
+                                            </connections>
+                                        </button>
+                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="n3k-Br-KIY">
+                                            <rect key="frame" x="14" y="139" width="315" height="18"/>
+                                            <buttonCell key="cell" type="check" title="Stop running entry on computer sleep/shutdown" bezelStyle="regularSquare" imagePosition="left" inset="2" id="aNu-ho-0Fk">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="stopOnShutdownAndSleepOnChange:" target="-2" id="dB5-5Q-HFh"/>
                                             </connections>
                                         </button>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="yWA-BY-OMt">
@@ -286,7 +297,7 @@
                                             </connections>
                                         </button>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="poP-TW-xtx">
-                                            <rect key="frame" x="16" y="235" width="412" height="5"/>
+                                            <rect key="frame" x="16" y="259" width="412" height="5"/>
                                         </box>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="9TR-Ue-Rqe">
                                             <rect key="frame" x="16" y="128" width="412" height="5"/>
@@ -335,6 +346,7 @@
                                     <constraints>
                                         <constraint firstItem="Rmf-uW-sZP" firstAttribute="top" secondItem="Lgk-gZ-8Ha" secondAttribute="bottom" constant="10" id="1Hv-gm-5tI"/>
                                         <constraint firstItem="BzK-d8-1HF" firstAttribute="leading" secondItem="Rmf-uW-sZP" secondAttribute="leading" id="4UU-y1-6NO"/>
+                                        <constraint firstItem="n3k-Br-KIY" firstAttribute="leading" secondItem="n4h-zi-TcC" secondAttribute="leading" id="4sA-ii-5ak"/>
                                         <constraint firstAttribute="trailing" secondItem="H8P-uU-DzS" secondAttribute="trailing" constant="16" id="5ad-g5-bi5"/>
                                         <constraint firstItem="V28-KN-5Vi" firstAttribute="leading" secondItem="BzK-d8-1HF" secondAttribute="leading" id="7Xk-Tk-6ri"/>
                                         <constraint firstItem="lUE-Lr-nId" firstAttribute="leading" secondItem="V28-KN-5Vi" secondAttribute="leading" id="7dt-CF-yzE"/>
@@ -348,6 +360,7 @@
                                         <constraint firstItem="DRh-rC-B0a" firstAttribute="top" secondItem="yWA-BY-OMt" secondAttribute="bottom" constant="10" id="CRT-eU-Qew"/>
                                         <constraint firstItem="n4h-zi-TcC" firstAttribute="top" secondItem="kR2-Ee-viZ" secondAttribute="bottom" constant="10" id="D1a-T6-qfR"/>
                                         <constraint firstItem="Ft4-tk-xRA" firstAttribute="trailing" secondItem="DLB-Fw-7tX" secondAttribute="trailing" id="F2N-pL-ZIT"/>
+                                        <constraint firstItem="n3k-Br-KIY" firstAttribute="top" secondItem="n4h-zi-TcC" secondAttribute="bottom" constant="10" id="F3F-lp-2ng"/>
                                         <constraint firstItem="bCE-Cp-Ipc" firstAttribute="centerY" secondItem="Rmf-uW-sZP" secondAttribute="centerY" id="G9A-Uh-Gnl"/>
                                         <constraint firstItem="Rmf-uW-sZP" firstAttribute="leading" secondItem="Lgk-gZ-8Ha" secondAttribute="leading" id="HSo-Fn-z7e"/>
                                         <constraint firstAttribute="trailing" secondItem="9TR-Ue-Rqe" secondAttribute="trailing" constant="16" id="I9h-mY-80q"/>
@@ -377,8 +390,8 @@
                                         <constraint firstItem="rmD-4u-Dda" firstAttribute="leading" secondItem="bCE-Cp-Ipc" secondAttribute="leading" id="gWh-8U-FI2"/>
                                         <constraint firstItem="K6B-0p-RS0" firstAttribute="leading" secondItem="7qY-5d-VHf" secondAttribute="leading" constant="16" id="gkL-2Y-GFc"/>
                                         <constraint firstItem="ufH-RC-hfd" firstAttribute="leading" secondItem="bCE-Cp-Ipc" secondAttribute="trailing" constant="10" id="jnr-ut-4QU"/>
+                                        <constraint firstItem="9TR-Ue-Rqe" firstAttribute="top" secondItem="n3k-Br-KIY" secondAttribute="bottom" constant="10" id="kae-py-y5M"/>
                                         <constraint firstItem="n4h-zi-TcC" firstAttribute="leading" secondItem="kR2-Ee-viZ" secondAttribute="leading" id="lGu-u1-3s5"/>
-                                        <constraint firstItem="9TR-Ue-Rqe" firstAttribute="top" secondItem="n4h-zi-TcC" secondAttribute="bottom" constant="10" id="n8N-H1-eCP"/>
                                         <constraint firstItem="TkJ-tA-lDK" firstAttribute="leading" secondItem="DRh-rC-B0a" secondAttribute="leading" id="nZj-dZ-xy8"/>
                                         <constraint firstAttribute="trailing" secondItem="DLB-Fw-7tX" secondAttribute="trailing" constant="16" id="o3o-38-iIQ"/>
                                         <constraint firstItem="V28-KN-5Vi" firstAttribute="top" secondItem="BzK-d8-1HF" secondAttribute="bottom" constant="10" id="rk5-uh-b8c"/>
@@ -632,7 +645,7 @@
                                             <rect key="frame" x="6" y="88" width="432" height="255"/>
                                             <clipView key="contentView" id="anG-U7-QUu">
                                                 <rect key="frame" x="1" y="0.0" width="430" height="254"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="SWk-HQ-4y3" id="aw6-zQ-ZW8">
                                                         <rect key="frame" x="0.0" y="0.0" width="430" height="231"/>
@@ -1001,7 +1014,7 @@
             <connections>
                 <outlet property="delegate" destination="-2" id="4"/>
             </connections>
-            <point key="canvasLocation" x="305" y="229.5"/>
+            <point key="canvasLocation" x="305" y="241.5"/>
         </window>
         <menu id="ign-Gc-Z0N">
             <items>

--- a/src/ui/osx/TogglDesktop/Settings.h
+++ b/src/ui/osx/TogglDesktop/Settings.h
@@ -43,4 +43,5 @@
 @property BOOL pomodoro_break;
 @property int pomodoro_minutes;
 @property int pomodoro_break_minutes;
+@property (assign, nonatomic) BOOL stopWhenShutdown;
 @end

--- a/src/ui/osx/TogglDesktop/Settings.m
+++ b/src/ui/osx/TogglDesktop/Settings.m
@@ -51,6 +51,7 @@
 	self.autotrack = data->Autotrack;
 
 	self.open_editor_on_shortcut = data->OpenEditorOnShortcut;
+	self.stopWhenShutdown = data->StopEntryOnShutdownSleep;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		BAD2342621D612DF0039C742 /* libPocoUtil.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BAD2341D21D612DF0039C742 /* libPocoUtil.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAD2342721D612DF0039C742 /* libPocoFoundation.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BAD2341E21D612DF0039C742 /* libPocoFoundation.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */; };
+		BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */ = {isa = PBXBuildFile; fileRef = BAFBFCC721CD1D3C004B443F /* SystemService.m */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
 		C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C5DA1FBD17F1B08A001C4565 /* MainWindowController.m */; };
 		C5DA1FC017F1B08A001C4565 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5DA1FBE17F1B08A001C4565 /* MainWindowController.xib */; };
@@ -680,6 +681,8 @@
 		BAD2341E21D612DF0039C742 /* libPocoFoundation.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoFoundation.60.dylib; path = ../../../../third_party/poco/lib/Darwin/x86_64/libPocoFoundation.60.dylib; sourceTree = "<group>"; };
 		BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTextField+Ext.h"; sourceTree = "<group>"; };
 		BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextField+Ext.m"; sourceTree = "<group>"; };
+		BAFBFCC621CD1D3C004B443F /* SystemService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemService.h; sourceTree = "<group>"; };
+		BAFBFCC721CD1D3C004B443F /* SystemService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SystemService.m; sourceTree = "<group>"; };
 		C5CB7F0217F43EE100A2AEB1 /* TimeEntryCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TimeEntryCell.h; sourceTree = "<group>"; };
 		C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TimeEntryCell.m; sourceTree = "<group>"; };
 		C5DA1FB817F19647001C4565 /* Kopsik.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = Kopsik.dylib; path = ../../../lib/osx/build/Kopsik.dylib; sourceTree = "<group>"; };
@@ -947,6 +950,10 @@
 				3C2F239C21A7B43300CBE6BC /* UnsupportedNotice.m */,
 				BA7B4C3521C24B9D00B75B14 /* UndoTextField.h */,
 				BA7B4C3621C24B9D00B75B14 /* UndoTextField.m */,
+				BAD232D021D495E20039C742 /* UserNotificationCenter.h */,
+				BAD232CF21D495E20039C742 /* UserNotificationCenter.m */,
+				BAFBFCC621CD1D3C004B443F /* SystemService.h */,
+				BAFBFCC721CD1D3C004B443F /* SystemService.m */,
 			);
 			name = ui;
 			path = test2;
@@ -1724,6 +1731,7 @@
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,
 				74E3CDD417FBABE400C3ADD3 /* BugsnagOSXNotifier.m in Sources */,
 				74AA9471180909F50000539F /* GTMHTTPFetcher.m in Sources */,
+				BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */,
 				74FE0D5D18E260A000ECFED2 /* MASShortcut+UserDefaults.m in Sources */,
 				74A7346A18297DD100525BBC /* ConvertHexColor.m in Sources */,
 				74BAAA0B17F37B140079386F /* TimeEntryViewItem.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -33,6 +33,7 @@
 #import "idler.h"
 #import "toggl_api.h"
 #import "UserNotificationCenter.h"
+#import "SystemService.h"
 
 @interface AppDelegate ()
 @property (nonatomic, strong) IBOutlet MainWindowController *mainWindowController;
@@ -86,6 +87,9 @@
 
 // Manual mode
 @property NSMenuItem *manualModeMenuItem;
+
+// System Service
+@property (strong, nonatomic) SystemService *systemService;
 
 @end
 
@@ -249,15 +253,8 @@ BOOL onTop = NO;
 		 }
 	 }];
 
-	NSDistributedNotificationCenter *distCenter = [NSDistributedNotificationCenter defaultCenter];
-	[distCenter addObserver:self
-				   selector:@selector(onScreenLockedNotification:)
-					   name:@"com.apple.screenIsLocked"
-					 object:nil];
-	[distCenter addObserver:self
-				   selector:@selector(onScreenUnlockedNotification:)
-					   name:@"com.apple.screenIsUnlocked"
-					 object:nil];
+	// Start system notification
+	[self.systemService registerSystemNotification];
 
 	[[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 
@@ -449,18 +446,6 @@ BOOL onTop = NO;
 		didDeliverNotification:(NSUserNotification *)notification
 {
 	NSLog(@"didDeliverNotification %@", notification);
-}
-
-- (void)onScreenLockedNotification:(NSNotification *)note
-{
-	NSLog(@"onScreenLockedNotification: %@", [note name]);
-	toggl_set_sleep(ctx);
-}
-
-- (void)onScreenUnlockedNotification:(NSNotification *)note
-{
-	NSLog(@"onScreenUnlockedNotification: %@", [note name]);
-	toggl_set_wake(ctx);
 }
 
 - (void)startNew:(NSNotification *)notification
@@ -1261,6 +1246,7 @@ const NSString *appName = @"osx_native_app";
 	self.db_path = [self.app_path stringByAppendingPathComponent:@"kopsik.db"];
 	self.log_path = [self.app_path stringByAppendingPathComponent:@"toggl_desktop.log"];
 	self.log_level = @"debug";
+	self.systemService = [[SystemService alloc] init];
 
 	[self parseCommandLineArguments];
 

--- a/src/ui/osx/TogglDesktop/test2/SystemService.h
+++ b/src/ui/osx/TogglDesktop/test2/SystemService.h
@@ -1,0 +1,19 @@
+//
+//  SystemService.h
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 12/21/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SystemService : NSObject
+
+- (void)registerSystemNotification;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/SystemService.m
+++ b/src/ui/osx/TogglDesktop/test2/SystemService.m
@@ -1,0 +1,60 @@
+//
+//  SystemService.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 12/21/18.
+//  Copyright © 2018 Alari. All rights reserved.
+//
+
+#import "SystemService.h"
+#import "toggl_api.h"
+
+extern void *ctx;
+
+static NSString *kScreenIsLockedNotification = @"com.apple.screenIsLocked";
+static NSString *kScreenIsUnlockedNotification = @"com.apple.screenIsUnlocked";
+
+@implementation SystemService
+
+- (void)dealloc
+{
+	[[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
+	[[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)registerSystemNotification
+{
+	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self
+														   selector:@selector(receiveShutdownNotification:)
+															   name:NSWorkspaceWillPowerOffNotification
+															 object:nil];
+
+	NSDistributedNotificationCenter *distCenter = [NSDistributedNotificationCenter defaultCenter];
+	[distCenter addObserver:self
+				   selector:@selector(onScreenLockedNotification:)
+					   name:kScreenIsLockedNotification
+					 object:nil];
+	[distCenter addObserver:self
+				   selector:@selector(onScreenUnlockedNotification:)
+					   name:kScreenIsUnlockedNotification
+					 object:nil];
+}
+
+- (void)onScreenLockedNotification:(NSNotification *)note
+{
+	NSLog(@"onScreenLockedNotification: %@", [note name]);
+	toggl_set_sleep(ctx);
+}
+
+- (void)onScreenUnlockedNotification:(NSNotification *)note
+{
+	NSLog(@"onScreenUnlockedNotification: %@", [note name]);
+	toggl_set_wake(ctx);
+}
+
+- (void)receiveShutdownNotification:(NSNotification *)notification
+{
+	toggl_os_shutdown(ctx);
+}
+
+@end

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -469,6 +469,11 @@ public static partial class Toggl
             return false;
         }
 
+        if (!toggl_set_settings_stop_entry_on_shutdown_sleep(ctx, settings.StopEntryOnShutdownSleep))
+        {
+            return false;
+        }
+ 
         return toggl_timeline_toggle_recording(ctx, settings.RecordTimeline);
     }
 
@@ -575,6 +580,11 @@ public static partial class Toggl
     public static void SetSleep()
     {
         toggl_set_sleep(ctx);
+    }
+    
+    public static void SetOSShutdown()
+    {
+        toggl_os_shutdown(ctx);
     }
 
     public static void TrackWindowSize(Size size)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -256,8 +256,10 @@ public static partial class Toggl
         public         bool PomodoroBreak;
         public         UInt64 PomodoroMinutes;
         public         UInt64 PomodoroBreakMinutes;
+        [MarshalAs(UnmanagedType.I1)]
+        public         bool StopEntryOnShutdownSleep;
 
-        public override string ToString()
+            public override string ToString()
         {
             return RemindEnds;
         }
@@ -1078,6 +1080,13 @@ public static partial class Toggl
         UInt64 pomodoro_break_minutes);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    private static extern bool toggl_set_settings_stop_entry_on_shutdown_sleep(
+        IntPtr context,
+        [MarshalAs(UnmanagedType.I1)]
+        bool stop_entry);
+
+    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     [return:MarshalAs(UnmanagedType.I1)]
     private static extern bool toggl_set_settings_manual_mode(
         IntPtr context,
@@ -1341,6 +1350,10 @@ public static partial class Toggl
         IntPtr context);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
+    private static extern void toggl_os_shutdown(
+        IntPtr context);
+
+        [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void track_window_size(
         IntPtr context,
         UInt64 width,

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -137,6 +137,7 @@ namespace TogglDesktop
         private void initializeSessionNotification()
         {
             SystemEvents.SessionSwitch += new SessionSwitchEventHandler(SystemEvents_SessionSwitch);
+            SystemEvents.SessionEnded += new SessionEndedEventHandler(SystemEventsSessionEndOnChanged);
         }
 
         private void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e)
@@ -148,6 +149,15 @@ namespace TogglDesktop
             else if (e.Reason == SessionSwitchReason.SessionUnlock)
             {
                 Toggl.SetWake();
+            }
+        }
+
+        private void SystemEventsSessionEndOnChanged(object sender, SessionEndedEventArgs e)
+        {
+            if (e.Reason == SessionEndReasons.SystemShutdown ||
+                e.Reason == SessionEndReasons.Logoff)
+            {
+                Toggl.SetOSShutdown();
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -5,15 +5,15 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:toggl="clr-namespace:TogglDesktop"
         mc:Ignorable="d" 
-        Height="500" Width="500"
+        Height="528" Width="500"
         KeyDown="windowKeyDown"
         IsToolWindow="True"
         Title="Preferences"
         Style="{StaticResource Preferences}"
         >
-    
+
     <!-- content -->
-    <Grid Background="{StaticResource ViewBackgroundLight}">
+    <Grid Background="{StaticResource ViewBackgroundLight}" Height="482">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -25,7 +25,7 @@
         <!-- tabbed content -->
         <TabControl Grid.Row="0" TabStripPlacement="Top">
             <TabItem Header="GENERAL">
-                <StackPanel Margin="11 11">
+                <StackPanel Margin="11" Height="373">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -33,10 +33,11 @@
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="28"/>
                         </Grid.RowDefinitions>
 
                         <CheckBox Grid.Column="0" Grid.Row="0"
@@ -85,9 +86,12 @@
                         <CheckBox Grid.Column="0" Grid.Row="4"
                             Name="onTopCheckBox" x:FieldModifier="private"
                             Margin="5">Keep Toggl on top of other windows</CheckBox>
+                        <CheckBox Grid.Column="0" Grid.Row="5"
+                            x:Name="onStopEntryCheckBox" x:FieldModifier="private"
+                            Margin="5" Content="Stop running entry on computer sleep/shutdown"/>
 
                     </Grid>
-                    
+
                     <GroupBox Header="Global Shortcuts">
                         <Grid>
                             <Grid.RowDefinitions>
@@ -100,7 +104,7 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" Grid.Row="0" Margin="5">Show/Hide Toggl</TextBlock>
                             <TextBlock Grid.Column="0" Grid.Row="1" Margin="5">Continue/Stop timer</TextBlock>
-                            
+
 
                             <Border Grid.Column="1" Grid.Row="0"
                                             Style="{StaticResource ShortcutRecordContainer}">
@@ -140,7 +144,7 @@
                                TextAlignment="Right" Margin="0 -2 10 0"
                                FontSize="12" Foreground="Red"
                                Text="No error. Everything is ok." />
-                    
+
                     <TextBlock Text="Default project" Margin="5 5 5 -5"
                                    />
                     <!-- default project selection -->
@@ -186,10 +190,10 @@
                         </TextBlock>
 
                     </Grid>
-                    
+
                     <CheckBox Name="keepEndTimeFixedCheckbox" x:FieldModifier="private"
                         Content="Change duration when changing start time"
-                              Margin="5"></CheckBox>
+                              Margin="5"/>
                 </StackPanel>
             </TabItem>
             <TabItem Header="PROXY">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -127,6 +127,8 @@ namespace TogglDesktop
 
             this.keepEndTimeFixedCheckbox.IsChecked = Toggl.GetKeepEndTimeFixed();
 
+            this.onStopEntryCheckBox.IsChecked = settings.StopEntryOnShutdownSleep;
+
             #endregion
 
             #region proxy
@@ -325,6 +327,8 @@ namespace TogglDesktop
 
                 PomodoroBreak = isChecked(this.enablePomodoroBreakCheckBox),
                 PomodoroBreakMinutes = toULong(this.pomodoroBreakTimerDuration.Text),
+
+                StopEntryOnShutdownSleep = isChecked(this.onStopEntryCheckBox),
 
                 #endregion
 


### PR DESCRIPTION
### 📒 Description
This PR would like to introduce the ability to stop the running entry if needed. Additionally, this feature could be opt-in opt-out by the checkbox in Preference 🥇 

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce `stop_entry_on_shutdown_sleep` state in Setting
- [x] Support new state for db migration.
- [x] Logic for stop running timer if this bool is enable.
- [x] Introduce SystemService model (mac), which is in charge of handling System Notification (Shutdown, Sleep, Wake)
- [x] Introduce new NSCheckbox in Preference (mac)
- [x] Same functionality for Windows 
- [x] Same functionality for Linux

### 👫 Relationships
Closes #1606 

### 🔎 Review hints

#### Logic
1. Enable this Toggle in Preference
2. Run any entry
3. Shutdown or Sleep -> If the running entry closes -> Success 
Otherwise, the running entry should be continue if this toggle in Preference is uncheck

#### Database
1. Run fresh app
2. Double check the sqlite database 
3. If the `stop_entry_on_shutdown_sleep` column is existing => Correct 💯 

#### Migration
1. Run old app firstly
2. Run this PR
3. If the `stop_entry_on_shutdown_sleep` column is migrated => Correct 💯 