### PR TITLE
Adopt dark theme from OS

### DIFF
--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p $PROJECT_DIR/build\ncp $TARGET_BUILD_DIR/*.dylib $PROJECT_DIR/build";
+			shellScript = "mkdir -p $PROJECT_DIR/build\ncp $TARGET_BUILD_DIR/*.dylib $PROJECT_DIR/build\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/src/ui/osx/TogglDesktop/FeedbackWindowController.xib
+++ b/src/ui/osx/TogglDesktop/FeedbackWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,10 +18,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Send Feedback" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="1">
+        <window title="Send Feedback" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="353" height="305"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="353" height="305"/>
             <value key="maxSize" type="size" width="353" height="305"/>
             <view key="contentView" id="2">
@@ -45,27 +45,27 @@
                     <scrollView fixedFrame="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TG8-w0-r91">
                         <rect key="frame" x="20" y="90" width="313" height="135"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <clipView key="contentView" ambiguous="YES" id="Ina-OJ-HA6">
-                            <rect key="frame" x="1" y="1" width="296" height="133"/>
+                        <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="Ina-OJ-HA6">
+                            <rect key="frame" x="1" y="1" width="311" height="133"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView ambiguous="YES" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" smartInsertDelete="YES" id="ELz-XL-Qzo">
-                                    <rect key="frame" x="0.0" y="0.0" width="296" height="133"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="311" height="133"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="296" height="133"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <size key="minSize" width="311" height="133"/>
                                     <size key="maxSize" width="463" height="10000000"/>
-                                    <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 </textView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         </clipView>
-                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="eYU-yC-MZ2">
+                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="eYU-yC-MZ2">
                             <rect key="frame" x="-100" y="-100" width="87" height="18"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="CVO-3Q-PTv">
-                            <rect key="frame" x="297" y="1" width="15" height="133"/>
+                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="CVO-3Q-PTv">
+                            <rect key="frame" x="296" y="1" width="16" height="133"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
@@ -96,8 +96,8 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Send us your feedback and questions" id="Pxe-7D-PlN">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x76-9l-cFh">
@@ -105,8 +105,8 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" placeholderString="(maximum image size 5MB)" id="uDw-EN-KEh">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                 </subviews>

--- a/src/ui/osx/TogglDesktop/LoginViewController.xib
+++ b/src/ui/osx/TogglDesktop/LoginViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -39,13 +38,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oP1-rJ-O83">
-                                <rect key="frame" x="18" y="380" width="216" height="40"/>
+                                <rect key="frame" x="19" y="380" width="215" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="FQH-VE-Gcc"/>
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" focusRingType="none" placeholderString="Your email address" drawsBackground="YES" id="2P3-Ts-4er" customClass="NSTextFieldVerticallyAligned">
                                     <font key="font" metaFont="cellTitle"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -53,13 +52,13 @@
                                 </connections>
                             </textField>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sok-9q-fwV">
-                                <rect key="frame" x="18" y="325" width="216" height="40"/>
+                                <rect key="frame" x="19" y="325" width="215" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="c1m-OY-oBi"/>
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" focusRingType="none" placeholderString="Password" drawsBackground="YES" id="0Xp-Z1-qCJ" customClass="NSSecureTextFieldVerticallyAligned">
                                     <font key="font" metaFont="cellTitle"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -77,7 +76,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Xk-yW-T0s" customClass="NSTextFieldClickablePointer">
-                                            <rect key="frame" x="10" y="102" width="227" height="21"/>
+                                            <rect key="frame" x="10" y="103" width="227" height="20"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="223" id="eFb-g5-Dlf"/>
                                             </constraints>

--- a/src/ui/osx/TogglDesktop/MainWindowController.xib
+++ b/src/ui/osx/TogglDesktop/MainWindowController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,10 +19,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" id="1">
+        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="398"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="240" height="20"/>
             <value key="maxSize" type="size" width="2500" height="2500"/>
             <view key="contentView" id="2">
@@ -46,12 +45,12 @@
                                     <rect key="frame" x="7" y="6" width="275" height="17"/>
                                     <textFieldCell key="cell" truncatesLastVisibleLine="YES" selectable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="Login failed!" id="epU-2w-W4x">
                                         <font key="font" metaFont="system"/>
-                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="tgB-wf-G92">
-                                    <rect key="frame" x="278" y="7" width="12" height="17"/>
+                                    <rect key="frame" x="278" y="5" width="12" height="19"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="12" id="WmO-N8-iCw"/>
                                     </constraints>
@@ -75,7 +74,6 @@
                             <constraint firstItem="tgB-wf-G92" firstAttribute="top" secondItem="gBV-Qp-t6E" secondAttribute="top" constant="5" id="SWB-i0-0Fw"/>
                             <constraint firstAttribute="trailing" secondItem="tgB-wf-G92" secondAttribute="trailing" constant="10" id="bOL-hH-mYo"/>
                         </constraints>
-                        <color key="fillColor" red="0.96470588235294119" green="0.96470588235294119" blue="0.96470588235294119" alpha="0.35000000000000003" colorSpace="custom" customColorSpace="sRGB"/>
                     </box>
                     <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fXQ-pa-GDD">
                         <rect key="frame" x="-2" y="-1" width="304" height="22"/>
@@ -85,7 +83,7 @@
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" borderStyle="bezel" title="Status: Online" id="iCQ-vt-0Yg">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                 </subviews>

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -103,7 +103,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="Zfu-jF-pu2">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="Rmf-uW-sZP" userLabel="pomodoro timer">
@@ -138,7 +138,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="uD2-dD-ZQE">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="BzK-d8-1HF" userLabel="pomodoro break timer">
@@ -173,15 +173,15 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="MLE-d1-bsN">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K6B-0p-RS0">
                                             <rect key="frame" x="14" y="401" width="107" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show/Hide Toggl" id="ZgR-r3-20o">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="DLB-Fw-7tX" customClass="MASShortcutView">
@@ -198,8 +198,8 @@
                                             <rect key="frame" x="14" y="374" width="126" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Continue/Stop timer" id="SH4-aB-XUn">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Ft4-tk-xRA" customClass="MASShortcutView">
@@ -310,7 +310,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default project" id="bIw-0T-jhz">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AQZ-NT-Pr8" customClass="NSCustomComboBox">
@@ -410,11 +410,11 @@
                             </tabViewItem>
                             <tabViewItem label="Proxy" identifier="2" id="adI-Zg-JOo">
                                 <view key="view" id="Leo-bI-fp3">
-                                    <rect key="frame" x="10" y="33" width="444" height="397"/>
+                                    <rect key="frame" x="10" y="33" width="444" height="421"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" borderType="line" title="Proxy Settings" translatesAutoresizingMaskIntoConstraints="NO" id="hoK-7e-akc">
-                                            <rect key="frame" x="13" y="183" width="418" height="138"/>
+                                            <rect key="frame" x="13" y="207" width="418" height="138"/>
                                             <view key="contentView" id="XhL-bq-2bj">
                                                 <rect key="frame" x="3" y="3" width="412" height="120"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -432,8 +432,8 @@
                                                                         </constraints>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Host" id="jPI-l8-v1o">
                                                                             <font key="font" metaFont="system"/>
-                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eSt-Rf-LI2">
@@ -468,8 +468,8 @@
                                                                         </constraints>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Port" id="iti-LA-FXa">
                                                                             <font key="font" metaFont="system"/>
-                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tH-DP-xDu">
@@ -504,8 +504,8 @@
                                                                         </constraints>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Username" id="Hvt-Np-nrM">
                                                                             <font key="font" metaFont="system"/>
-                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hml-tw-LUI">
@@ -540,8 +540,8 @@
                                                                         </constraints>
                                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password" id="Xi1-qQ-Ttt">
                                                                             <font key="font" metaFont="system"/>
-                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                         </textFieldCell>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bcT-3P-lAf" customClass="NSSecureTextField">
@@ -596,7 +596,7 @@
                                             </connections>
                                         </box>
                                         <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CE1-H6-4lx">
-                                            <rect key="frame" x="16" y="331" width="412" height="62"/>
+                                            <rect key="frame" x="16" y="355" width="412" height="62"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             <size key="cellSize" width="412" height="18"/>
                                             <size key="intercellSpacing" width="4" height="4"/>
@@ -638,17 +638,17 @@
                             </tabViewItem>
                             <tabViewItem label="Autotracker" identifier="" id="L4T-cB-5tT">
                                 <view key="view" id="Z2O-u3-FHM">
-                                    <rect key="frame" x="10" y="33" width="444" height="397"/>
+                                    <rect key="frame" x="10" y="33" width="444" height="421"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PL2-PA-tEh">
-                                            <rect key="frame" x="6" y="88" width="432" height="255"/>
+                                            <rect key="frame" x="6" y="88" width="432" height="279"/>
                                             <clipView key="contentView" id="anG-U7-QUu">
-                                                <rect key="frame" x="1" y="0.0" width="430" height="254"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <rect key="frame" x="1" y="0.0" width="430" height="278"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="SWk-HQ-4y3" id="aw6-zQ-ZW8">
-                                                        <rect key="frame" x="0.0" y="0.0" width="430" height="231"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="430" height="255"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -705,7 +705,7 @@
                                             </connections>
                                         </scrollView>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="jHx-ps-PhJ">
-                                            <rect key="frame" x="4" y="377" width="436" height="18"/>
+                                            <rect key="frame" x="4" y="401" width="436" height="18"/>
                                             <buttonCell key="cell" type="check" title="Enable autotracker" bezelStyle="regularSquare" imagePosition="left" inset="2" id="iNP-sg-BCr">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -716,7 +716,7 @@
                                             </connections>
                                         </button>
                                         <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TN9-Mx-4gf" customClass="NSCustomComboBox">
-                                            <rect key="frame" x="248" y="347" width="131" height="26"/>
+                                            <rect key="frame" x="248" y="371" width="131" height="26"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="128" id="YVl-np-WHd"/>
                                             </constraints>
@@ -731,7 +731,7 @@
                                             </connections>
                                         </comboBox>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hCm-WD-AX4">
-                                            <rect key="frame" x="378" y="344" width="66" height="32"/>
+                                            <rect key="frame" x="378" y="368" width="66" height="32"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="fas-jz-0am"/>
                                             </constraints>
@@ -745,7 +745,7 @@
                                             </connections>
                                         </button>
                                         <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="afg-Ty-RcE">
-                                            <rect key="frame" x="6" y="347" width="239" height="26"/>
+                                            <rect key="frame" x="6" y="371" width="239" height="26"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="eN3-5n-TFS"/>
                                                 <constraint firstAttribute="width" constant="236" id="rQA-FE-7Cm"/>
@@ -783,11 +783,11 @@
                             </tabViewItem>
                             <tabViewItem label="Reminder" identifier="" id="BnX-Iu-Map">
                                 <view key="view" id="g4Y-c9-6hQ">
-                                    <rect key="frame" x="10" y="33" width="444" height="397"/>
+                                    <rect key="frame" x="10" y="33" width="444" height="421"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button translatesAutoresizingMaskIntoConstraints="NO" id="Spu-c6-dBl">
-                                            <rect key="frame" x="14" y="371" width="148" height="18"/>
+                                            <rect key="frame" x="14" y="395" width="148" height="18"/>
                                             <buttonCell key="cell" type="check" title="Remind to track time" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kRx-0D-K8X">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -798,31 +798,31 @@
                                             </connections>
                                         </button>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9TN-or-dpG">
-                                            <rect key="frame" x="14" y="346" width="124" height="17"/>
+                                            <rect key="frame" x="14" y="370" width="124" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder start time" id="7rS-yr-ohN">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XOd-HM-bZN">
-                                            <rect key="frame" x="14" y="319" width="118" height="17"/>
+                                            <rect key="frame" x="14" y="343" width="118" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder end time" id="sJf-LA-jhB">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oCh-IL-u0y">
-                                            <rect key="frame" x="14" y="292" width="94" height="17"/>
+                                            <rect key="frame" x="14" y="316" width="94" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reminder days" id="tgu-cW-ZXH">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R9v-BZ-yhR">
-                                            <rect key="frame" x="316" y="369" width="38" height="22"/>
+                                            <rect key="frame" x="316" y="393" width="38" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="22" id="9lM-Om-bo1"/>
                                                 <constraint firstAttribute="width" constant="38" id="VSd-ZN-c0v"/>
@@ -839,15 +839,15 @@
                                             </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JK4-nq-3q2">
-                                            <rect key="frame" x="362" y="372" width="53" height="17"/>
+                                            <rect key="frame" x="362" y="396" width="53" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="minutes" id="A65-xb-c7i">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="duI-RG-4BI">
-                                            <rect key="frame" x="316" y="344" width="57" height="22"/>
+                                            <rect key="frame" x="316" y="368" width="57" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="57" id="IYe-sQ-zK2"/>
                                                 <constraint firstAttribute="height" constant="22" id="ItT-9F-fLb"/>
@@ -863,7 +863,7 @@
                                             </connections>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4pc-oy-DHZ">
-                                            <rect key="frame" x="316" y="317" width="57" height="22"/>
+                                            <rect key="frame" x="316" y="341" width="57" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="22" id="ZkZ-hV-j3b"/>
                                                 <constraint firstAttribute="width" constant="57" id="nVk-qd-Xs5"/>
@@ -879,7 +879,7 @@
                                             </connections>
                                         </textField>
                                         <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6QJ-hs-Dfs">
-                                            <rect key="frame" x="316" y="175" width="46" height="134"/>
+                                            <rect key="frame" x="316" y="199" width="46" height="134"/>
                                             <subviews>
                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="6g9-yq-5Jx">
                                                     <rect key="frame" x="-2" y="118" width="49" height="18"/>

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.h
@@ -69,7 +69,6 @@
 - (IBAction)addClientButtonClicked:(id)sender;
 - (IBAction)saveAddClientButtonClicked:(id)sender;
 - (void)setDragHandle:(BOOL)onLeft;
-- (void)setInsertionPointColor;
 - (void)closeEdit;
 - (BOOL)autcompleteFocused;
 - (void)updateWithSelectedDescription:(AutocompleteItem *)autocomplete withKey:(NSString *)key;

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.m
@@ -756,16 +756,6 @@ extern void *ctx;
 	[self.resizeHandleLeft setHidden:!onLeft];
 }
 
-- (void)setInsertionPointColor
-{
-	NSTextView *textField = (NSTextView *)[self.durationTextField currentEditor];
-
-	if ([textField respondsToSelector:@selector(setInsertionPointColor:)])
-	{
-		[textField setInsertionPointColor:[NSColor blackColor]];
-	}
-}
-
 - (void)draggingResizeStart:(id)sender
 {
 	self.lastPosition = [NSEvent mouseLocation];

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
@@ -76,8 +76,8 @@
                                 </constraints>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="What are you doing?" drawsBackground="YES" usesSingleLineMode="YES" id="SDE-tz-ohH">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
                                     <action selector="descriptionAutoCompleteChanged:" target="-2" id="3t4-o3-SrR"/>
@@ -98,8 +98,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Project" drawsBackground="YES" usesSingleLineMode="YES" id="WOr-dn-XwP">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                             <connections>
                                                 <action selector="projectAutoCompleteChanged:" target="-2" id="5mv-uH-Kg4"/>
@@ -164,8 +164,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Project name:" id="ZCR-I1-gJU">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Pz-WE-b3h">
@@ -205,8 +205,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Workspace:" id="3U6-7m-fqn">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ewn-SY-SXJ" userLabel="Workspace Select Box">
@@ -234,8 +234,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Client:" id="Jfn-xE-qrc">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Kdc-c6-b4n" userLabel="Client Combo Box">
@@ -345,11 +345,11 @@
                                                         </constraints>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Duration:" id="GuL-lb-tra">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EMR-ul-vEb" customClass="UndoTextField">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EMR-ul-vEb">
                                                         <rect key="frame" x="118" y="9" width="125" height="22"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="125" id="6rf-F2-ZAy"/>
@@ -392,8 +392,8 @@
                                                         </constraints>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Start-end time:" id="uFy-pH-4VS">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hWW-Ak-Wbd" customClass="UndoTextField">
@@ -467,8 +467,8 @@
                                                         </constraints>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Date:" id="EJZ-fK-CJa">
                                                             <font key="font" metaFont="system"/>
-                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
                                                     <datePicker verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xTj-21-Dv1" customClass="TFDatePicker">
@@ -530,8 +530,8 @@
                                             <rect key="frame" x="11" y="78" width="37" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Tags:" id="rWN-Hm-fAH">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <tokenField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Uk-YS-6nx">
@@ -566,7 +566,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Workspace:" id="CcP-SH-Xh2">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="feg-gg-X4L">
@@ -574,7 +574,7 @@
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Workspace" id="amF-LP-y9l">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                     </subviews>
@@ -598,7 +598,6 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="56z-X5-tBm"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
                             </box>
                         </subviews>
                         <constraints>
@@ -630,8 +629,8 @@
                     </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Last update: Today 2:03AM" id="LOB-Vt-nno">
                         <font key="font" metaFont="miniSystem"/>
-                        <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wpz-9G-IOZ" customClass="NSHoverButton">
@@ -652,8 +651,8 @@
                     <rect key="frame" x="335" y="242" width="14" height="19"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="||" id="AcP-XE-cJn">
                         <font key="font" metaFont="system" size="15"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
                         <outlet property="delegate" destination="-2" id="Y7v-ic-XoW"/>
@@ -663,8 +662,8 @@
                     <rect key="frame" x="-1" y="242" width="14" height="19"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="||" id="2fC-dQ-TDq">
                         <font key="font" metaFont="system" size="15"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
                         <outlet property="delegate" destination="-2" id="Vmr-5c-TTO"/>

--- a/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryEditViewController.xib
@@ -349,7 +349,7 @@
                                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EMR-ul-vEb">
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EMR-ul-vEb" customClass="UndoTextField">
                                                         <rect key="frame" x="118" y="9" width="125" height="22"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="125" id="6rf-F2-ZAy"/>

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -368,7 +368,6 @@ extern void *ctx;
 
 		BOOL onLeft = (self.view.window.frame.origin.x > self.timeEntryPopupEditView.window.frame.origin.x);
 		[self.timeEntryEditViewController setDragHandle:onLeft];
-		[self.timeEntryEditViewController setInsertionPointColor];
 	}
 }
 

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -112,6 +112,11 @@ extern void *ctx;
 												 selector:@selector(escapeListing:)
 													 name:kEscapeListing
 												   object:nil];
+
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(effectiveAppearanceChangedNotification)
+													 name:NSNotification.EffectiveAppearanceChanged
+												   object:nil];
 	}
 	return self;
 }
@@ -866,6 +871,11 @@ extern void *ctx;
 			 };
 		 }];
 	}
+}
+
+- (void)effectiveAppearanceChangedNotification {
+    // Re-draw hard-code color sheme for all cells in tableview
+	[self.timeEntriesTableView reloadData];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
@@ -33,6 +33,7 @@
         <customView id="ozl-58-bBU" customClass="NSViewEscapable">
             <rect key="frame" x="0.0" y="0.0" width="346" height="356"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <point key="canvasLocation" x="26" y="512"/>
         </customView>
         <customView id="3">
             <rect key="frame" x="0.0" y="0.0" width="252" height="260"/>

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,7 +25,7 @@
                 <outlet property="view" destination="ozl-58-bBU" id="kIv-R4-Xca"/>
             </connections>
         </viewController>
-        <popover appearance="aqua" id="dIa-oe-UAP">
+        <popover id="dIa-oe-UAP">
             <connections>
                 <outlet property="delegate" destination="-2" id="Za9-G4-27V"/>
             </connections>
@@ -51,7 +51,7 @@
                     </constraints>
                     <textFieldCell key="cell" enabled="NO" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Welcome back! Your previous entries are available in the web under reports" id="kLq-fS-jvh">
                         <font key="font" metaFont="system" size="15"/>
-                        <color key="textColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
@@ -60,18 +60,18 @@
                 </textField>
                 <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="17" horizontalPageScroll="10" verticalLineScroll="17" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fu8-w4-kYq">
                     <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>
-                    <clipView key="contentView" id="TQQ-db-grk">
+                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="TQQ-db-grk">
                         <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="kSc-tv-Cw1" customClass="NSUnstripedTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <color key="backgroundColor" red="0.96078437566757202" green="0.96078437566757202" blue="0.96078437566757202" alpha="1" colorSpace="deviceRGB"/>
+                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                <color key="gridColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="" editable="NO" width="252" minWidth="40" maxWidth="2500" id="Pqa-db-i5f">
+                                    <tableColumn editable="NO" width="252" minWidth="40" maxWidth="2500" id="Pqa-db-i5f">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -112,13 +112,13 @@
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" red="0.89803928136825562" green="0.89803928136825562" blue="0.89803928136825562" alpha="1" colorSpace="deviceRGB"/>
+                        <nil key="backgroundColor"/>
                     </clipView>
-                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RWC-Ro-rhd">
+                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RWC-Ro-rhd">
                         <rect key="frame" x="0.0" y="314" width="255" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="mPP-6U-WOC">
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="mPP-6U-WOC">
                         <rect key="frame" x="236" y="0.0" width="16" height="95"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,7 +25,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="M2u-7B-WCs">
+        <customView appearanceType="aqua" id="M2u-7B-WCs">
             <rect key="frame" x="0.0" y="0.0" width="258" height="46"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		BA6E873521DDC1E2005E2451 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; };
 		BA6E873621DDC1E2005E2451 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BA6F1B1A21EEE258009265E4 /* NSColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */; };
