### PR TITLE
Refactor NotificationCenter

### DIFF
--- a/src/ui/osx/TogglDesktop/AutocompleteDataSource.m
+++ b/src/ui/osx/TogglDesktop/AutocompleteDataSource.m
@@ -59,9 +59,7 @@ extern void *ctx;
 
 - (void)startDisplayAutocomplete:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayAutocomplete:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayAutocomplete:notification.object];
 }
 
 - (void)displayAutocomplete:(NSMutableArray *)entries

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -12,6 +12,7 @@
 #import "UIEvents.h"
 #import "const.h"
 #import "NSTextField+Ext.h"
+#import "TogglDesktop-Swift.h"
 
 @interface LoginViewController ()
 @property AutocompleteDataSource *countryAutocompleteDataSource;
@@ -124,8 +125,8 @@ extern void *ctx;
 
 - (void)changeView:(BOOL)hide
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kHideDisplayError
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kHideDisplayError
+																object:nil];
 	[self.loginBox setHidden:hide];
 	[self.signUpBox setHidden:!hide];
 	if (hide)
@@ -167,8 +168,8 @@ extern void *ctx;
 	[windowController signInSheetModalForWindow:[[NSApplication sharedApplication] mainWindow]
 									   delegate:self
 							   finishedSelector:@selector(viewController:finishedWithAuth:error:)];
-	[[NSNotificationCenter defaultCenter] postNotificationName:kHideDisplayError
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kHideDisplayError
+																object:nil];
 }
 
 - (void)viewController:(GTMOAuth2WindowController *)viewController
@@ -210,8 +211,8 @@ extern void *ctx;
 			errorStr = @"Window was closed before login completed.";
 		}
 
-		[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-															object:errorStr];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																	object:errorStr];
 		return;
 	}
 
@@ -226,8 +227,8 @@ extern void *ctx;
 	if (email == nil || !email.length)
 	{
 		[self.email.window makeFirstResponder:self.email];
-		[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-															object:emailMissingError];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																	object:emailMissingError];
 		return NO;
 	}
 
@@ -237,8 +238,8 @@ extern void *ctx;
 	if (pass == nil || !pass.length)
 	{
 		[self.password.window makeFirstResponder:self.password];
-		[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-															object:passwordMissingError];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																	object:passwordMissingError];
 		return NO;
 	}
 
@@ -251,8 +252,8 @@ extern void *ctx;
 	if (self.selectedCountryID == -1 || self.countrySelect.stringValue.length == 0)
 	{
 		[self.countrySelect.window makeFirstResponder:self.countrySelect];
-		[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-															object:countryNotSelectedError];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																	object:countryNotSelectedError];
 		return NO;
 	}
 
@@ -261,8 +262,8 @@ extern void *ctx;
 	if (!tosChecked)
 	{
 		[self.tosCheckbox.window makeFirstResponder:self.tosCheckbox];
-		[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-															object:tosAgreeError];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																	object:tosAgreeError];
 		return NO;
 	}
 

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -16,6 +16,7 @@
 #import "DisplayCommand.h"
 #include <Carbon/Carbon.h>
 #import "TrackingService.h"
+#import "TogglDesktop-Swift.h"
 
 @interface MainWindowController ()
 @property (nonatomic, strong) IBOutlet LoginViewController *loginViewController;
@@ -111,9 +112,7 @@ extern void *ctx;
 
 - (void)startDisplayLogin:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayLogin:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayLogin:notification.object];
 }
 
 - (void)displayLogin:(DisplayCommand *)cmd
@@ -134,9 +133,7 @@ extern void *ctx;
 
 - (void)startDisplayTimeEntryList:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryList:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryList:notification.object];
 }
 
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
@@ -157,18 +154,15 @@ extern void *ctx;
 			[self.loginViewController.view removeFromSuperview];
 			[self.overlayViewController.view removeFromSuperview];
 
-			[[NSNotificationCenter defaultCenter] postNotificationName:kFocusTimer
-																object:nil
-															  userInfo:nil];
+			[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
+																		object:nil];
 		}
 	}
 }
 
 - (void)startDisplayOverlay:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayOverlay:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayOverlay:notification.object];
 }
 
 - (void)displayOverlay:(NSNumber *)type
@@ -188,9 +182,7 @@ extern void *ctx;
 
 - (void)startDisplayError:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayError:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayError:notification.object];
 }
 
 - (void)displayError:(NSString *)msg
