### PR TITLE
Fixed Crashreporter path script path (mac), closes #2738

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,17 @@ MSBUILD=/cygdrive/c/Program\ Files/MSBuild/12.0/Bin/MSBuild.exe
 endif
 
 ifeq ($(uname), Darwin)
-executable=./src/ui/osx/TogglDesktop/build/Release/TogglDesktop.app/Contents/MacOS/TogglDesktop
+xcodebuild_command=xcodebuild $(XCODELEGACYSDK) \
+				  -scheme TogglDesktop \
+				  -project src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj  \
+				  -configuration Release
+executable=$(shell $(xcodebuild_command) \
+			 -showBuildSettings \
+ 			| grep -w 'BUILT_PRODUCTS_DIR' \
+ 			| cut -d'=' -f 2)/TogglDesktop.app/Contents/MacOS/TogglDesktop
 pocolib=$(pocodir)/lib/Darwin/x86_64/
 osname=mac
-endif
+endif	
 
 ifeq ($(uname), Linux)
 executable=./src/ui/linux/TogglDesktop/build/release/TogglDesktop
@@ -256,8 +263,7 @@ endif
 
 ifeq ($(osname), mac)
 ui:
-	xcodebuild $(XCODELEGACYSDK) -scheme "TogglDesktop" -project src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj && \
-	!(otool -L $(executable) | grep "Users" && echo "Executable should not contain hardcoded paths!")
+	$(xcodebuild_command)
 endif
 
 ifeq ($(osname), linux)

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -1442,7 +1442,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "install_name_tool -change @rpath/CrashReporter.framework/Versions/A/CrashReporter @executable_path/../../Contents/Frameworks/CrashReporter.framework/Versions/A/CrashReporter $PROJECT_DIR/build/Release/TogglDesktop.app/Contents/MacOS/TogglDesktop";
+			shellScript = "install_name_tool -change @rpath/CrashReporter.framework/Versions/A/CrashReporter @executable_path/../../Contents/Frameworks/CrashReporter.framework/Versions/A/CrashReporter $BUILT_PRODUCTS_DIR/TogglDesktop.app/Contents/MacOS/TogglDesktop\n";
 		};
 		BA6406F121C8FC690074BC96 /* Run Formatter */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
### 📒 Description
Fixes the path the Crashreporter looks for the built app

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
Path update in Crashreporter script

### 👫 Relationships
Closes #2738 

### 🔎 Review hints
- Remove all Cache in `~/Library/Developer/Xcode/DerivedData`
- Run app either from XCode or with `make run`