+		BA6F1B3821EEE998009265E4 /* Theme+Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */; };
 		BA7B4BCB21C0EF8800B75B14 /* NSAlert+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */; };
 		BA712EC221BF907200A2D8DD /* UndoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA712EC121BF907200A2D8DD /* UndoStorage.swift */; };
 		BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA712EC121BF907200A2D8DD /* UndoManager.swift */; };
@@ -663,6 +664,7 @@
 		BA2DA11F21A691FF0027B7A5 /* TrackingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrackingService.m; sourceTree = "<group>"; };
 		BA6E86A521DDB331005E2451 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = ../../../../third_party/Sparkle/Sparkle.xcodeproj; sourceTree = "<group>"; };
 		BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Utils.swift"; sourceTree = "<group>"; };
+		BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Notification.swift"; sourceTree = "<group>"; };
 		BA7B4BC921C0EF8800B75B14 /* NSAlert+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSAlert+Utils.h"; sourceTree = "<group>"; };
 		BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSAlert+Utils.m"; sourceTree = "<group>"; };
 		BA712EC121BF907200A2D8DD /* UndoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoStorage.swift; sourceTree = "<group>"; };
@@ -1215,6 +1217,7 @@
 			isa = PBXGroup;
 			children = (
 				BA229D0F21EDEDC400DEB4B9 /* Theme.swift */,