@@ -204,9 +196,7 @@ extern void *ctx;
 
 - (void)startDisplayOnlineState:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayOnlineState:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayOnlineState:notification.object];
 }
 
 - (void)displayOnlineState:(NSNumber *)status
@@ -273,9 +263,8 @@ extern void *ctx;
 {
 	if ([event keyCode] == kVK_DownArrow && ([event modifierFlags] & NSShiftKeyMask))
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kFocusListing
-															object:nil
-														  userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusListing
+																	object:nil];
 	}
 	else
 	{

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -279,9 +279,7 @@ const int kUseProxyToConnectToToggl = 2;
 
 - (void)startDisplayLogin:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayLogin:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayLogin:notification.object];
 }
 
 - (void)displayLogin:(DisplayCommand *)cmd
@@ -302,9 +300,7 @@ const int kUseProxyToConnectToToggl = 2;
 
 - (void)startDisplayAutotrackerRules:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayAutotrackerRules:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayAutotrackerRules:notification.object];
 }
 
 - (void)displayAutotrackerRules:(NSDictionary *)data
@@ -321,9 +317,7 @@ const int kUseProxyToConnectToToggl = 2;
 
 - (void)startDisplaySettings:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displaySettings:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displaySettings:notification.object];
 }
 
 - (void)displaySettings:(DisplayCommand *)cmd

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
@@ -16,10 +16,7 @@
 #import "DisplayCommand.h"
 #import "Utils.h"
 #import "TogglDesktop-Swift.h"
-<<<<<<< HEAD
 #import "UndoTextField.h"
-=======
->>>>>>> 389e945f8... Refactor on TimeEntry List/Edit and AutoCompleteDatasource (mac)
 
 @interface TimeEntryEditViewController ()
 @property LiteAutoCompleteDataSource *liteDescriptionAutocompleteDataSource;
@@ -291,7 +288,6 @@ extern void *ctx;
 
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:addedHeight forKey:@"height"];
 
-//    [NSNotificationCenter defaultCenter] postnotifi
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResizeEditForm
 																object:nil
 															  userInfo:userInfo];

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
@@ -16,7 +16,10 @@
 #import "DisplayCommand.h"
 #import "Utils.h"
 #import "TogglDesktop-Swift.h"
+<<<<<<< HEAD
 #import "UndoTextField.h"
+=======
+>>>>>>> 389e945f8... Refactor on TimeEntry List/Edit and AutoCompleteDatasource (mac)
 
 @interface TimeEntryEditViewController ()
 @property LiteAutoCompleteDataSource *liteDescriptionAutocompleteDataSource;
@@ -288,9 +291,10 @@ extern void *ctx;
 
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:addedHeight forKey:@"height"];
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kResizeEditForm
-														object:nil
-													  userInfo:userInfo];
+//    [NSNotificationCenter defaultCenter] postnotifi
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResizeEditForm
+																object:nil
+															  userInfo:userInfo];
 	[self.projectNameTextField.window makeFirstResponder:self.projectNameTextField];
 	[self.addProjectBox setHidden:NO];
 	[self.projectSelectBox setHidden:YES];
@@ -433,9 +437,7 @@ extern void *ctx;
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryEditor:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryEditor:notification.object];
 }
 
 - (void)displayTimeEntryEditor:(DisplayCommand *)cmd
@@ -456,6 +458,11 @@ extern void *ctx;
 {
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 	NSLog(@"TimeEntryEditViewController render, %@", self.timeEntry);
+
+	if (self.timeEntry == nil)
+	{
+		return;
+	}
 
 	if (nil == self.startDate.listener)
 	{
@@ -614,9 +621,7 @@ extern void *ctx;
 
 - (void)startDisplayTags:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTags:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTags:notification.object];
 }
 
 - (void)displayTags:(NSMutableArray *)tags
@@ -630,9 +635,7 @@ extern void *ctx;
 
 - (void)startDisplayWorkspaceSelect:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayWorkspaceSelect:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayWorkspaceSelect:notification.object];
 }
 
 - (void)displayWorkspaceSelect:(NSMutableArray *)workspaces
@@ -684,9 +687,7 @@ extern void *ctx;
 
 - (void)startDisplayClientSelect:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayClientSelect:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayClientSelect:notification.object];
 }
 
 - (void)displayClientSelect:(NSMutableArray *)clients
