### PR TITLE
Use CMake instead of Make to build the Linux package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(TOGGL_VERSION "TogglDesktop version string" "7.0.0")
 option(TOGGL_PRODUCTION_BUILD "Use production servers in the app" OFF)
 option(TOGGL_ALLOW_UPDATE_CHECK "Allow the app to check for updates" OFF)
 option(USE_BUNDLED_LIBRARIES "Prefer bundled libraries to bundled ones" OFF)
+option(INSTALL_HIRES_ICONS "Do not install icons over 512x512" OFF)
 
 # Use PkgConfig to look for packages without native CMake support
 include(FindPkgConfig)

--- a/src/ui/linux/TogglDesktop.sh
+++ b/src/ui/linux/TogglDesktop.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 appname=`basename "$(test -L "$0" && readlink "$0" || echo "$0")" | sed s,\.sh$,,`
-dirname=`dirname "$(test -L "$0" && readlink "$0" || echo "$0")"`
+dirname=`dirname "$(test -L "$0" && readlink "$0" || echo "$0")"/`
+if [ -f "$dirname/bin/TogglDesktop" ]; then
+  dirname="$dirname/bin"
+fi
 tmp="${dirname#?}"
 
 if [ "${dirname%$tmp}" != "/" ]; then
 dirname=$PWD/$dirname
 fi
 
-if [ -f $dirname/QtWebEngineProcess ]; then
+if [ -f "$dirname/QtWebEngineProcess" ]; then
   QTWEBENGINEPROCESS_PATH=$dirname/QtWebEngineProcess
   export QTWEBENGINEPROCESS_PATH
 fi

