### PR TITLE
Run Toggl Desktop Windows in Debug mode 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,10 @@ third_party/poco/bin
 third_party/poco/lib
 
 # VS 
-src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin/Release/
+src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin/Debug
+src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin/Release
 src/lib/windows/TogglDesktopDLL/Debug
+src/lib/windows/TogglDesktopDLL/Release
 src/ui/windows/TogglDesktop/.vs
+src/ui/windows/TogglDesktop/Debug
+src/ui/windows/TogglDesktop/Release

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,12 @@ src/ui/windows/TogglDesktop/TogglDesktopDLLInteropTest/bin
 
 # Qt Creator
 .*.swp
+
+# Poco binary
+third_party/poco/bin
+third_party/poco/lib
+
+# VS 
+src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin/Release/
+src/lib/windows/TogglDesktopDLL/Debug
+src/ui/windows/TogglDesktop/.vs

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -61,6 +61,9 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>PocoFoundationd.lib;PocoUtild.lib;PocoXMLd.lib;PocoNetd.lib;PocoCryptod.lib;PocoNetSSLd.lib;PocoDatad.lib;PocoDataSQLited.lib;sqlite3;%(AdditionalDependencies)</AdditionalDependencies>
+      <ImportLibrary>$(OutDir)$(TargetName).lib</ImportLibrary>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\src\ui\windows\TogglDesktop\Release\;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\obj\SQLite\release_shared;$(ProjectDir)..\..\..\..\third_party\openssl\out32dll;$(ProjectDir)..\..\..\..\third_party\poco\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -54,7 +54,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;TOGGLDESKTOPDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>E:\toggldesktop\third_party\openssl\inc32;E:\toggldesktop\third_party\poco\Foundation\include;E:\toggldesktop\third_party\poco\Util\include;E:\toggldesktop\third_party\poco\NetSSL_OpenSSL\include;E:\toggldesktop\third_party\poco\Net\include;E:\toggldesktop\third_party\poco\Data\include;E:\toggldesktop\third_party\poco\Data\SQLite\include;E:\toggldesktop\third_party\poco\Crypto\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\..\third_party\poco\openssl;$(ProjectDir)..\..\..\..\third_party\openssl\include;$(ProjectDir)..\..\..\..\third_party\jsoncpp\dist;$(ProjectDir)..\..\..\..\third_party\poco\Foundation\include;$(ProjectDir)..\..\..\..\third_party\poco\Util\include;$(ProjectDir)..\..\..\..\third_party\poco\Crypto\include;$(ProjectDir)..\..\..\..\third_party\poco\Net\include;$(ProjectDir)..\..\..\..\third_party\poco\NetSSL_OpenSSL\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\src;$(ProjectDir)..\..\..\..\third_party\lua\src;$(ProjectDir)..\..\..\..\third_party\luafar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>
       </AdditionalOptions>
     </ClCompile>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -12,6 +12,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
+    <NuGetPackageImportStamp>8fb27a70</NuGetPackageImportStamp>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -26,9 +29,6 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <NuGetPackageImportStamp>8fb27a70</NuGetPackageImportStamp>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,7 +36,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;INVS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -36,7 +36,7 @@
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;INVS</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
### 📒 Description
There was an error that we couldn't run Toggl Desktop in Debug mode in Visual Studio due to inaccurate configuration. Ex: Additional Include Dir and Linkers Dir, ...

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue

### 🤯 List of changes
- [x] Fix Additional Include Dir and Linkers Dir in TogglDesktopLibrary project
- [x] Fix the missing of `INVS` arg in Debug scheme.
- [x] Update `gitignore` to discard all unnecessary files from VS 

### 👫 Relationships
Close #2735 

### 🔎 Review hints
1. Clone freshly the project
2. git reset and clean
3. Able to run on `Debug` mode by using Visual Studio