@@ -790,9 +791,9 @@ extern void *ctx;
 
 	self.lastPosition = mouseLoc;
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:addedWidth forKey:@"width"];
-	[[NSNotificationCenter defaultCenter] postNotificationName:kResizeEditFormWidth
-														object:nil
-													  userInfo:userInfo];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResizeEditFormWidth
+																object:nil
+															  userInfo:userInfo];
 }
 
 - (IBAction)durationTextFieldChanged:(id)sender

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -168,9 +168,7 @@ extern void *ctx;
 
 - (void)startDisplayTimeEntryList:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryList:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryList:notification.object];
 }
 
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
@@ -328,9 +326,8 @@ extern void *ctx;
 {
 	if (notification.object == self.timeEntrypopover)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kResetEditPopover
-															object:nil
-														  userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResetEditPopover
+																	object:nil];
 	}
 }
 
@@ -394,9 +391,7 @@ extern void *ctx;
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryEditor:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryEditor:notification.object];
 }
 
 - (int)numberOfRowsInTableView:(NSTableView *)tv
@@ -497,7 +492,7 @@ extern void *ctx;
     // Group header clicked, toggle group open/closed
 	if (cell.Group)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kToggleGroup object:cell.GroupName];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kToggleGroup object:cell.GroupName];
 		return;
 	}
 
@@ -548,9 +543,8 @@ extern void *ctx;
 
 - (void)resetEditPopoverSize:(NSNotification *)notification
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kResetEditPopover
-														object:nil
-													  userInfo:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResetEditPopover
+																object:nil];
 	[self setDefaultPopupSize];
 }
 
@@ -652,9 +646,7 @@ extern void *ctx;
 
 - (void)startDisplayLogin:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayLogin:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayLogin:notification.object];
 }
 
 - (void)displayLogin:(DisplayCommand *)cmd
@@ -714,9 +706,8 @@ extern void *ctx;
 		[self closeEditPopup:nil];
 		return;
 	}
-	[[NSNotificationCenter defaultCenter] postNotificationName:kFocusTimer
-														object:nil
-													  userInfo:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
+																object:nil];
 	[self clearLastSelectedEntry];
 	self.lastSelectedRowIndex = -1;
 	[self.timeEntriesTableView deselectAll:nil];

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -492,7 +492,8 @@ extern void *ctx;
     // Group header clicked, toggle group open/closed
 	if (cell.Group)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kToggleGroup object:cell.GroupName];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kToggleGroup
+																	object:cell.GroupName];
 		return;
 	}
 

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -18,6 +18,7 @@
 #import "NSCustomComboBox.h"
 #import "NSCustomTimerComboBox.h"
 #import "DisplayCommand.h"
+#import "TogglDesktop-Swift.h"
 
 @interface TimerEditViewController ()
 @property LiteAutoCompleteDataSource *liteAutocompleteDataSource;
@@ -168,9 +169,7 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)startDisplayTimeEntryList:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryList:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryList:notification.object];
 }
 
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
@@ -187,9 +186,7 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)startDisplayTimerState:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimerState:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimerState:notification.object];
 }
 
 - (void)displayTimerState:(TimeEntryViewItem *)te
@@ -286,9 +283,7 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimeEntryEditor:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimeEntryEditor:notification.object];
 }
 
 - (void)displayTimeEntryEditor:(DisplayCommand *)cmd
@@ -394,9 +389,8 @@ NSString *kInactiveTimerColor = @"#999999";
 {
 	[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kResetEditPopoverSize
-														object:nil
-													  userInfo:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kResetEditPopoverSize
+																object:nil];
 
 	if (nil == self.time_entry || nil == self.time_entry.GUID)
 	{
@@ -464,13 +458,13 @@ NSString *kInactiveTimerColor = @"#999999";
 			[self.view removeConstraints:self.projectLabelConstraint];
 			self.constraintsAdded = NO;
 		}
-		[[NSNotificationCenter defaultCenter] postNotificationName:kCommandStop
-															object:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandStop
+																	object:nil];
 		return;
 	}
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kForceCloseEditPopover
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kForceCloseEditPopover
+																object:nil];
 
 	self.disableChange = YES;
 	// resign current firstResponder
@@ -478,8 +472,8 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.disableChange = NO;
 	self.time_entry.duration = self.durationTextField.stringValue;
 	self.time_entry.Description = self.autoCompleteInput.stringValue;
