### PR TITLE
Fix System tray error 'QSystemTrayIcon::setVisible: No Icon set'

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -109,7 +109,7 @@ MainWindowController::MainWindowController(
 
 
     setWindowIcon(icon);
-    trayIcon = new SystemTray(this);
+    trayIcon = new SystemTray(this, icon);
     preferencesDialog->setRemindersEnabled(trayIcon->notificationsAvailable());
 
     setShortcuts();

--- a/src/ui/linux/TogglDesktop/systemtray.cpp
+++ b/src/ui/linux/TogglDesktop/systemtray.cpp
@@ -7,10 +7,12 @@
 #include "./systemtray.h"
 #include "./mainwindowcontroller.h"
 
-SystemTray::SystemTray(MainWindowController *parent) :
+SystemTray::SystemTray(MainWindowController *parent, QIcon defaultIcon) :
     QSystemTrayIcon(parent),
     notificationsPresent(true)
 {
+    setIcon(defaultIcon);
+
     show();
 
     connect(TogglApi::instance, &TogglApi::displayIdleNotification, this, &SystemTray::displayIdleNotification);

--- a/src/ui/linux/TogglDesktop/systemtray.h
+++ b/src/ui/linux/TogglDesktop/systemtray.h
@@ -13,7 +13,7 @@ class SystemTray : public QSystemTrayIcon
 {
     Q_OBJECT
 public:
-    SystemTray(MainWindowController *parent = nullptr);
+    SystemTray(MainWindowController *parent = nullptr, QIcon defaultIcon = QIcon());
 
     MainWindowController *mainWindow();
 


### PR DESCRIPTION
### 📒 Description
Adds default icon for system tray and avoids app throwing error:
```
Fix tray icon error "QSystemTrayIcon::setVisible: No Icon set"
```

### 🕶️ Types of changes

**Bug fix** (a non-breaking change which fixes an issue)

### 🤯 List of changes

- [ ] Added default icon to load before showing the tray icon

### 🔎 Review hints
Just start the app and see that the console does not show the error anymore.

