### PR TITLE
Remove $XCODELEGACYSDK in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ MSBUILD=/cygdrive/c/Program\ Files/MSBuild/12.0/Bin/MSBuild.exe
 endif
 
 ifeq ($(uname), Darwin)
-xcodebuild_command=xcodebuild $(XCODELEGACYSDK) \
+xcodebuild_command=xcodebuild \
 				  -scheme TogglDesktop \
 				  -project src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj  \
 				  -configuration Release
@@ -238,7 +238,7 @@ app: lib ui
 
 ifeq ($(osname), mac)
 lib:
-	xcodebuild $(XCODELEGACYSDK) -project src/lib/osx/TogglDesktopLibrary.xcodeproj
+	xcodebuild -project src/lib/osx/TogglDesktopLibrary.xcodeproj
 endif
 
 ifeq ($(osname), linux)


### PR DESCRIPTION
### 📒 Description
This PR will remove $XCODELEGACYSDK in `Makefile` since we don't need it anymore.

It collaborates with https://github.com/toggl/toggldesktop/issues/2752#issuecomment-453945901

### 🕶️ Types of changes
**Improvement** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Remove $XCODELEGACYSDK

### 👫 Relationships
It's part of #2752 

### 🔎 Review hints
- Execute `make app` in Build Platform machine, then running the app on Target Platform (according https://github.com/toggl/toggldesktop/issues/2752#issuecomment-453945901)
- If it works well -> 💯 