-	[[NSNotificationCenter defaultCenter] postNotificationName:kCommandNew
-														object:self.time_entry];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandNew
+																object:self.time_entry];
 
 	// Reset autocomplete
 	[self.autoCompleteInput resetTable];

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		BAD2342521D612DF0039C742 /* libPocoJSON.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BAD2341C21D612DF0039C742 /* libPocoJSON.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAD2342621D612DF0039C742 /* libPocoUtil.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BAD2341D21D612DF0039C742 /* libPocoUtil.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BAD2342721D612DF0039C742 /* libPocoFoundation.60.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = BAD2341E21D612DF0039C742 /* libPocoFoundation.60.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */; };
 		BAF87DED21A3E1F600624EBE /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */; };
 		BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */ = {isa = PBXBuildFile; fileRef = BAFBFCC721CD1D3C004B443F /* SystemService.m */; };
 		C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */ = {isa = PBXBuildFile; fileRef = C5CB7F0317F43EE100A2AEB1 /* TimeEntryCell.m */; };
@@ -679,6 +680,7 @@
 		BAD2341C21D612DF0039C742 /* libPocoJSON.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoJSON.60.dylib; path = ../../../../third_party/poco/lib/Darwin/x86_64/libPocoJSON.60.dylib; sourceTree = "<group>"; };
 		BAD2341D21D612DF0039C742 /* libPocoUtil.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoUtil.60.dylib; path = ../../../../third_party/poco/lib/Darwin/x86_64/libPocoUtil.60.dylib; sourceTree = "<group>"; };
 		BAD2341E21D612DF0039C742 /* libPocoFoundation.60.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoFoundation.60.dylib; path = ../../../../third_party/poco/lib/Darwin/x86_64/libPocoFoundation.60.dylib; sourceTree = "<group>"; };
+		BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+MainThread.swift"; sourceTree = "<group>"; };
 		BAF87DEB21A3E1F600624EBE /* NSTextField+Ext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSTextField+Ext.h"; sourceTree = "<group>"; };
 		BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSTextField+Ext.m"; sourceTree = "<group>"; };
 		BAFBFCC621CD1D3C004B443F /* SystemService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemService.h; sourceTree = "<group>"; };
@@ -1230,6 +1232,7 @@
 				BAF87DEC21A3E1F600624EBE /* NSTextField+Ext.m */,
 				BA7B4BC921C0EF8800B75B14 /* NSAlert+Utils.h */,
 				BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */,
+				BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */,
 			);
 			name = Extension;
 			sourceTree = "<group>";
@@ -1730,6 +1733,7 @@
 				BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */,
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,
 				74E3CDD417FBABE400C3ADD3 /* BugsnagOSXNotifier.m in Sources */,