--- a/src/ui/linux/TogglDesktop/CMakeLists.txt
+++ b/src/ui/linux/TogglDesktop/CMakeLists.txt
@@ -84,7 +84,9 @@ install(FILES icons/64x64/toggldesktop.png DESTINATION share/icons/hicolor/64x64
 install(FILES icons/96x96/toggldesktop.png DESTINATION share/icons/hicolor/96x96/apps)
 install(FILES icons/128x128/toggldesktop.png DESTINATION share/icons/hicolor/128x128/apps)
 install(FILES icons/256x256/toggldesktop.png DESTINATION share/icons/hicolor/256x256/apps)
-install(FILES icons/1024x1024/toggldesktop.png DESTINATION share/icons/hicolor/1024x1024/apps)
+if(INSTALL_HIRES_ICONS)
+    install(FILES icons/1024x1024/toggldesktop.png DESTINATION share/icons/hicolor/1024x1024/apps)
+endif()
 install(FILES dist/toggldesktop.desktop DESTINATION share/applications)
 install(FILES dist/toggldesktop.appdata.xml DESTINATION share/appdata)
 

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -61,9 +61,18 @@ for i in $PLUGINS; do
     CHECK cp -n $(ldd $newpath/$file | grep -e libQt -e ssl | sed 's/.* => \(.*\)[(]0x.*/\1/') lib
 done
 
+for i in $(ls lib/*.so); do
+    for j in $(ldd $i | grep -e libQt | sed 's/.* => \(.*\)[(]0x.*/\1/'); do
+        CHECK cp $j lib
+    done
+done
+
 CHECK patchelf --set-rpath '\$ORIGIN/../lib/' bin/TogglDesktop >> ../patchelf.log
 CHECK patchelf --set-rpath '\$ORIGIN/../lib/' bin/QtWebEngineProcess >> ../patchelf.log
-CHECK patchelf --set-rpath '\$ORIGIN' lib/libTogglDesktopLibrary.so >> ../patchelf.log
+
+for i in $(ls lib/*.so); do
+    CHECK patchelf --set-rpath '\$ORIGIN' $i >> ../patchelf.log
+done
 
 CHECK mkdir -p lib/qt5/translations lib/qt5/resources
 CHECK cp -r "$translationdir/qtwebengine_locales" lib/qt5/translations

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -76,16 +76,15 @@ done
 
 CHECK mkdir -p lib/qt5/translations lib/qt5/resources
 CHECK cp -r "$translationdir/qtwebengine_locales" lib/qt5/translations
-CHECK cp "$datadir/resources/qtwebengine"* lib/qt5/resources
+CHECK cp "$datadir/resources/"* lib/qt5/resources
 
-# probably not necessary in ubuntu
-#CHECK cat <<EOF >bin/qt.conf
-#[Paths]
-#Prefix=..
-#Plugins=lib/qt5/plugins
-#Data=lib/qt5
-#Translations=lib/qt5/translations
-#EOF
+CHECK cat <<EOF >bin/qt.conf
+[Paths]
+Prefix=..
+Plugins=lib/qt5/plugins
+Data=lib/qt5
+Translations=lib/qt5/translations
+EOF
 
 echo "Stripping" >&2
 for i in bin/QtWebEngineProcess $(find . -name \*.so); do 

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -78,6 +78,8 @@ CHECK mkdir -p lib/qt5/translations lib/qt5/resources
 CHECK cp -r "$translationdir/qtwebengine_locales" lib/qt5/translations
 CHECK cp "$datadir/resources/"* lib/qt5/resources
 
+CHECK mv "bin/TogglDesktop.sh" "."
+
 CHECK cat <<EOF >bin/qt.conf
 [Paths]
 Prefix=..

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -8,6 +8,10 @@ fi
 fullbuilddir=$PWD/$builddir
 errorlog=$fullbuilddir/error.log
 
+if [ ! -z "$TOGGL_VERSION" ]; then
+    VERSION_DEFINE="-DTOGGL_VERSION=$TOGGL_VERSION"
+fi
+
 function CHECK() {
     echo "===================================" >> $errorlog
     echo "Running $@" >> $errorlog
@@ -27,7 +31,7 @@ pushd $builddir >/dev/null
 mkdir "package"
 
 echo "Configuring" >&2
-CHECK cmake -DTOGGL_PRODUCTION_BUILD=ON -DTOGGL_ALLOW_UPDATE_CHECK=ON -DUSE_BUNDLED_LIBRARIES=OFF -DCMAKE_INSTALL_PREFIX="$PWD/package" .. > cmake.log
+CHECK cmake -DTOGGL_PRODUCTION_BUILD=ON -DTOGGL_ALLOW_UPDATE_CHECK=ON $VERSION_DEFINE -DUSE_BUNDLED_LIBRARIES=OFF -DCMAKE_INSTALL_PREFIX="$PWD/package" .. > cmake.log
 echo "Building..." >&2
 CHECK make -j8 > build.log
 echo "Installing" >&2

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -71,6 +71,11 @@ Data=lib/qt5
 Translations=lib/qt5/translations
 EOF
 
+echo "Stripping" >&2
+for i in bin/QtWebEngineProcess $(find . -name \*.so); do 
+    strip --strip-unneeded $i; 2>/dev/null >/dev/null
+done
+
 echo "Packaging" >&2
 CHECK tar cvfz ../../toggldesktop_$(uname -m).tar.gz * >/dev/null
 

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -41,8 +41,8 @@ pushd package >/dev/null
 
 echo "Composing the package" >&2
 rm -fr include lib/cmake
-if [ ! -z "$CMAKE_INSTALL_PREFIX" ]; then
-    export LD_LIBRARY_PATH="$CMAKE_INSTALL_PREFIX/../"
+if [ ! -z "$CMAKE_PREFIX_PATH" ]; then
+    export LD_LIBRARY_PATH="$CMAKE_PREFIX_PATH/../"
 fi
 CHECK cp $(ldd bin/TogglDesktop | grep -e libQt -e ssl -e libicu | sed 's/.* => \(.*\)[(]0x.*/\1/') lib
 

--- a/src/ui/linux/package.sh
+++ b/src/ui/linux/package.sh
@@ -52,12 +52,13 @@ for i in $PLUGINS; do
     file=$(basename $i)
     CHECK mkdir -p $newpath
     CHECK cp $plugindir/$i $newpath
-    CHECK patchelf --set-rpath '$ORIGIN/../../..' $newpath/$file >> ../patchelf.log
+    CHECK patchelf --set-rpath '\$ORIGIN/../../../' $newpath/$file >> ../patchelf.log
     CHECK cp -n $(ldd $newpath/$file | grep -e libQt -e ssl | sed 's/.* => \(.*\)[(]0x.*/\1/') lib
 done
 
-CHECK patchelf --set-rpath '$ORIGIN/../lib' bin/TogglDesktop >> ../patchelf.log
-CHECK patchelf --set-rpath '$ORIGIN/../lib' bin/QtWebEngineProcess >> ../patchelf.log
+CHECK patchelf --set-rpath '\$ORIGIN/../lib/' bin/TogglDesktop >> ../patchelf.log
+CHECK patchelf --set-rpath '\$ORIGIN/../lib/' bin/QtWebEngineProcess >> ../patchelf.log
+CHECK patchelf --set-rpath '\$ORIGIN' lib/libTogglDesktopLibrary.so >> ../patchelf.log
 
 CHECK mkdir -p lib/qt5/translations lib/qt5/resources
 CHECK cp -r "$translationdir/qtwebengine_locales" lib/qt5/translations


### PR DESCRIPTION
### 📒 Description
This changes the package.sh script for linux to use CMake instead of plain Makefile to create the Linux tarball.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes

### 👫 Relationships
Depends on #2696

### 🔎 Review hints

