### PR TITLE
Support custom error message from Response

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1000,10 +1000,7 @@ error Context::displayError(const error err, const std::string message) {
         }
     }
 
-    if (!message.empty()) {
-        return UI()->DisplayError(message);
-    }
-    return UI()->DisplayError(err);
+    return UI()->DisplayError(err, message);
 }
 
 int Context::nextSyncIntervalSeconds() const {

--- a/src/context.h
+++ b/src/context.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <memory>
 #include <iostream> // NOLINT
+#include <tuple>
 
 #include "./analytics.h"
 #include "./custom_error_handler.h"
@@ -513,6 +514,7 @@ class Context : public TimelineDatasource {
 
     void updateUI(const UIElements &elements);
 
+    error displayError(const error err, const std::string message);
     error displayError(const error err);
 
     void scheduleSync();
@@ -531,7 +533,7 @@ class Context : public TimelineDatasource {
     error attemptOfflineLogin(const std::string email,
                               const std::string password);
 
-    error downloadUpdate();
+    std::tuple<error, std::string> downloadUpdate();
 
     void stopActivities();
 

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -141,7 +141,7 @@ void GUI::DisplayLogin(const bool open, const uint64_t user_id) {
     lastDisplayLoginUserID = user_id;
 }
 
-error GUI::DisplayError(const error err) {
+error GUI::DisplayError(const error err, const std::string error_message) {
     if (noError == err) {
         return noError;
     }
@@ -177,7 +177,8 @@ error GUI::DisplayError(const error err) {
     }
 
     char_t *err_s = copy_string(actionable);
-    on_display_error_(err_s, is_user_error);
+    char_t *message = copy_string(error_message);
+    on_display_error_(err_s, message, is_user_error);
     free(err_s);
 
     lastErr = err;

--- a/src/gui.h
+++ b/src/gui.h
@@ -377,7 +377,7 @@ class GUI : public SyncStateMonitor {
 
     void DisplayApp();
 
-    error DisplayError(const error);
+    error DisplayError(const error, const std::string error_message);
 
     // Overlay screen triggers
     error DisplayWSError();

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -492,7 +492,8 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         resp.err = statusCodeToError(resp.status_code);
 
         // Get human-readable error message from response
-        if (resp.err != noError && response.getContentType() == kContentTypeApplicationJSON) {
+        if (resp.err != noError &&
+                response.getContentType().find(kContentTypeApplicationJSON) != std::string::npos) {
             Json::Value root;
             Json::Reader reader;
             if (reader.parse(resp.body, root)) {

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -490,6 +490,16 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         }
 
         resp.err = statusCodeToError(resp.status_code);
+
+        // Get human-readable error message from response
+        if (resp.err != noError && response.getContentType() == kContentTypeApplicationJSON) {
+            Json::Value root;
+            Json::Reader reader;
+            if (reader.parse(resp.body, root)) {
+                resp.error_message = root["error_message"].asString();
+            }
+        }
+
     } catch(const Poco::Exception& exc) {
         resp.err = exc.displayText();
         return resp;

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -126,11 +126,13 @@ class HTTPSResponse {
     HTTPSResponse()
         : body("")
     , err(noError)
+    , error_message(noError)
     , status_code(0) {}
     virtual ~HTTPSResponse() {}
 
     std::string body;
     error err;
+    std::string error_message;
     Poco::Int64 status_code;
 };
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -202,6 +202,7 @@ extern "C" {
 
     typedef void (*TogglDisplayError)(
         const char_t *errmsg,
+        const char_t *message,
         const bool_t user_error);
 
     typedef void (*TogglDisplayOverlay)(

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -38,9 +38,12 @@ void on_display_update(const char *url) {
 
 void on_display_error(
     const char *errmsg,
+    const char *message,
     const bool_t user_error) {
     TogglApi::instance->aboutToDisplayError();
-    TogglApi::instance->displayError(QString(errmsg), user_error);
+    QString user_message = QString(message);
+    QString space = QString(" ");
+    TogglApi::instance->displayError(QString(errmsg) + space + user_message, user_error);
 }
 
 void on_overlay(const int64_t type) {

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1719,12 +1719,14 @@ void on_app(const bool_t open)
 														object:cmd];
 }
 
-void on_error(const char *errmsg, const bool_t is_user_error)
+void on_error(const char *errmsg, const char *message, const bool_t is_user_error)
 {
 	NSString *msg = [NSString stringWithUTF8String:errmsg];
+	NSString *userMessage = [NSString stringWithUTF8String:message];
+	NSString *text = [NSString stringWithFormat:@"%@ %@", msg, userMessage];
 
 	[[NSNotificationCenter defaultCenter] postNotificationName:kDisplayError
-														object:msg];
+														object:text];
 	if (!is_user_error)
 	{
 		char *str = toggl_get_update_channel(ctx);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -77,7 +77,7 @@ static class Program
                 uid = user_id;
             };
 
-            Toggl.OnError += delegate(string errmsg, bool user_error)
+            Toggl.OnError += delegate(string errmsg, string message, bool user_error)
             {
                 Toggl.Debug(errmsg);
                 try

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -74,6 +74,7 @@ public static partial class Toggl
 
     public delegate void DisplayError(
         string errmsg,
+        string message,
         bool user_error);
 
     public delegate void DisplaySyncState(
@@ -744,11 +745,11 @@ public static partial class Toggl
             }
         });
 
-        toggl_on_error(ctx, (errmsg, user_error) =>
+        toggl_on_error(ctx, (errmsg, message, user_error) =>
         {
             using (Performance.Measure("Calling OnError, user_error: {1}, message: {0}", errmsg, user_error))
             {
-                OnError(errmsg, user_error);
+                OnError(errmsg, message, user_error);
             }
         });
 
@@ -1367,7 +1368,7 @@ public static partial class Toggl
 
     public static void NewError(string errmsg, bool user_error)
     {
-        OnError(errmsg, user_error);
+        OnError(errmsg, "", user_error);
     }
 
     public static bool AskToDeleteEntry(string guid)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -349,6 +349,8 @@ public static partial class Toggl
     private delegate void     TogglDisplayError(
         [MarshalAs(UnmanagedType.LPWStr)]
         string errmsg,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string message,
         [MarshalAs(UnmanagedType.I1)]
         bool user_error);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -395,12 +395,12 @@ namespace TogglDesktop
             this.setActiveView(this.overlayView);   
         }
 
-        private void onError(string errmsg, bool userError)
+        private void onError(string errmsg, string message, bool userError)
         {
-            if (this.TryBeginInvoke(this.onError, errmsg, userError))
+            if (this.TryBeginInvoke(this.onError, errmsg, message, userError))
                 return;
 
-            this.errorBar.ShowError(errmsg);
+            this.errorBar.ShowError(errmsg + " " + message);
         }
 
         private void onApp(bool open)


### PR DESCRIPTION
### 📒 Description
This PR will introduce the minimal changes in order to adopt the customizable error message, which is bundled from Toggl's API responses.

Technically, it will check whether `error_message` key is existed or not:
- If not, it will fallback to current implementation.
- If it presents, we extract it and present it by combining with the current local error by following the format: 
```
{local_error_message} + {error_message}(if presents)
```
For instance, if user tries signing in with incorrect credentials. 

`Invalid email/password. Your account email is expired` will be present. 

`Your account email is expired` is customizable error message from Toggl Server.

By following this way, we **diminish** significantly the rate of change our current codebase, since the error mechanism in Desktop Library is so complicated.

### 🕶️ Types of changes
**New feature**

### 🤯 List of changes
- [x] Extract `error_message` and pass it out
- [x] Fallback to current error logic if `error_message` is not presented. 
- [x] Update `toggl_on_error` interface on all platforms.

### 👫 Relationships
Closes #2431 

### 🔎 Review hints
- Since the backend team doesn't return any `error_message`, so it's hard to test it on production. Thus, we have to fake it by hard-coding it.
- On the other hand, all current error logic should be remained.