+				BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */,
 				74AA9471180909F50000539F /* GTMHTTPFetcher.m in Sources */,
 				BAFBFCC821CD1D3C004B443F /* SystemService.m in Sources */,
 				74FE0D5D18E260A000ECFED2 /* MASShortcut+UserDefaults.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -34,6 +34,7 @@
 #import "toggl_api.h"
 #import "UserNotificationCenter.h"
 #import "SystemService.h"
+#import "TogglDesktop-Swift.h"
 
 @interface AppDelegate ()
 @property (nonatomic, strong) IBOutlet MainWindowController *mainWindowController;
@@ -450,9 +451,7 @@ BOOL onTop = NO;
 
 - (void)startNew:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(new:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self new:notification.object];
 }
 
 - (void)new:(TimeEntryViewItem *)new_time_entry
@@ -482,9 +481,7 @@ BOOL onTop = NO;
 
 - (void)startNewShortcut:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(newShortcut:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self newShortcut:notification.object];
 }
 
 - (void)newShortcut:(TimeEntryViewItem *)new_time_entry
@@ -506,9 +503,7 @@ BOOL onTop = NO;
 
 - (void)startContinueTimeEntry:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(continueTimeEntry:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self continueTimeEntry:notification.object];
 }
 
 - (void)continueTimeEntry:(NSString *)guid
@@ -528,9 +523,7 @@ BOOL onTop = NO;
 
 - (void)startStop:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(stop)
-						   withObject:nil
-						waitUntilDone:NO];
+	[self stop];
 }
 
 - (void)stop
@@ -543,9 +536,7 @@ BOOL onTop = NO;
 
 - (void)startToggleGroup:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(toggleGroup:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self toggleGroup:notification.object];
 }
 
 - (void)toggleGroup:(NSString *)key
@@ -558,9 +549,7 @@ BOOL onTop = NO;
 
 - (void)startUpdateIconTooltip:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(updateIconTooltip:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self updateIconTooltip:notification.object];
 }
 
 - (void)updateIconTooltip:(NSString *)text
@@ -571,9 +560,7 @@ BOOL onTop = NO;
 
 - (void)startDisplaySettings:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displaySettings:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displaySettings:notification.object];
 }
 
 - (void)displaySettings:(DisplayCommand *)cmd
@@ -683,15 +670,13 @@ BOOL onTop = NO;
 	{
 		[self.manualModeMenuItem setTitle:@"Use manual mode"];
 	}
-	[[NSNotificationCenter defaultCenter] postNotificationName:mode
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:mode
+																object:nil];
 }
 
 - (void)startDisplayApp:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayApp:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayApp:notification.object];
 }
 
 - (void)displayApp:(DisplayCommand *)cmd
@@ -705,9 +690,7 @@ BOOL onTop = NO;
 
 - (void)startDisplayPromotion:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayPromotion:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayPromotion:notification.object];
 }
 
 - (void)displayPromotion:(NSNumber *)promotion_type
@@ -735,9 +718,7 @@ BOOL onTop = NO;
 
 - (void)startDisplayLogin:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayLogin:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayLogin:notification.object];
 }
 
 - (void)displayLogin:(DisplayCommand *)cmd
@@ -760,9 +741,7 @@ BOOL onTop = NO;
 
 - (void)startDisplayOnlineState:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayOnlineState:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayOnlineState:notification.object];
 }
 
 - (void)displayOnlineState:(NSNumber *)state
@@ -775,9 +754,7 @@ BOOL onTop = NO;
 
 - (void)startDisplaySyncState:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displaySyncState:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displaySyncState:notification.object];
 }
 
 - (void)displaySyncState:(NSNumber *)state
@@ -796,9 +773,7 @@ BOOL onTop = NO;
 
 - (void)startDisplayUnsyncedItems:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayUnsyncedItems:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayUnsyncedItems:notification.object];
 }
 
 - (void)displayUnsyncedItems:(NSNumber *)count
@@ -880,9 +855,7 @@ BOOL onTop = NO;
 
 - (void)startDisplayTimerState:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayTimerState:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayTimerState:notification.object];
 }
 
 - (void)displayTimerState:(TimeEntryViewItem *)timeEntry
@@ -1029,8 +1002,8 @@ BOOL onTop = NO;
 
 - (void)onNewMenuItem:(id)sender
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kCommandNewShortcut
-														object:[[TimeEntryViewItem alloc] init]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandNewShortcut
+																object:[[TimeEntryViewItem alloc] init]];
 }
 
 - (void)onSendFeedbackMenuItem
@@ -1046,14 +1019,14 @@ BOOL onTop = NO;
 
 - (IBAction)onContinueMenuItem:(id)sender
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kCommandContinue
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandContinue
+																object:nil];
 }
 
 - (IBAction)onStopMenuItem:(id)sender
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kCommandStop
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandStop
+																object:nil];
 }
 
 - (IBAction)onSyncMenuItem:(id)sender
@@ -1444,9 +1417,7 @@ const NSString *appName = @"osx_native_app";
 
 - (void)startDisplayIdleNotification:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayIdleNotification:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayIdleNotification:notification.object];
 }
 
 - (void)displayIdleNotification:(IdleEvent *)idleEvent
@@ -1532,20 +1503,20 @@ const NSString *appName = @"osx_native_app";
 
 void on_online_state(const int64_t state)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayOnlineState
-														object:[NSNumber numberWithLong:state]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayOnlineState
+																object:[NSNumber numberWithLong:state]];
 }
 
 void on_sync_state(const int64_t state)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplaySyncState
-														object:[NSNumber numberWithLong:state]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplaySyncState
+																object:[NSNumber numberWithLong:state]];
 }
 
 void on_unsynced_items(const int64_t count)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayUnsyncedItems
-														object:[NSNumber numberWithLong:count]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayUnsyncedItems
+																object:[NSNumber numberWithLong:count]];
 }
 
 void on_login(const bool_t open, const uint64_t user_id)
@@ -1556,8 +1527,8 @@ void on_login(const bool_t open, const uint64_t user_id)
 	cmd.open = open;
 	cmd.user_id = user_id;
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayLogin
-														object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayLogin
+																object:cmd];
 }
 
 void on_reminder(const char *title, const char *informative_text)
@@ -1607,34 +1578,34 @@ void on_time_entry_list(const bool_t open,
 	cmd.open = open;
 	cmd.timeEntries = viewitems;
 	cmd.show_load_more = show_load_more;
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayTimeEntryList
-														object:cmd];
-	[[NSNotificationCenter defaultCenter] postNotificationName:kUpdateIconTooltip
-														object:todayTotal];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayTimeEntryList
+																object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kUpdateIconTooltip
+																object:todayTotal];
 }
 
 void on_time_entry_autocomplete(TogglAutocompleteView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayTimeEntryAutocomplete
-														object:[AutocompleteItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayTimeEntryAutocomplete
+																object:[AutocompleteItem loadAll:first]];
 }
 
 void on_mini_timer_autocomplete(TogglAutocompleteView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayMinitimerAutocomplete
-														object:[AutocompleteItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayMinitimerAutocomplete
+																object:[AutocompleteItem loadAll:first]];
 }
 
 void on_project_autocomplete(TogglAutocompleteView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayProjectAutocomplete
-														object:[AutocompleteItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayProjectAutocomplete
+																object:[AutocompleteItem loadAll:first]];
 }
 
 void on_tags(TogglGenericView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayTags
-														object:[ViewItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayTags
+																object:[ViewItem loadAll:first]];
 }
 
 void on_autotracker_rules(TogglAutotrackerRuleView *first, const uint64_t title_count, char_t *title_list[])
@@ -1650,8 +1621,8 @@ void on_autotracker_rules(TogglAutotrackerRuleView *first, const uint64_t title_
 			@"rules": [AutotrackerRuleItem loadAll:first],
 			@"titles": titles
 	};
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayAutotrackerRules
-														object:data];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayAutotrackerRules
+																object:data];
 }
 
 void on_autotracker_notification(const char_t *project_name,
@@ -1665,20 +1636,20 @@ void on_autotracker_notification(const char_t *project_name,
 
 void on_promotion(const int64_t promotion_type)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayPromotion
-														object:[NSNumber numberWithLong:promotion_type]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayPromotion
+																object:[NSNumber numberWithLong:promotion_type]];
 }
 
 void on_client_select(TogglGenericView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayClientSelect
-														object:[ViewItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayClientSelect
+																object:[ViewItem loadAll:first]];
 }
 
 void on_workspace_select(TogglGenericView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayWorkspaceSelect
-														object:[ViewItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayWorkspaceSelect
+																object:[ViewItem loadAll:first]];
 }
 
 void on_time_entry_editor(const bool_t open,
@@ -1692,8 +1663,8 @@ void on_time_entry_editor(const bool_t open,
 	cmd.open = open;
 	cmd.timeEntry = item;
 	cmd.timeEntry.focusedFieldName = [NSString stringWithUTF8String:focused_field_name];
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayTimeEntryEditor
-														object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayTimeEntryEditor
+																object:cmd];
 }
 
 void on_app(const bool_t open)
@@ -1701,16 +1672,16 @@ void on_app(const bool_t open)
 	DisplayCommand *cmd = [[DisplayCommand alloc] init];
 
 	cmd.open = open;
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayApp
-														object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayApp
+																object:cmd];
 }
 
 void on_error(const char *errmsg, const bool_t is_user_error)
 {
 	NSString *msg = [NSString stringWithUTF8String:errmsg];
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-														object:msg];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayError
+																object:msg];
 	if (!is_user_error)
 	{
 		char *str = toggl_get_update_channel(ctx);
@@ -1723,8 +1694,9 @@ void on_error(const char *errmsg, const bool_t is_user_error)
 
 void on_overlay(const int64_t type)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayOverlay
-														object:[NSNumber numberWithLong:type]];
+//    [NSNotificationCenter defaultCenter] post
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayOverlay
+																object:[NSNumber numberWithLong:type]];
 }
 
 void on_settings(const bool_t open,
@@ -1737,8 +1709,8 @@ void on_settings(const bool_t open,
 	DisplayCommand *cmd = [[DisplayCommand alloc] init];
 	cmd.open = open;
 	cmd.settings = s;
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplaySettings
-														object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplaySettings
+																object:cmd];
 }
 
 void on_timer_state(TogglTimeEntryView *te)
@@ -1750,7 +1722,8 @@ void on_timer_state(TogglTimeEntryView *te)
 		view_item = [[TimeEntryViewItem alloc] init];
 		[view_item load:te];
 	}
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayTimerState object:view_item];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayTimerState
+																object:view_item];
 }
 
 void on_idle_notification(
@@ -1767,7 +1740,8 @@ void on_idle_notification(
 	idleEvent.duration = [NSString stringWithUTF8String:duration];
 	idleEvent.started = started;
 	idleEvent.timeEntryDescription = [NSString stringWithUTF8String:description];
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayIdleNotification object:idleEvent];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayIdleNotification
+																object:idleEvent];
 }
 
 void on_project_colors(
@@ -1780,12 +1754,14 @@ void on_project_colors(
 	{
 		[colors addObject:[NSString stringWithUTF8String:list[i]]];
 	}
-	[[NSNotificationCenter defaultCenter] postNotificationName:kSetProjectColors object:colors];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kSetProjectColors
+																object:colors];
 }
 
 void on_countries(TogglCountryView *first)
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayCountries object:[CountryViewItem loadAll:first]];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayCountries
+																object:[CountryViewItem loadAll:first]];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -10,6 +10,7 @@
 #import "toggl_api.h"
 #import "DisplayCommand.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation IdleNotificationWindowController
 
@@ -58,8 +59,8 @@ extern void *ctx;
 	DisplayCommand *cmd = [[DisplayCommand alloc] init];
 
 	cmd.open = YES;
-	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayApp
-														object:cmd];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayApp
+																object:cmd];
 }
 
 - (IBAction)discardIdleAndContinue:(id)sender

--- a/src/ui/osx/TogglDesktop/test2/LiteAutoCompleteDataSource.m
+++ b/src/ui/osx/TogglDesktop/test2/LiteAutoCompleteDataSource.m
@@ -64,9 +64,7 @@ extern void *ctx;
 
 - (void)startDisplayAutocomplete:(NSNotification *)notification
 {
-	[self performSelectorOnMainThread:@selector(displayAutocomplete:)
-						   withObject:notification.object
-						waitUntilDone:NO];
+	[self displayAutocomplete:notification.object];
 }
 
 - (void)displayAutocomplete:(NSMutableArray *)entries

--- a/src/ui/osx/TogglDesktop/test2/NSCustomTimerComboBox.m
+++ b/src/ui/osx/TogglDesktop/test2/NSCustomTimerComboBox.m
@@ -8,6 +8,7 @@
 
 #import "NSCustomTimerComboBox.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation NSCustomTimerComboBox
 
@@ -15,8 +16,8 @@
 {
 	if (self.isEditable)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kForceCloseEditPopover
-															object:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kForceCloseEditPopover
+																	object:nil];
 		return;
 	}
 }

--- a/src/ui/osx/TogglDesktop/test2/NSTextFieldClickable.m
+++ b/src/ui/osx/TogglDesktop/test2/NSTextFieldClickable.m
@@ -8,6 +8,7 @@
 
 #import "NSTextFieldClickable.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation NSTextFieldClickable
 
@@ -15,8 +16,8 @@
 {
 	if (self.isEditable)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kForceCloseEditPopover
-															object:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kForceCloseEditPopover
+																	object:nil];
 		return;
 	}
 	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];

--- a/src/ui/osx/TogglDesktop/test2/NSUnstripedTableView.m
+++ b/src/ui/osx/TogglDesktop/test2/NSUnstripedTableView.m
@@ -7,12 +7,11 @@
 //
 
 #import "NSUnstripedTableView.h"
-
 #include <Carbon/Carbon.h>
-
 #import "TimeEntryCell.h"
 #import "TimeEntryCellWithHeader.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation NSUnstripedTableView
 
@@ -39,9 +38,9 @@ extern void *ctx;
 	}
 	else if (event.keyCode == kVK_Escape)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kEscapeListing
-															object:nil
-														  userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kEscapeListing
+																	object:nil
+																  userInfo:nil];
 	}
 	else if (event.keyCode == kVK_Delete)
 	{

--- a/src/ui/osx/TogglDesktop/test2/NSViewEscapable.m
+++ b/src/ui/osx/TogglDesktop/test2/NSViewEscapable.m
@@ -9,13 +9,14 @@
 #import "NSViewEscapable.h"
 #import "DisplayCommand.h"
 #import "UIEvents.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation NSViewEscapable
 
 - (void)cancelOperation:(id)sender
 {
-	[[NSNotificationCenter defaultCenter] postNotificationName:kForceCloseEditPopover
-														object:nil];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kForceCloseEditPopover
+																object:nil];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
+++ b/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
@@ -1,0 +1,32 @@
+//
+//  NotificationCenter+MainThread.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 1/10/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+
+extension NotificationCenter {
+
+    func postOnMainThread(with aName: NSNotification.Name, object anObject: Any?) {
+        runOnMainThreadIfNeed {[unowned self] in
+            self.post(name: aName, object: anObject)
+        }
+    }
+}
+
+func runOnMainThreadIfNeed(_ block: @escaping () -> Void) {
+
+    // If it's main thread, just execute
+    if Thread.isMainThread {
+        block()
+        return
+    }
+
+    // Or run async on Main Thread later
+    DispatchQueue.main.async {
+        block()
+    }
+}

--- a/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
+++ b/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
@@ -12,9 +12,9 @@ extension NotificationCenter {
 
     @objc func postNotificationOnMainThread(_ aName: NSNotification.Name,
                                             object anObject: Any?) {
-        runOnMainThreadIfNeed {[unowned self] in
-            self.post(name: aName, object: anObject)
-        }
+        postNotificationOnMainThread(aName,
+                                     object: anObject,
+                                     userInfo: nil)
     }
 
     @objc func postNotificationOnMainThread(_ aName: NSNotification.Name,

--- a/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
+++ b/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
@@ -10,9 +10,18 @@ import Foundation
 
 extension NotificationCenter {
 
-    @objc func postNotificationOnMainThread(_ aName: NSNotification.Name, object anObject: Any?) {
+    @objc func postNotificationOnMainThread(_ aName: NSNotification.Name,
+                                            object anObject: Any?) {
         runOnMainThreadIfNeed {[unowned self] in
             self.post(name: aName, object: anObject)
+        }
+    }
+
+    @objc func postNotificationOnMainThread(_ aName: NSNotification.Name,
+                                            object anObject: Any?,
+                                            userInfo: [AnyHashable: Any]?) {
+        runOnMainThreadIfNeed {[unowned self] in
+            self.post(name: aName, object: anObject, userInfo: userInfo)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
+++ b/src/ui/osx/TogglDesktop/test2/NotificationCenter+MainThread.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension NotificationCenter {
 
-    func postOnMainThread(with aName: NSNotification.Name, object anObject: Any?) {
+    @objc func postNotificationOnMainThread(_ aName: NSNotification.Name, object anObject: Any?) {
         runOnMainThreadIfNeed {[unowned self] in
             self.post(name: aName, object: anObject)
         }

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -9,8 +9,8 @@
 #import "TimeEntryCell.h"
 #import "UIEvents.h"
 #import "ConvertHexColor.h"
-
 #import "toggl_api.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation TimeEntryCell
 
@@ -20,14 +20,14 @@ extern void *ctx;
 {
 	NSLog(@"TimeEntryCell continueTimeEntry GUID=%@", self.GUID);
 
-	[[NSNotificationCenter defaultCenter] postNotificationName:kCommandContinue object:self.GUID];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandContinue object:self.GUID];
 }
 
 - (IBAction)toggleGroup:(id)sender
 {
 	if (self.Group)
 	{
-		[[NSNotificationCenter defaultCenter] postNotificationName:kToggleGroup object:self.GroupName];
+		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kToggleGroup object:self.GroupName];
 	}
 }
 


### PR DESCRIPTION
### 📒 Description
This PR is the implementation from the [NotificationCenter proposal](https://github.com/toggl/toggldesktop/issues/2704)

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- Introduce helper methods for NSNotificationCenter, to guarantee that it posts on Main Thread
- Replace all `[self postNotificationName:object:userInfo]`
- Replace all `[self performSelectorOnMainThread:withObject:waitUntilDone]`

### 👫 Relationships
Closes #2704 

### 🔎 Review hints
- Put a checkpoint in any Observers -> If we able to see the parent caller from TogglDesktopLibrary in Stack Tree -> 💯 
- No crash and the logics are remain 💯 