+				BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */,
 			);
 			name = Theme;
 			sourceTree = "<group>";
@@ -1748,6 +1751,7 @@
 				74A7346A18297DD100525BBC /* ConvertHexColor.m in Sources */,
 				74BAAA0B17F37B140079386F /* TimeEntryViewItem.m in Sources */,
 				7423393C1829B99C00063FA9 /* IdleNotificationWindowController.m in Sources */,
+				BA6F1B3821EEE998009265E4 /* Theme+Notification.swift in Sources */,
 				7430750418204EFB009019CB /* AboutWindowController.m in Sources */,
 				74D1D27217EB72D900E709B0 /* TimerEditViewController.m in Sources */,
 				3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -142,9 +142,11 @@
 		BA0CEC5321BE528900F1BF01 /* TableViewDiffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0CEC5221BE528900F1BF01 /* TableViewDiffer.swift */; };
 		BA0CEC6521BE590200F1BF01 /* NSTableView+Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0CEC6421BE590200F1BF01 /* NSTableView+Diff.swift */; };
 		BA13E05C21C7BA6000835EC1 /* UserNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA13E05921C7B9D900835EC1 /* UserNotificationCenter.m */; };
+		BA229D1021EDEDC400DEB4B9 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA229D0F21EDEDC400DEB4B9 /* Theme.swift */; };
 		BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11F21A691FF0027B7A5 /* TrackingService.m */; };
 		BA6E873521DDC1E2005E2451 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; };
 		BA6E873621DDC1E2005E2451 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BA6F1B1A21EEE258009265E4 /* NSColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */; };
 		BA7B4BCB21C0EF8800B75B14 /* NSAlert+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */; };
 		BA712EC221BF907200A2D8DD /* UndoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA712EC121BF907200A2D8DD /* UndoStorage.swift */; };
 		BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA712EC121BF907200A2D8DD /* UndoManager.swift */; };
