### PR TITLE
Fix a potential crash (lib)

### DIFF
--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -65,6 +65,10 @@ static char *get_property(Display *disp, Window win, Atom xa_prop_type,
     // null terminate the result to make string handling easier
     tmp_size = (ret_format / (32 / sizeof(long))) * ret_nitems; // NOLINT
     ret = reinterpret_cast<char *>(malloc(tmp_size + 1));
+    if (!ret) {
+        XFree(ret_prop);
+        return NULL;
+    }
     memcpy(ret, ret_prop, tmp_size);
     ret[tmp_size] = '\0';
 


### PR DESCRIPTION
### 📒 Description
Probably fixes #2410

`malloc` calls have to be checked before you start working with the pointer. The crash could be caused by a low-memory situation.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes

### 👫 Relationships
Fixes #2410 probably

### 🔎 Review hints
If you can reproduce the crash, it would be great.

