### PR TITLE
ScopedLock for RelatedData.TimeEntries

### DIFF
--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -652,7 +652,7 @@
 		C55DA5AA17F06A3B00B42178 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
@@ -692,7 +692,7 @@
 		C55DA5AB17F06A3B00B42178 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -29,6 +29,11 @@ void clearList(std::vector<T *> *list) {
     list->clear();
 }
 
+void RelatedData::pushBackTimeEntry(TimeEntry *timeEntry) {
+    Poco::Mutex::ScopedLock lock(timeEntries_m_);
+    TimeEntries.push_back(timeEntry);
+}
+
 void RelatedData::Clear() {
     clearList(&Workspaces);
     clearList(&Clients);

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -17,6 +17,7 @@
 #include "./task.h"
 #include "./time_entry.h"
 #include "./workspace.h"
+#include "Poco/RWLock.h"
 
 namespace toggl {
 
@@ -27,6 +28,11 @@ void clearList(std::vector<T *> *list) {
         delete value;
     }
     list->clear();
+}
+
+void RelatedData::forEachTimeEntries(std::function<void(TimeEntry *)> f) {
+    Poco::Mutex::ScopedLock lock(timeEntries_m_);
+    std::for_each(TimeEntries.begin(), TimeEntries.end(), f);
 }
 
 void RelatedData::pushBackTimeEntry(TimeEntry *timeEntry) {

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -17,7 +17,6 @@
 #include "./task.h"
 #include "./time_entry.h"
 #include "./workspace.h"
-#include "Poco/RWLock.h"
 
 namespace toggl {
 

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -101,6 +101,8 @@ class RelatedData {
 
     void pushBackTimeEntry(TimeEntry  *timeEntry);
 
+    void forEachTimeEntries(std::function<void(TimeEntry *)> f);
+
  private:
     Poco::Mutex timeEntries_m_;
 

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -11,6 +11,8 @@
 #include "./timeline_event.h"
 #include "./types.h"
 
+#include "Poco/Mutex.h"
+
 namespace toggl {
 
 class AutotrackerRule;
@@ -97,7 +99,11 @@ class RelatedData {
 
     Client *clientByProject(Project *p) const;
 
+    void pushBackTimeEntry(TimeEntry  *timeEntry);
+
  private:
+    Poco::Mutex timeEntries_m_;
+
     void timeEntryAutocompleteItems(
         std::set<std::string> *unique_names,
         std::map<Poco::UInt64, std::string> *ws_names,

--- a/src/user.cc
+++ b/src/user.cc
@@ -215,7 +215,7 @@ TimeEntry *User::Start(
 
     te->SetUIModified();
 
-    related.TimeEntries.push_back(te);
+    related.pushBackTimeEntry(te);
 
     return te;
 }
@@ -256,7 +256,7 @@ TimeEntry *User::Continue(
 
     result->SetCreatedWith(HTTPSClient::Config.UserAgent());
 
-    related.TimeEntries.push_back(result);
+    related.pushBackTimeEntry(result);
 
     return result;
 }
@@ -438,7 +438,7 @@ TimeEntry *User::DiscardTimeAt(
         split->SetDurationInSeconds(-at);
         split->SetUIModified();
         split->SetWID(te->WID());
-        related.TimeEntries.push_back(split);
+        related.pushBackTimeEntry(split);
         return split;
     }
 
@@ -1080,7 +1080,7 @@ void User::loadUserTimeEntryFromJSON(
 
     if (!model) {
         model = new TimeEntry();
-        related.TimeEntries.push_back(model);
+        related.pushBackTimeEntry(model);
     }
     if (alive) {
         alive->insert(id);

--- a/src/user.cc
+++ b/src/user.cc
@@ -261,21 +261,17 @@ TimeEntry *User::Continue(
     return result;
 }
 
-std::string User::DateDuration(TimeEntry * const te) const {
+std::string User::DateDuration(TimeEntry * const te) {
     Poco::Int64 date_duration(0);
     std::string date_header = Formatter::FormatDateHeader(te->Start());
-    for (std::vector<TimeEntry *>::const_iterator it =
-        related.TimeEntries.begin();
-            it != related.TimeEntries.end();
-            it++) {
-        TimeEntry *n = *it;
+    related.forEachTimeEntries([&](TimeEntry *n) {
         if (Formatter::FormatDateHeader(n->Start()) == date_header) {
             Poco::Int64 duration = n->DurationInSeconds();
             if (duration > 0) {
                 date_duration += duration;
             }
         }
-    }
+    });
     return Formatter::FormatDurationForDateHeader(date_duration);
 }
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -261,17 +261,21 @@ TimeEntry *User::Continue(
     return result;
 }
 
-std::string User::DateDuration(TimeEntry * const te) {
+std::string User::DateDuration(TimeEntry * const te) const {
     Poco::Int64 date_duration(0);
     std::string date_header = Formatter::FormatDateHeader(te->Start());
-    related.forEachTimeEntries([&](TimeEntry *n) {
+    for (std::vector<TimeEntry *>::const_iterator it =
+        related.TimeEntries.begin();
+            it != related.TimeEntries.end();
+            it++) {
+        TimeEntry *n = *it;
         if (Formatter::FormatDateHeader(n->Start()) == date_header) {
             Poco::Int64 duration = n->DurationInSeconds();
             if (duration > 0) {
                 date_duration += duration;
             }
         }
-    });
+    }
     return Formatter::FormatDurationForDateHeader(date_duration);
 }
 
@@ -505,13 +509,11 @@ void User::RemoveProjectFromRelatedModels(const Poco::UInt64 pid) {
 }
 
 void User::RemoveTaskFromRelatedModels(const Poco::UInt64 tid) {
-    for (std::vector<TimeEntry *>::iterator it = related.TimeEntries.begin();
-            it != related.TimeEntries.end(); it++) {
-        TimeEntry *model = *it;
+    related.forEachTimeEntries([&](TimeEntry *model) {
         if (model->TID() == tid) {
             model->SetTID(0);
         }
-    }
+    });
 }
 
 void User::loadUserTagFromJSON(

--- a/src/user.h
+++ b/src/user.h
@@ -95,7 +95,7 @@ class User : public BaseModel {
 
     void AddClientToList(Client *c);
 
-    std::string DateDuration(TimeEntry *te) const;
+    std::string DateDuration(TimeEntry *te);
 
     const std::string &APIToken() const {
         return api_token_;

--- a/src/user.h
+++ b/src/user.h
@@ -95,7 +95,7 @@ class User : public BaseModel {
 
     void AddClientToList(Client *c);
 
-    std::string DateDuration(TimeEntry *te);
+    std::string DateDuration(TimeEntry *te) const;
 
     const std::string &APIToken() const {
         return api_token_;


### PR DESCRIPTION
### 📒 Description
Following from the result of preliminary investigation https://github.com/toggl/toggldesktop/issues/2506#issuecomment-452302800

This PR will introduce a **minimal** solution by introducing `ScopedLock` for `RelatedData.TimeEntries`.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Lock the modification of TimeEntries vector in RelatedData class
- [x] Find the way to lock ~~all~~ few TimeEntries's iterators

### 👫 Relationships
Closes #2506 

### 🔎 Review hints
- Review code and make sure, if there are any threads are trying to modify the TimeEntries container, other threads should NOT iterate it.
- Logics are remain.