@@ -422,7 +424,6 @@
 				BAD2342621D612DF0039C742 /* libPocoUtil.60.dylib in CopyFiles */,
 				BAD2342021D612DF0039C742 /* libPocoNetSSL.60.dylib in CopyFiles */,
 				BAD2342221D612DF0039C742 /* libPocoCrypto.60.dylib in CopyFiles */,
-				74A3D06219E418CB00C51BB6 /* Sparkle.framework in CopyFiles */,
 				BAD2342421D612DF0039C742 /* libPocoXML.60.dylib in CopyFiles */,
 				74213490195C50B5007EF78B /* CrashReporter.framework in CopyFiles */,
 				BA6E873621DDC1E2005E2451 /* Sparkle.framework in CopyFiles */,
@@ -657,9 +658,11 @@
 		BA0CEC6421BE590200F1BF01 /* NSTableView+Diff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Diff.swift"; sourceTree = "<group>"; };
 		BA13E05921C7B9D900835EC1 /* UserNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = UserNotificationCenter.m; path = test2/UserNotificationCenter.m; sourceTree = SOURCE_ROOT; };
 		BA13E05A21C7B9D900835EC1 /* UserNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UserNotificationCenter.h; path = test2/UserNotificationCenter.h; sourceTree = SOURCE_ROOT; };
+		BA229D0F21EDEDC400DEB4B9 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		BA2DA11E21A691FF0027B7A5 /* TrackingService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackingService.h; sourceTree = "<group>"; };
 		BA2DA11F21A691FF0027B7A5 /* TrackingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrackingService.m; sourceTree = "<group>"; };
 		BA6E86A521DDB331005E2451 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = ../../../../third_party/Sparkle/Sparkle.xcodeproj; sourceTree = "<group>"; };
+		BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Utils.swift"; sourceTree = "<group>"; };
 		BA7B4BC921C0EF8800B75B14 /* NSAlert+Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSAlert+Utils.h"; sourceTree = "<group>"; };
 		BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSAlert+Utils.m"; sourceTree = "<group>"; };
 		BA712EC121BF907200A2D8DD /* UndoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoStorage.swift; sourceTree = "<group>"; };
@@ -840,6 +843,7 @@
 		69FC17FA17E6534400B96425 /* ui */ = {
 			isa = PBXGroup;
 			children = (
+				BA229D0E21EDEDBA00DEB4B9 /* Theme */,
 				BA13E05B21C7B9F800835EC1 /* UserNotification */,
 				BAF87DDB21A3E1E700624EBE /* Extension */,
 				BAF50DF521A2A16D0090BA95 /* Icon */,
@@ -1207,6 +1211,14 @@
 			path = Undo;
 			sourceTree = "<group>";
 		};
+		BA229D0E21EDEDBA00DEB4B9 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				BA229D0F21EDEDC400DEB4B9 /* Theme.swift */,
+			);
+			name = Theme;
+			sourceTree = "<group>";
+		};
 		BA6E86A621DDB331005E2451 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1222,14 +1234,7 @@
 				BA6E86C821DDB331005E2451 /* sign_update */,
 			);
 			name = Products;
