### PR TITLE
Restore / Save current windows frame in Linux

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -107,7 +107,6 @@ MainWindowController::MainWindowController(
     connect(TogglApi::instance, SIGNAL(updateContinueStopShortcut()),  // NOLINT
             this, SLOT(updateContinueStopShortcut()));  // NOLINT
 
-
     setWindowIcon(icon);
     trayIcon = new SystemTray(this, icon);
     preferencesDialog->setRemindersEnabled(trayIcon->notificationsAvailable());
@@ -118,6 +117,8 @@ MainWindowController::MainWindowController(
 
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(toggleWindow(QSystemTrayIcon::ActivationReason)));
+
+    restoreLastWindowsFrame();
 }
 
 MainWindowController::~MainWindowController() {
@@ -434,6 +435,13 @@ void MainWindowController::writeSettings() {
 }
 
 void MainWindowController::closeEvent(QCloseEvent *event) {
+
+    // Save current windows frame
+    TogglApi::instance->setWindowsFrameSetting(QRect(pos().x(),
+                                                     pos().y(),
+                                                     size().width(),
+                                                     size().height()));
+
     if (trayIcon->isVisible()) {
         event->ignore();
         hide();
@@ -501,4 +509,10 @@ void MainWindowController::runScript() {
     if (TogglApi::instance->runScriptFile(script)) {
         quitApp();
     }
+}
+
+void MainWindowController::restoreLastWindowsFrame() {
+    const QRect frame = TogglApi::instance->getWindowsFrameSetting();
+    move(frame.x(), frame.y());
+    resize(frame.width(), frame.height());
 }

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -130,6 +130,8 @@ class MainWindowController : public QMainWindow {
     void enableMenuActions();
 
     bool ui_started;
+
+    void restoreLastWindowsFrame();
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_MAINWINDOWCONTROLLER_H_

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -769,3 +769,19 @@ void TogglApi::openLegal(const QString &link) {
         toggl_privacy_policy(ctx);
     }
 }
+
+QRect const TogglApi::getWindowsFrameSetting() {
+    int64_t x;
+    int64_t y;
+    int64_t w;
+    int64_t h;
+    toggl_window_settings(ctx, &x, &y, &h, &w);
+    return QRect(static_cast<int>(x),
+                 static_cast<int>(y),
+                 static_cast<int>(h),
+                 static_cast<int>(w));
+}
+
+void TogglApi::setWindowsFrameSetting(const QRect frame) {
+    toggl_set_window_settings(ctx, frame.x(), frame.y(), frame.height(), frame.width());
+}

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -778,10 +778,14 @@ QRect const TogglApi::getWindowsFrameSetting() {
     toggl_window_settings(ctx, &x, &y, &h, &w);
     return QRect(static_cast<int>(x),
                  static_cast<int>(y),
-                 static_cast<int>(h),
-                 static_cast<int>(w));
+                 static_cast<int>(w),
+                 static_cast<int>(h));
 }
 
 void TogglApi::setWindowsFrameSetting(const QRect frame) {
-    toggl_set_window_settings(ctx, frame.x(), frame.y(), frame.height(), frame.width());
+    toggl_set_window_settings(ctx,
+                              frame.x(),
+                              frame.y(),
+                              frame.height(),
+                              frame.width());
 }

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -212,6 +212,9 @@ class TogglApi : public QObject {
     static const QString formatDurationInSecondsHHMMSS(
         const int64_t duration);
 
+    QRect const getWindowsFrameSetting();
+    void setWindowsFrameSetting(const QRect frame);
+
  signals:
     void displayApp(
         const bool open);


### PR DESCRIPTION
### 📒 Description
It's an effect to introduce "memory 📝" to Windows. 

Thus, Toggl Desktop can restore to latest sessions appropriately in term of size and position of windows 🖥 

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce two funs (getWindowsFrameSetting and setWindowsFrameSetting) in `TogglApi`
- [x] Save current frame during CloseEvent
- [x] Restore previous frame during initialization.

### 👫 Relationships
Closes #1644 

### 🔎 Review hints
1. Open app and freely resize or change position of Entry List Windows
2. Close app by tapping X
3. Exit app on Menu
4. Open app again

If the position and size are same with last session -> Correct 💯 

### Note
- Don't stop app suddenly in Qt Debug because `void MainWindowController::closeEvent(QCloseEvent *event)` will never be executed.