### PR TITLE
Unable to build `master` on Windows

### DIFF
--- a/src/related_data.h
+++ b/src/related_data.h
@@ -12,6 +12,7 @@
 #include "./types.h"
 
 #include "Poco/Mutex.h"
+#include <functional>
 
 namespace toggl {
 


### PR DESCRIPTION
### 📒 Description
Regarding #2748, there was a missing header in `RelatedData` class which lead to the error 💥  in Windows VS 2017.

This PR will fix it.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Add missing functional header

### 👫 Relationships
There is no ticket here.

### 🔎 Review hints
- Able to build and run on macOS / Windows / Linux