-		};
-		BA6E874C21DE12B5005E2451 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				BAD232CF21D495E20039C742 /* UserNotificationCenter.m */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
+			sourceTree = "<unknown>";
 		};
 		BAF87DDB21A3E1E700624EBE /* Extension */ = {
 			isa = PBXGroup;
@@ -1239,6 +1244,7 @@
 				BA7B4BC921C0EF8800B75B14 /* NSAlert+Utils.h */,
 				BA7B4BCA21C0EF8800B75B14 /* NSAlert+Utils.m */,
 				BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */,
+				BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */,
 			);
 			name = Extension;
 			sourceTree = "<group>";
@@ -1647,20 +1653,6 @@
 			shellPath = /usr/bin/ruby;
 			shellScript = "if ENV[\"DEBUG_INFORMATION_FORMAT\"] != \"dwarf-with-dsym\"\nexit\nend\n\nfork do\nProcess.setsid\nSTDIN.reopen(\"/dev/null\")\nSTDOUT.reopen(\"/dev/null\", \"a\")\nSTDERR.reopen(\"/dev/null\", \"a\")\n\nrequire 'shellwords'\n\nDir[\"#{ENV[\"DWARF_DSYM_FOLDER_PATH\"]}/#{ENV[\"DWARF_DSYM_FILE_NAME\"]}/Contents/Resources/DWARF/*\"].each do |dsym|\nsystem(\"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\"PROJECT_DIR\"])} https://upload.bugsnag.com/\")\nend\nend";
 		};
-		74F125D51BB2ED9000487B14 /* Run Script (fix CrashReporter path in main app) */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script (fix CrashReporter path in main app)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "install_name_tool -change @rpath/CrashReporter.framework/Versions/A/CrashReporter @executable_path/../../Contents/Frameworks/CrashReporter.framework/Versions/A/CrashReporter $BUILT_PRODUCTS_DIR/TogglDesktop.app/Contents/MacOS/TogglDesktop\n";
-		};
 		BA6406F121C8FC690074BC96 /* Run Formatter */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1735,6 +1727,7 @@
 				3C0A571B1C22E12E00301D77 /* MKColorSwatchCell.m in Sources */,
 				3CD30F431F58B02C006FAA0D /* OverlayViewController.m in Sources */,
 				74D1D25617EB713F00E709B0 /* TimeEntryListViewController.m in Sources */,
+				BA6F1B1A21EEE258009265E4 /* NSColor+Utils.swift in Sources */,
 				74AA9476180909F50000539F /* GTMOAuth2WindowController.m in Sources */,
 				74D1D25D17EB71C100E709B0 /* TimeEntryEditViewController.m in Sources */,
 				3C0A571C1C22E12E00301D77 /* MKColorSwatchMatrix.m in Sources */,
@@ -1770,6 +1763,7 @@
 				BA7B4C7C21C293E700B75B14 /* String+Optional.swift in Sources */,
 				BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */,
 				3C6B2486203E01D90063FC08 /* AutoCompleteTableCell.m in Sources */,
+				BA229D1021EDEDC400DEB4B9 /* Theme.swift in Sources */,
 				3CE30E022052BD8B00AF2E2A /* AutoCompleteTableContainer.m in Sources */,
 				3C0A571D1C22E12E00301D77 /* MKColorWell+Bindings.m in Sources */,
 				BA7B4C3721C24B9D00B75B14 /* UndoTextField.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -226,7 +226,10 @@ BOOL onTop = NO;
 												 name:kUpdateIconTooltip
 											   object:nil];
 
-	self.effectiveAppearanceObs = [self.mainWindowController.window observerEffectiveAppearanceNotification];
+	if (@available(macOS 10.14, *))
+	{
+		self.effectiveAppearanceObs = [self.mainWindowController.window observerEffectiveAppearanceNotification];
+	}
 
 	toggl_set_environment(ctx, [self.environment UTF8String]);
 

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -89,6 +89,7 @@
 
 // Manual mode
 @property NSMenuItem *manualModeMenuItem;
+@property (strong, nonatomic) NSKeyValueObservation *effectiveAppearanceObs;
 
 // System Service
 @property (strong, nonatomic) SystemService *systemService;
@@ -224,6 +225,8 @@ BOOL onTop = NO;
 											 selector:@selector(startUpdateIconTooltip:)
 												 name:kUpdateIconTooltip
 											   object:nil];
+
+	self.effectiveAppearanceObs = [self.mainWindowController.window observerEffectiveAppearanceNotification];
 
 	toggl_set_environment(ctx, [self.environment UTF8String]);
 

--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteTableCell.xib
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteTableCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
-        <capability name="box content view" minToolsVersion="7.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -30,11 +29,9 @@
                             <constraint firstAttribute="bottom" secondItem="8t3-Aw-a0W" secondAttribute="bottom" id="scF-GU-XRJ"/>
                         </constraints>
                     </view>
-                    <color key="borderColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                    <color key="fillColor" red="0.43355683137617618" green="1" blue="0.23677784642988997" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </box>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Esa-Pm-mxj">
-                    <rect key="frame" x="5" y="5" width="190" height="17"/>
+                    <rect key="frame" x="5" y="4" width="190" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="17" id="4pE-iB-o9m"/>
                     </constraints>

--- a/src/ui/osx/TogglDesktop/test2/LoadMoreCell.xib
+++ b/src/ui/osx/TogglDesktop/test2/LoadMoreCell.xib
@@ -43,7 +43,6 @@
                             <constraint firstItem="mHA-iF-pCY" firstAttribute="centerX" secondItem="26W-Y5-via" secondAttribute="centerX" id="kcz-eC-sLd"/>
                         </constraints>
                     </view>
-                    <color key="fillColor" red="0.92156862745098034" green="0.92156862745098034" blue="0.92156862745098034" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
             </subviews>
             <constraints>

--- a/src/ui/osx/TogglDesktop/test2/NSColor+Utils.swift
+++ b/src/ui/osx/TogglDesktop/test2/NSColor+Utils.swift
@@ -1,0 +1,20 @@
+//
+//  NSColor+Utils.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 1/16/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+extension NSColor {
+
+    @objc class var safeUnemphasizedSelectedContentBackgroundColor: NSColor {
+        if #available(OSX 10.14, *) {
+            return NSColor.unemphasizedSelectedContentBackgroundColor
+        } else {
+            return NSColor(white: 0.21, alpha: 1.0)
+        }
+    }
+}

--- a/src/ui/osx/TogglDesktop/test2/NSCustomComboBox.m
+++ b/src/ui/osx/TogglDesktop/test2/NSCustomComboBox.m
@@ -23,21 +23,6 @@
 	[self.cell setCalculatedMaxWidth:fmax(8 * n, self.frame.size.width)];
 }
 
-- (BOOL)becomeFirstResponder
-{
-	BOOL success = [super becomeFirstResponder];
-
-	if (success)
-	{
-		NSTextView *textField = (NSTextView *)[self currentEditor];
-		if ([textField respondsToSelector:@selector(setInsertionPointColor:)])
-		{
-			[textField setInsertionPointColor:[NSColor blackColor]];
-		}
-	}
-	return success;
-}
-
 - (BOOL)isExpanded
 {
 	return self.accessibilityExpanded;

--- a/src/ui/osx/TogglDesktop/test2/NSCustomTimerComboBox.m
+++ b/src/ui/osx/TogglDesktop/test2/NSCustomTimerComboBox.m
@@ -22,21 +22,6 @@
 	}
 }
 
-- (BOOL)becomeFirstResponder
-{
-	BOOL success = [super becomeFirstResponder];
-
-	if (success)
-	{
-		NSTextView *textField = (NSTextView *)[self currentEditor];
-		if ([textField respondsToSelector:@selector(setInsertionPointColor:)])
-		{
-			[textField setInsertionPointColor:[NSColor whiteColor]];
-		}
-	}
-	return success;
-}
-
 - (void)drawRect:(NSRect)dirtyRect
 {
 	if (([[self window] firstResponder] == [self currentEditor]) && [NSApp isActive])

--- a/src/ui/osx/TogglDesktop/test2/NSTextFieldClickable.m
+++ b/src/ui/osx/TogglDesktop/test2/NSTextFieldClickable.m
@@ -23,19 +23,4 @@
 	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
 }
 
-- (BOOL)becomeFirstResponder
-{
-	BOOL success = [super becomeFirstResponder];
-
-	if (success && self.isEditable)
-	{
-		NSTextView *textField = (NSTextView *)[self currentEditor];
-		if ([textField respondsToSelector:@selector(setInsertionPointColor:)])
-		{
-			[textField setInsertionPointColor:[NSColor whiteColor]];
-		}
-	}
-	return success;
-}
-
 @end

--- a/src/ui/osx/TogglDesktop/test2/NSTextFieldDuration.m
+++ b/src/ui/osx/TogglDesktop/test2/NSTextFieldDuration.m
@@ -16,21 +16,6 @@
 	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
 }
 
-- (BOOL)becomeFirstResponder
-{
-	BOOL success = [super becomeFirstResponder];
-
-	if (success && self.isEditable)
-	{
-		NSTextView *textField = (NSTextView *)[self currentEditor];
-		if ([textField respondsToSelector:@selector(setInsertionPointColor:)])
-		{
-			[textField setInsertionPointColor:[NSColor whiteColor]];
-		}
-	}
-	return success;
-}
-
 - (BOOL)isExpanded
 {
 	return NO;

--- a/src/ui/osx/TogglDesktop/test2/OverlayViewController.xib
+++ b/src/ui/osx/TogglDesktop/test2/OverlayViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,11 +29,11 @@
                             <textView focusRingType="none" editable="NO" drawsBackground="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" textCompletion="NO" id="rVi-dV-7Qd">
                                 <rect key="frame" x="0.0" y="0.0" width="225" height="200"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="deviceWhite"/>
+                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <size key="minSize" width="225" height="200"/>
                                 <size key="maxSize" width="463" height="10000000"/>
-                                <color key="insertionPointColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -42,17 +42,17 @@
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="160" id="AUB-dT-R6g"/>
                         <constraint firstAttribute="width" constant="225" id="ta5-mu-vXF"/>
                     </constraints>
-                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="MYa-Yh-6vh">
+                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="MYa-Yh-6vh">
                         <rect key="frame" x="-100" y="-100" width="87" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3FW-SE-eLU">
+                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3FW-SE-eLU">
                         <rect key="frame" x="-100" y="-100" width="15" height="62"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iQo-bT-Stg">
-                    <rect key="frame" x="31" y="317" width="189" height="42"/>
+                    <rect key="frame" x="32" y="317" width="189" height="42"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="185" id="EzF-pq-qMV"/>
                         <constraint firstAttribute="height" constant="37" id="bp4-Os-3rU"/>
@@ -77,8 +77,8 @@ DQ
                         <font key="font" metaFont="system"/>
                         <string key="title">Created your new workspace? 
 </string>
-                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
                         <outlet property="delegate" destination="-2" id="zzZ-uy-jKZ"/>

--- a/src/ui/osx/TogglDesktop/test2/Theme+Notification.swift
+++ b/src/ui/osx/TogglDesktop/test2/Theme+Notification.swift
@@ -1,0 +1,27 @@
+//
+//  Theme+Notification.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 1/16/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+extension Notification.Name {
+    static let EffectiveAppearanceChanged = Notification.Name("EffectiveAppearanceChanged")
+}
+
+extension NSNotification {
+    @objc static let EffectiveAppearanceChanged: String = Notification.Name.EffectiveAppearanceChanged.rawValue
+}
+
+extension NSWindow {
+
+    @objc func observerEffectiveAppearanceNotification() -> NSKeyValueObservation {
+        return observe(\.effectiveAppearance) {[weak self] (_, _) in
+            guard let _ = self else { return }
+            NotificationCenter.default.post(name: .EffectiveAppearanceChanged, object: nil)
+        }
+    }
+}

--- a/src/ui/osx/TogglDesktop/test2/Theme.swift
+++ b/src/ui/osx/TogglDesktop/test2/Theme.swift
@@ -1,0 +1,27 @@
+//
+//  Theme.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 1/15/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+
+enum Theme {
+
+    case dark
+    case light
+
+    static func current() -> Theme {
+        let mode = UserDefaults.standard.string(forKey: "AppleInterfaceStyle")
+        return mode == "Dark" ? .dark : .light
+    }
+}
+
+@objc class ThemeUtils: NSObject {
+
+    @objc class func isDarkTheme() -> Bool {
+        return Theme.current() == .dark
+    }
+}

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -138,6 +138,18 @@ extern void *ctx;
 	return string;
 }
 
+- (NSColor *)adaptedBackgroundColor {
+	BOOL isDarkTheme = [ThemeUtils isDarkTheme];
+
+	NSColor *primaryColor = isDarkTheme ? [NSColor safeUnemphasizedSelectedContentBackgroundColor] : [ConvertHexColor hexCodeToNSColor:@"#FAFAFA"];
+
+	if (self.GroupItemCount && self.GroupOpen && !self.Group)
+	{
+		primaryColor = isDarkTheme ? [NSColor controlColor] : [ConvertHexColor hexCodeToNSColor:@"#f0f0f0"];
+	}
+	return primaryColor;
+}
+
 - (void)setupGroupMode
 {
 	// Default descriptionbox trail (no group icon)
@@ -146,22 +158,20 @@ extern void *ctx;
 	NSString *continueIcon = @"continue_light.pdf";
 	NSString *toggleGroupIcon = @"group_icon_closed.pdf";
 	NSString *toggleGroupText = [NSString stringWithFormat:@"%lld", self.GroupItemCount];
-
-	// Default color of light gray
-	NSString *fillColor = @"#FAFAFA";
+	BOOL isDarkTheme = [ThemeUtils isDarkTheme];
 
 	// Grouped mode background update
 	if (self.GroupItemCount && self.GroupOpen && !self.Group)
 	{
-		// Subitems to darker gray
-		fillColor = @"#f0f0f0";
 		lead = 10;
+
+		NSColor *textColor = isDarkTheme ? [NSColor secondaryLabelColor] : [ConvertHexColor hexCodeToNSColor:@"#696969"];
 
 		// Gray color for subitem
 		NSMutableAttributedString *description = [[NSMutableAttributedString alloc] initWithString:self.descriptionTextField.stringValue];
 		[description setAttributes:
 		 @{
-			 NSForegroundColorAttributeName:[ConvertHexColor hexCodeToNSColor:@"#696969"]
+			 NSForegroundColorAttributeName:textColor
 		 }
 							 range:NSMakeRange(0, [description length])];
 
@@ -179,6 +189,8 @@ extern void *ctx;
 		}
 		else
 		{
+			NSColor *textColor = isDarkTheme ? [NSColor labelColor] : [ConvertHexColor hexCodeToNSColor:@"#a4a4a4"];
+
 			// Gray color to grouped button text
 			NSMutableParagraphStyle *paragrapStyle = NSMutableParagraphStyle.new;
 			paragrapStyle.alignment = kCTTextAlignmentCenter;
@@ -187,7 +199,7 @@ extern void *ctx;
 			[string setAttributes:
 			 @{
 				 NSFontAttributeName : [NSFont systemFontOfSize:9.0],
-				 NSForegroundColorAttributeName:[ConvertHexColor hexCodeToNSColor:@"#a4a4a4"],
+				 NSForegroundColorAttributeName:textColor,
 				 NSParagraphStyleAttributeName:paragrapStyle
 			 }
 							range:NSMakeRange(0, [string length])];
@@ -203,6 +215,8 @@ extern void *ctx;
 	[self.groupToggleButton setHidden:!self.Group];
 	self.descriptionBoxLead.constant = lead;
 	self.descriptionBoxTrail.constant = trail;
+
+	[self.backgroundBox setFillColor:[self adaptedBackgroundColor]];
 }
 
 - (void)focusFieldName
@@ -237,6 +251,10 @@ extern void *ctx;
 
 - (void)setFocused
 {
+	BOOL isDarkTheme = [ThemeUtils isDarkTheme];
+	NSColor *fillColor = isDarkTheme ? [NSColor controlColor] : [ConvertHexColor hexCodeToNSColor:@"#E8E8E8"];
+
+	[self.backgroundBox setFillColor:fillColor];
 }
 
 - (void)openEdit

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -237,7 +237,6 @@ extern void *ctx;
 
 - (void)setFocused
 {
-	// [self.backgroundBox setFillColor:[ConvertHexColor hexCodeToNSColor:@"#E8E8E8"]];
 }
 
 - (void)openEdit

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -203,8 +203,6 @@ extern void *ctx;
 	[self.groupToggleButton setHidden:!self.Group];
 	self.descriptionBoxLead.constant = lead;
 	self.descriptionBoxTrail.constant = trail;
-
-	[self.backgroundBox setFillColor:[ConvertHexColor hexCodeToNSColor:fillColor]];
 }
 
 - (void)focusFieldName
@@ -239,7 +237,7 @@ extern void *ctx;
 
 - (void)setFocused
 {
-	[self.backgroundBox setFillColor:[ConvertHexColor hexCodeToNSColor:@"#E8E8E8"]];
+	// [self.backgroundBox setFillColor:[ConvertHexColor hexCodeToNSColor:@"#E8E8E8"]];
 }
 
 - (void)openEdit

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
@@ -111,6 +111,7 @@
                         <constraint firstItem="dt4-Zf-56t" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" id="ewN-Z0-chU"/>
                         <constraint firstAttribute="bottom" secondItem="dt4-Zf-56t" secondAttribute="bottom" id="wpH-TW-gRX"/>
                     </constraints>
+                    <color key="fillColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pUA-1d-pGg">
                     <rect key="frame" x="151" y="12" width="24" height="24"/>

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
@@ -32,8 +32,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="left" title="Blogpost about ne..." id="KGe-cR-NlL">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="98" translatesAutoresizingMaskIntoConstraints="NO" id="deS-e6-3Ui" customClass="NSTextFieldWithBackground">
@@ -43,8 +43,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="left" title="NEW - TOGGL" id="apI-Za-Hk2">
                                                 <font key="font" metaFont="systemBold"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" red="0.98039215686274506" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <imageView hidden="YES" toolTip="Time Entry has not been synced to the server" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Kef-8A-XnH" userLabel="Unsynced_icon">
@@ -69,8 +69,6 @@
                                     <constraint firstItem="Kef-8A-XnH" firstAttribute="top" secondItem="CwR-d5-aWs" secondAttribute="bottom" id="hxV-rw-GA2"/>
                                     <constraint firstAttribute="trailing" secondItem="CwR-d5-aWs" secondAttribute="trailing" id="nSQ-Fz-0X7"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </box>
                             <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7lc-zN-Cm5" userLabel="GroupBox">
                                 <rect key="frame" x="88" y="13" width="24" height="24"/>
@@ -100,8 +98,6 @@
                                     <constraint firstItem="yV9-eP-fCj" firstAttribute="leading" secondItem="7lc-zN-Cm5" secondAttribute="leading" id="H0q-II-jla"/>
                                     <constraint firstAttribute="width" constant="24" id="g2X-HK-drE"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
                         </subviews>
                         <constraints>
@@ -115,8 +111,6 @@
                         <constraint firstItem="dt4-Zf-56t" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" id="ewN-Z0-chU"/>
                         <constraint firstAttribute="bottom" secondItem="dt4-Zf-56t" secondAttribute="bottom" id="wpH-TW-gRX"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215686274506" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pUA-1d-pGg">
                     <rect key="frame" x="151" y="12" width="24" height="24"/>
@@ -146,8 +140,6 @@
                         <constraint firstItem="Gcj-ki-Hus" firstAttribute="leading" secondItem="pUA-1d-pGg" secondAttribute="leading" id="dOT-4w-73G"/>
                         <constraint firstAttribute="width" constant="24" id="zEn-2B-XRB"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="TagBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6v5-Qq-QVS">
                     <rect key="frame" x="119" y="18" width="13" height="11"/>
@@ -171,8 +163,6 @@
                         <constraint firstItem="29c-rg-nft" firstAttribute="centerY" secondItem="6v5-Qq-QVS" secondAttribute="centerY" id="X25-jH-9YZ"/>
                         <constraint firstAttribute="width" constant="13" id="rQy-J7-ueT"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="BillableBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A8h-uh-nk3">
                     <rect key="frame" x="139" y="17" width="7" height="13"/>
@@ -196,8 +186,6 @@
                         <constraint firstAttribute="height" constant="13" id="9nA-ZA-Dcx"/>
                         <constraint firstAttribute="width" constant="7" id="bXb-gf-AYb"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="DurationBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lUV-Fj-IYJ">
                     <rect key="frame" x="177" y="16" width="63" height="16"/>
@@ -210,8 +198,8 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="03:21:30" id="Ten-lK-6RR">
                                     <font key="font" metaFont="cellTitle"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
                         </subviews>
@@ -220,8 +208,6 @@
                         <constraint firstAttribute="height" constant="16" id="Nob-mi-BiS"/>
                         <constraint firstAttribute="width" constant="63" id="iL1-tt-qe0"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                 </box>
             </subviews>
             <constraints>

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -111,7 +112,7 @@
                         <constraint firstItem="dt4-Zf-56t" firstAttribute="top" secondItem="ar8-w3-mLZ" secondAttribute="top" id="ewN-Z0-chU"/>
                         <constraint firstAttribute="bottom" secondItem="dt4-Zf-56t" secondAttribute="bottom" id="wpH-TW-gRX"/>
                     </constraints>
-                    <color key="fillColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    <color key="fillColor" name="unemphasizedSelectedContentBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pUA-1d-pGg">
                     <rect key="frame" x="151" y="12" width="24" height="24"/>

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCellWithHeader.xib
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCellWithHeader.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="System colors introduced in macOS 10.14" minToolsVersion="10.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,7 +28,7 @@
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Thu 22. Jan" id="Rk2-8z-I6y">
                                     <font key="font" metaFont="cellTitle"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
@@ -52,6 +53,7 @@
                         <constraint firstAttribute="trailing" secondItem="A9Z-Z5-Qzd" secondAttribute="trailing" constant="14" id="pdU-vs-HlT"/>
                         <constraint firstItem="Eux-yk-8iS" firstAttribute="leading" secondItem="PuG-98-30a" secondAttribute="leading" constant="15" id="zGM-wF-4mT"/>
                     </constraints>
+                    <color key="fillColor" name="alternatingContentBackgroundColor" catalog="System" colorSpace="catalog"/>
                     <size key="contentViewMargins" width="0.0" height="10"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="HvF-1T-7Z3">
@@ -250,6 +252,7 @@
                         <constraint firstAttribute="trailing" secondItem="DdV-RE-Kny" secondAttribute="trailing" constant="12" id="wEr-pQ-m6g"/>
                         <constraint firstAttribute="trailing" secondItem="zIj-LV-eXy" secondAttribute="trailing" constant="106" id="ySX-Kj-fCR"/>
                     </constraints>
+                    <color key="fillColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="contentViewMargins" width="0.0" height="10"/>
                 </box>
             </subviews>

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCellWithHeader.xib
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCellWithHeader.xib
@@ -27,8 +27,8 @@
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Thu 22. Jan" id="Rk2-8z-I6y">
                                     <font key="font" metaFont="cellTitle"/>
-                                    <color key="textColor" white="0.41999999999999998" alpha="1" colorSpace="calibratedWhite"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A9Z-Z5-Qzd">
@@ -39,7 +39,7 @@
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="2 h  12 min" id="6GT-P9-Wsv">
                                     <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" white="0.41999999999999998" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
@@ -52,8 +52,6 @@
                         <constraint firstAttribute="trailing" secondItem="A9Z-Z5-Qzd" secondAttribute="trailing" constant="14" id="pdU-vs-HlT"/>
                         <constraint firstItem="Eux-yk-8iS" firstAttribute="leading" secondItem="PuG-98-30a" secondAttribute="leading" constant="15" id="zGM-wF-4mT"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.92156862745098034" green="0.92156862745098034" blue="0.92156862745098034" alpha="1" colorSpace="calibratedRGB"/>
                     <size key="contentViewMargins" width="0.0" height="10"/>
                 </box>
                 <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="HvF-1T-7Z3">
@@ -75,8 +73,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="left" title="PROJECT NAME - CLIENT" id="YKk-bz-65B">
                                                 <font key="font" metaFont="systemBold"/>
-                                                <color key="textColor" name="controlDarkShadowColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" red="0.98039215686274506" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="175" translatesAutoresizingMaskIntoConstraints="NO" id="IPX-6P-J70">
@@ -86,8 +84,8 @@
                                             </constraints>
                                             <textFieldCell key="cell" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="left" title="This is a time entry" id="bKB-0i-C0M">
                                                 <font key="font" metaFont="system"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <imageView hidden="YES" toolTip="Time Entry has not been synced to the server" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m2D-dM-ygH" userLabel="Unsynced_icon">
@@ -121,8 +119,8 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="03:21:30" id="P10-iS-flR">
                                                 <font key="font" metaFont="cellTitle"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                     </subviews>
@@ -131,8 +129,6 @@
                                     <constraint firstAttribute="height" constant="16" id="f7F-x8-Fmy"/>
                                     <constraint firstAttribute="width" constant="63" id="kOR-ex-wFu"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
                             <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="63N-7j-264">
                                 <rect key="frame" x="229" y="7" width="24" height="24"/>
@@ -185,8 +181,6 @@
                                     <constraint firstAttribute="height" constant="13" id="MsQ-Qo-FHh"/>
                                     <constraint firstAttribute="width" constant="7" id="YIJ-F1-Bv9"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
                             <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="TagBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vMk-19-ANF">
                                 <rect key="frame" x="197" y="12" width="13" height="11"/>
@@ -210,8 +204,6 @@
                                     <constraint firstAttribute="bottom" secondItem="Uzs-Rq-HN0" secondAttribute="bottom" id="RAA-8i-lbS"/>
                                     <constraint firstAttribute="trailing" secondItem="Uzs-Rq-HN0" secondAttribute="trailing" id="dQs-Kg-l4f"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
                             <box autoresizesSubviews="NO" boxType="custom" borderType="line" borderWidth="0.0" title="ContinueBox" titlePosition="noTitle" transparent="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XKl-Hx-jZr" userLabel="GroupBox">
                                 <rect key="frame" x="166" y="6" width="24" height="24"/>
@@ -236,8 +228,6 @@
                                     <constraint firstAttribute="width" constant="24" id="h59-Ul-7YD"/>
                                     <constraint firstAttribute="height" constant="24" id="qNx-MI-cQR"/>
                                 </constraints>
-                                <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                                <color key="fillColor" red="0.98039215690000003" green="0.98039215690000003" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
                             </box>
                         </subviews>
                         <constraints>
@@ -260,8 +250,6 @@
                         <constraint firstAttribute="trailing" secondItem="DdV-RE-Kny" secondAttribute="trailing" constant="12" id="wEr-pQ-m6g"/>
                         <constraint firstAttribute="trailing" secondItem="zIj-LV-eXy" secondAttribute="trailing" constant="106" id="ySX-Kj-fCR"/>
                     </constraints>
-                    <color key="borderColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
-                    <color key="fillColor" red="0.98039215686274506" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="calibratedRGB"/>
                     <size key="contentViewMargins" width="0.0" height="10"/>
                 </box>
             </subviews>


### PR DESCRIPTION
### 📒 Description
This PR will introduce the light-dark theme capability for Toggl Desktop app.

- If OS >= 10.14, TogglDesktop will change depend on current OS's theme
- Otherwise, light theme (old) is still remained.

### 🕶️ Types of changes
 **New feature**

### 🤯 List of changes
- [x] Use default color for NSLabel and NSTextField as possible
- [x] Remove all cursor hard-code color - since NSTextFields is responsible for updating it => Make sure the cursor colors is always distinguishable from background color.
- [x] Adopt dark theme for all windows except (About windows, since it's always black)
- [x] Fix hard-code color in EntryTimeCell
- [x] Observe globally the change of `effectiveAppearance` and notify to TimeEntryListController to re-render hard-code color again.

### 👫 Relationships
Closes #2728 

### 🔎 Review hints
- Open app in light / dark theme separately 
- Or changing theme while opening the app.