### PR TITLE
Background thread for APIs

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -3779,6 +3779,14 @@ void Context::SetSleep() {
     }
 }
 
+error Context::AsyncOpenReportsInBrowser() {
+    std::thread backgroundThread([&]() {
+        return this->OpenReportsInBrowser();
+    });
+    backgroundThread.detach();
+    return noError;
+}
+
 error Context::OpenReportsInBrowser() {
     // Do not even allow to open reports
     // else they will linger around in the app

--- a/src/context.cc
+++ b/src/context.cc
@@ -56,6 +56,8 @@
 #include "Poco/Util/TimerTask.h"
 #include "Poco/Util/TimerTaskAdapter.h"
 #include <mutex> // NOLINT
+#include <thread>
+#include <future>
 
 namespace toggl {
 
@@ -2169,6 +2171,16 @@ error Context::attemptOfflineLogin(const std::string email,
     updateUI(UIElements::Reset());
 
     return save();
+}
+
+error Context::asyncLogin(const std::string email,
+                          const std::string password) {
+    std::future<error> resultFromDB = std::async([&](std::string email, std::string password) {
+        return this->Login(email, password);
+    }, email, password);
+
+    //error result = resultFromDB.get();
+    return noError;
 }
 
 error Context::Login(

--- a/src/context.cc
+++ b/src/context.cc
@@ -57,7 +57,6 @@
 #include "Poco/Util/TimerTaskAdapter.h"
 #include <mutex> // NOLINT
 #include <thread>
-#include <future>
 
 namespace toggl {
 
@@ -2175,11 +2174,10 @@ error Context::attemptOfflineLogin(const std::string email,
 
 error Context::asyncLogin(const std::string email,
                           const std::string password) {
-    std::future<error> resultFromDB = std::async([&](std::string email, std::string password) {
+    std::thread backgroundThread([&](std::string email, std::string password) {
         return this->Login(email, password);
     }, email, password);
-
-    //error result = resultFromDB.get();
+    backgroundThread.detach();
     return noError;
 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -5481,6 +5481,14 @@ error Context::ToggleEntriesGroup(std::string name) {
     return noError;
 }
 
+error Context::AsyncPullCountries() {
+    std::thread backgroundThread([&]() {
+        return this->PullCountries();
+    });
+    backgroundThread.detach();
+    return noError;
+}
+
 error Context::PullCountries() {
     try {
         TogglClient toggl_client(UI());

--- a/src/context.cc
+++ b/src/context.cc
@@ -2115,6 +2115,10 @@ Database *Context::db() const {
 }
 
 error Context::GoogleLogin(const std::string access_token) {
+    return Login(access_token, "google_access_token");
+}
+
+error Context::AsyncGoogleLogin(const std::string access_token) {
     return AsyncLogin(access_token, "google_access_token");
 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -2115,7 +2115,7 @@ Database *Context::db() const {
 }
 
 error Context::GoogleLogin(const std::string access_token) {
-    return Login(access_token, "google_access_token");
+    return AsyncLogin(access_token, "google_access_token");
 }
 
 error Context::attemptOfflineLogin(const std::string email,
@@ -2172,7 +2172,7 @@ error Context::attemptOfflineLogin(const std::string email,
     return save();
 }
 
-error Context::asyncLogin(const std::string email,
+error Context::AsyncLogin(const std::string email,
                           const std::string password) {
     std::thread backgroundThread([&](std::string email, std::string password) {
         return this->Login(email, password);
@@ -2239,6 +2239,16 @@ error Context::Login(
     } catch(const std::string& ex) {
         return displayError(ex);
     }
+    return noError;
+}
+
+error Context::AsyncSignup(const std::string email,
+                           const std::string password,
+                           const uint64_t country_id) {
+    std::thread backgroundThread([&](std::string email, std::string password, uint64_t country_id) {
+        return this->Signup(email, password, country_id);
+    }, email, password, country_id);
+    backgroundThread.detach();
     return noError;
 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -276,12 +276,17 @@ class Context : public TimelineDatasource {
     void SetMiniTimerW(
         const int64_t w);
 
-    error asyncLogin(const std::string email,
+    error AsyncLogin(const std::string email,
                      const std::string password);
 
     error Login(
         const std::string email,
         const std::string password);
+
+    error AsyncSignup(
+        const std::string email,
+        const std::string password,
+        const uint64_t country_id);
 
     error Signup(
         const std::string email,

--- a/src/context.h
+++ b/src/context.h
@@ -421,6 +421,7 @@ class Context : public TimelineDatasource {
 
     void SetOnline();
 
+    error AsyncOpenReportsInBrowser();
     error OpenReportsInBrowser();
 
     error ToSAccept();

--- a/src/context.h
+++ b/src/context.h
@@ -276,6 +276,8 @@ class Context : public TimelineDatasource {
     void SetMiniTimerW(
         const int64_t w);
 
+    error asyncLogin(const std::string email,
+                     const std::string password);
 
     error Login(
         const std::string email,

--- a/src/context.h
+++ b/src/context.h
@@ -294,6 +294,7 @@ class Context : public TimelineDatasource {
         const uint64_t country_id);
 
     error GoogleLogin(const std::string access_token);
+    error AsyncGoogleLogin(const std::string access_token);
 
     error Logout();
 

--- a/src/context.h
+++ b/src/context.h
@@ -464,6 +464,7 @@ class Context : public TimelineDatasource {
     error ToggleEntriesGroup(
         std::string name);
 
+    error AsyncPullCountries();
     error PullCountries();
 
     void TrackWindowSize(const Poco::Int64 width,

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -146,12 +146,6 @@ error GUI::DisplayError(const error err) {
         return noError;
     }
 
-    // Don't surpress login errors
-    if (std::string::npos == std::string(err).find(kForbiddenError)
-            && err == lastErr) {
-        return err;
-    }
-
     logger().error(err);
 
     if (IsNetworkingError(err)) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1043,7 +1043,7 @@ void toggl_set_online(void *context) {
 }
 
 void toggl_open_in_browser(void *context) {
-    app(context)->OpenReportsInBrowser();
+    app(context)->AsyncOpenReportsInBrowser();
 }
 
 bool_t toggl_accept_tos(void *context) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -850,7 +850,7 @@ void toggl_get_project_colors(
 }
 
 void toggl_get_countries(void *context) {
-    app(context)->PullCountries();
+    app(context)->AsyncPullCountries();
 }
 
 // Close/Open Entries Group

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -403,7 +403,7 @@ bool_t toggl_login(
     void *context,
     const char_t *email,
     const char_t *password) {
-    return toggl::noError == app(context)->asyncLogin(to_string(email),
+    return toggl::noError == app(context)->AsyncLogin(to_string(email),
             to_string(password));
 }
 
@@ -412,7 +412,7 @@ bool_t toggl_signup(
     const char_t *email,
     const char_t *password,
     const uint64_t country_id) {
-    return toggl::noError == app(context)->Signup(to_string(email),
+    return toggl::noError == app(context)->AsyncSignup(to_string(email),
             to_string(password), country_id);
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -403,11 +403,28 @@ bool_t toggl_login(
     void *context,
     const char_t *email,
     const char_t *password) {
+    return toggl::noError == app(context)->Login(to_string(email),
+            to_string(password));
+}
+
+bool_t toggl_login_async(
+    void *context,
+    const char_t *email,
+    const char_t *password) {
     return toggl::noError == app(context)->AsyncLogin(to_string(email),
             to_string(password));
 }
 
 bool_t toggl_signup(
+    void *context,
+    const char_t *email,
+    const char_t *password,
+    const uint64_t country_id) {
+    return toggl::noError == app(context)->Signup(to_string(email),
+            to_string(password), country_id);
+}
+
+bool_t toggl_signup_async(
     void *context,
     const char_t *email,
     const char_t *password,
@@ -420,6 +437,12 @@ bool_t toggl_google_login(
     void *context,
     const char_t *access_token) {
     return toggl::noError == app(context)->GoogleLogin(to_string(access_token));
+}
+
+bool_t toggl_google_login_async(
+    void *context,
+    const char_t *access_token) {
+    return toggl::noError == app(context)->AsyncGoogleLogin(to_string(access_token));
 }
 
 bool_t toggl_logout(

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -873,6 +873,10 @@ void toggl_get_project_colors(
 }
 
 void toggl_get_countries(void *context) {
+    app(context)->PullCountries();
+}
+
+void toggl_get_countries_async(void *context) {
     app(context)->AsyncPullCountries();
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -403,7 +403,7 @@ bool_t toggl_login(
     void *context,
     const char_t *email,
     const char_t *password) {
-    return toggl::noError == app(context)->Login(to_string(email),
+    return toggl::noError == app(context)->asyncLogin(to_string(email),
             to_string(password));
 }
 

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -860,6 +860,8 @@ extern "C" {
     TOGGL_EXPORT void toggl_get_countries(
         void *context);
 
+    TOGGL_EXPORT void toggl_get_countries_async(void *context);
+
     // You must free() the result
     TOGGL_EXPORT char_t *toggl_get_default_project_name(
         void *context);

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -501,13 +501,28 @@ extern "C" {
         const char_t *email,
         const char_t *password);
 
+    TOGGL_EXPORT bool_t toggl_login_async(
+        void *context,
+        const char_t *email,
+        const char_t *password);
+
     TOGGL_EXPORT bool_t toggl_signup(
         void *context,
         const char_t *email,
         const char_t *password,
         const uint64_t country_id);
 
+    TOGGL_EXPORT bool_t toggl_signup_async(
+        void *context,
+        const char_t *email,
+        const char_t *password,
+        const uint64_t country_id);
+
     TOGGL_EXPORT bool_t toggl_google_login(
+        void *context,
+        const char_t *access_token);
+
+    TOGGL_EXPORT bool_t toggl_google_login_async(
         void *context,
         const char_t *access_token);
 

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -17,7 +17,7 @@ oauth2(new OAuth2(this)) {
     connect(TogglApi::instance, SIGNAL(setCountries(QVector<CountryView * >)),  // NOLINT
             this, SLOT(setCountries(QVector<CountryView * >)));  // NOLINT
 
-   connect(TogglApi::instance, SIGNAL(displayError(QString,bool)),  // NOLINT
+    connect(TogglApi::instance, SIGNAL(displayError(QString,bool)),  // NOLINT
             this, SLOT(displayError(QString,bool)));  // NOLINT
 
     oauth2->setScope("profile email");

--- a/src/ui/linux/TogglDesktop/loginwidget.cpp
+++ b/src/ui/linux/TogglDesktop/loginwidget.cpp
@@ -17,6 +17,9 @@ oauth2(new OAuth2(this)) {
     connect(TogglApi::instance, SIGNAL(setCountries(QVector<CountryView * >)),  // NOLINT
             this, SLOT(setCountries(QVector<CountryView * >)));  // NOLINT
 
+   connect(TogglApi::instance, SIGNAL(displayError(QString,bool)),  // NOLINT
+            this, SLOT(displayError(QString,bool)));  // NOLINT
+
     oauth2->setScope("profile email");
     oauth2->setAppName("Toggl Desktop");
     oauth2->setClientID("426090949585.apps.googleusercontent.com");
@@ -33,6 +36,24 @@ oauth2(new OAuth2(this)) {
 
 LoginWidget::~LoginWidget() {
     delete ui;
+}
+
+void LoginWidget::displayError(
+    const QString errmsg,
+    const bool user_error) {
+    Q_UNUSED(errmsg);
+    Q_UNUSED(user_error);
+    enableAllControls(true);
+}
+
+void LoginWidget::enableAllControls(const bool enable) {
+    ui->email->setEnabled(enable);
+    ui->password->setEnabled(enable);
+    ui->login->setEnabled(enable);
+    ui->signup->setEnabled(enable);
+    ui->googleLogin->setEnabled(enable);
+    ui->forgotPassword->setEnabled(enable);
+    ui->viewchangelabel->setEnabled(enable);
 }
 
 void LoginWidget::display() {
@@ -67,12 +88,16 @@ void LoginWidget::displayLogin(
     if (user_id) {
         ui->password->clear();
     }
+
+    // Enable all
+    enableAllControls(true);
 }
 
 void LoginWidget::on_login_clicked() {
     if (!validateFields(false)) {
         return;
     }
+    enableAllControls(false);
     TogglApi::instance->login(ui->email->text(), ui->password->text());
 }
 

--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -52,7 +52,11 @@ class LoginWidget : public QWidget {
 
     void on_countryComboBox_currentIndexChanged(int index);
 
- private:
+    void displayError(
+        const QString errmsg,
+        const bool user_error);
+
+   private:
     Ui::LoginWidget *ui;
 
     OAuth2 *oauth2;
@@ -61,6 +65,8 @@ class LoginWidget : public QWidget {
 
     bool countriesLoaded;
     uint64_t selectedCountryId;
+
+    void enableAllControls(const bool enable);
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_LOGINWIDGET_H_

--- a/src/ui/linux/TogglDesktop/loginwidget.h
+++ b/src/ui/linux/TogglDesktop/loginwidget.h
@@ -56,7 +56,7 @@ class LoginWidget : public QWidget {
         const QString errmsg,
         const bool user_error);
 
-   private:
+ private:
     Ui::LoginWidget *ui;
 
     OAuth2 *oauth2;

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -278,8 +278,8 @@ void MainWindowController::onOnlineStateChanged() {
 void MainWindowController::onShortcutDelete() {
     if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
         if (ui->timeEntryListWidget->focusWidget() &&
-            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
-            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+                ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+                qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
             qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->deleteTimeEntry();
         }
         else {
@@ -303,8 +303,8 @@ void MainWindowController::onShortcutPause() {
         }
         else if (timeEntryList) {
             bool thisItem = !timeEntryList->timer()->currentEntryGuid().isEmpty() &&
-                    timeEntryList->highlightedCell() &&
-                    timeEntryList->timer()->currentEntryGuid() == timeEntryList->highlightedCell()->entryGuid();
+                            timeEntryList->highlightedCell() &&
+                            timeEntryList->timer()->currentEntryGuid() == timeEntryList->highlightedCell()->entryGuid();
             QString selectedGuid = timeEntryList->highlightedCell() ? timeEntryList->highlightedCell()->entryGuid() : QString();
             if (tracking) {
                 onActionStop();
@@ -347,8 +347,8 @@ void MainWindowController::onShortcutConfirm() {
 void MainWindowController::onShortcutGroupOpen() {
     if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
         if (ui->timeEntryListWidget->focusWidget() &&
-            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
-            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+                ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+                qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
             qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->toggleGroup(true);
         }
     }
@@ -357,8 +357,8 @@ void MainWindowController::onShortcutGroupOpen() {
 void MainWindowController::onShortcutGroupClose() {
     if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
         if (ui->timeEntryListWidget->focusWidget() &&
-            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
-            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+                ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+                qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
             qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->toggleGroup(false);
         }
     }

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -440,7 +440,7 @@ void TimeEntryEditorWidget::displayTags(
     }
 
     QSet<QString> actuallyAddedTags;
-    for (auto recentlyAddedTag : recentlyAddedTags) {
+for (auto recentlyAddedTag : recentlyAddedTags) {
         if (!recentlyAddedTag.isEmpty() && !tagList.contains(recentlyAddedTag)) {
             tagList << recentlyAddedTag;
         }
@@ -451,7 +451,7 @@ void TimeEntryEditorWidget::displayTags(
     tagList.sort();
     recentlyAddedTags = recentlyAddedTags - actuallyAddedTags;
 
-    for(auto tag : tagList) {
+for(auto tag : tagList) {
         QListWidgetItem *item = new QListWidgetItem(tag, ui->tags);
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         item->setCheckState(Qt::Unchecked);
@@ -606,7 +606,9 @@ void TimeEntryEditorWidget::on_newTagButton_clicked() {
         }
     }
 
-    QTimer::singleShot(0, [this]() { toggleNewTagMode(false); });
+    QTimer::singleShot(0, [this]() {
+        toggleNewTagMode(false);
+    });
 }
 
 void TimeEntryEditorWidget::on_newTag_returnPressed() {

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -11,7 +11,7 @@ TimeEntryListWidget::TimeEntryListWidget(QStackedWidget *parent) : QWidget(paren
 ui(new Ui::TimeEntryListWidget) {
     ui->setupUi(this);
 
-    connect(ui->list, &QListWidget::currentRowChanged, [=](int row){
+    connect(ui->list, &QListWidget::currentRowChanged, [=](int row) {
         qCritical() << row;
     });
 

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -251,7 +251,7 @@ TogglApi::TogglApi(
     QString cacertPath = executableDir.filePath("cacert.pem");
 #ifdef TOGGL_DATA_DIR
     if (!QFile::exists(cacertPath)) {
-         cacertPath = QString("%1/cacert.pem").arg(TOGGL_DATA_DIR);
+        cacertPath = QString("%1/cacert.pem").arg(TOGGL_DATA_DIR);
     }
 #endif // TOGGL_DATA_DIR
     toggl_set_cacert_path(ctx, cacertPath.toUtf8().constData());

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -313,16 +313,16 @@ bool TogglApi::startEvents() {
 
 void TogglApi::login(const QString email, const QString password) {
     toggl_login_async(ctx,
-                email.toStdString().c_str(),
-                password.toStdString().c_str());
+                      email.toStdString().c_str(),
+                      password.toStdString().c_str());
 }
 
 void TogglApi::signup(const QString email, const QString password,
                       const uint64_t countryID) {
     toggl_signup_async(ctx,
-                 email.toStdString().c_str(),
-                 password.toStdString().c_str(),
-                 countryID);
+                       email.toStdString().c_str(),
+                       password.toStdString().c_str(),
+                       countryID);
 }
 
 void TogglApi::setEnvironment(const QString environment) {

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -312,14 +312,14 @@ bool TogglApi::startEvents() {
 }
 
 void TogglApi::login(const QString email, const QString password) {
-    toggl_login(ctx,
+    toggl_login_async(ctx,
                 email.toStdString().c_str(),
                 password.toStdString().c_str());
 }
 
 void TogglApi::signup(const QString email, const QString password,
                       const uint64_t countryID) {
-    toggl_signup(ctx,
+    toggl_signup_async(ctx,
                  email.toStdString().c_str(),
                  password.toStdString().c_str(),
                  countryID);
@@ -355,7 +355,7 @@ bool TogglApi::setTimeEntryStop(
 }
 
 void TogglApi::googleLogin(const QString accessToken) {
-    toggl_google_login(ctx, accessToken.toStdString().c_str());
+    toggl_google_login_async(ctx, accessToken.toStdString().c_str());
 }
 
 bool TogglApi::setProxySettings(

--- a/src/ui/osx/TogglDesktop/LoginViewController.h
+++ b/src/ui/osx/TogglDesktop/LoginViewController.h
@@ -13,4 +13,5 @@
 #import "NSCustomComboBox.h"
 
 @interface LoginViewController : NSViewController <NSTextFieldDelegate, NSTableViewDataSource, NSComboBoxDataSource, NSComboBoxDelegate>
+- (void)resetLoader;
 @end

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -142,7 +142,7 @@ extern void *ctx;
 	// Show loader and disable text boxs
 	[self showLoaderView:YES];
 
-	if (!toggl_login(ctx, [email UTF8String], [pass UTF8String]))
+	if (!toggl_login_async(ctx, [email UTF8String], [pass UTF8String]))
 	{
 		return;
 	}
@@ -285,7 +285,7 @@ extern void *ctx;
 	// Show loader and disable text boxs
 	[self showLoaderView:YES];
 
-	toggl_google_login(ctx, [auth.accessToken UTF8String]);
+	toggl_google_login_async(ctx, [auth.accessToken UTF8String]);
 }
 
 - (BOOL)validateForm:(BOOL)signup
@@ -357,7 +357,7 @@ extern void *ctx;
 	// Show loader and disable text boxs
 	[self showLoaderView:YES];
 
-	if (!toggl_signup(ctx, [email UTF8String], [pass UTF8String], self.selectedCountryID))
+	if (!toggl_signup_async(ctx, [email UTF8String], [pass UTF8String], self.selectedCountryID))
 	{
 		return;
 	}

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -44,6 +44,7 @@ typedef NS_ENUM (NSUInteger, TabViewType)
 - (IBAction)clickLoginButton:(id)sender;
 - (IBAction)clickSignupButton:(id)sender;
 - (IBAction)countrySelected:(id)sender;
+@property (weak) IBOutlet NSProgressIndicator *loginLoader;
 
 @end
 
@@ -137,6 +138,8 @@ extern void *ctx;
 
 	// for empty State
 	[self setUserSignUp:NO];
+	// Show loader and disable text boxs
+	[self showLoginLoader:YES];
 
 	if (!toggl_login(ctx, [email UTF8String], [pass UTF8String]))
 	{
@@ -418,6 +421,28 @@ extern void *ctx;
 {
 	[[NSUserDefaults standardUserDefaults] setBool:isSignUp forKey:kUserHasBeenSignup];
 	[[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)showLoginLoader:(BOOL)show 
+{
+	self.loginLoader.hidden = !show;
+	if (show)
+	{
+		[self.loginLoader startAnimation:self.loginLoader];
+	}
+	else
+	{
+		[self.loginLoader stopAnimation:self.loginLoader];
+	}
+
+	self.email.enabled = !show;
+	self.password.enabled = !show;
+	self.loginButton.enabled = !show;
+	self.googleLoginTextField.enabled = !show;
+}
+
+- (void)resetLoader {
+	[self showLoginLoader:NO];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -205,7 +205,7 @@ extern void *ctx;
 			if (!self.countriesLoaded)
 			{
 				// Load countries in signup view
-				toggl_get_countries(ctx);
+				toggl_get_countries_async(ctx);
 				self.countriesLoaded = YES;
 			}
 

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -44,8 +44,8 @@ typedef NS_ENUM (NSUInteger, TabViewType)
 - (IBAction)clickLoginButton:(id)sender;
 - (IBAction)clickSignupButton:(id)sender;
 - (IBAction)countrySelected:(id)sender;
-@property (weak) IBOutlet NSProgressIndicator *loginLoader;
-@property (weak) IBOutlet NSProgressIndicator *loaderView;
+@property (weak) IBOutlet NSProgressIndicator *loginLoaderView;
+@property (weak) IBOutlet NSProgressIndicator *signUpLoaderView;
 
 @end
 
@@ -139,7 +139,6 @@ extern void *ctx;
 
 	// for empty State
 	[self setUserSignUp:NO];
-	// Show loader and disable text boxs
 	[self showLoaderView:YES];
 
 	if (!toggl_login_async(ctx, [email UTF8String], [pass UTF8String]))
@@ -429,27 +428,27 @@ extern void *ctx;
 	[[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (void)showLoginLoader:(BOOL)show 
+- (void)showLoaderView:(BOOL)show
 {
-	self.loginLoader.hidden = !show;
-}
+	self.loginLoaderView.hidden = !show;
+	self.signUpLoaderView.hidden = !show;
 
-- (void)showLoaderView:(BOOL)show {
-	self.loaderView.hidden = !show;
 	if (show)
 	{
-		[self.loaderView startAnimation:self.loaderView];
+		[self.loginLoaderView startAnimation:self];
+		[self.signUpLoaderView startAnimation:self];
 	}
 	else
 	{
-		[self.loaderView stopAnimation:self.loaderView];
+		[self.loginLoaderView stopAnimation:self];
+		[self.signUpLoaderView stopAnimation:self];
 	}
 
 	self.email.enabled = !show;
 	self.password.enabled = !show;
 	self.loginButton.enabled = !show;
-	self.SignupButton.enabled = !show;
-	self.googleLoginTextField.enabled = !show;
+	self.signupButton.enabled = !show;
+	self.loginGooglBtn.enabled = !show;
 	self.loginLink.enabled = !show;
 	self.signUpLink.enabled = !show;
 }

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -45,6 +45,7 @@ typedef NS_ENUM (NSUInteger, TabViewType)
 - (IBAction)clickSignupButton:(id)sender;
 - (IBAction)countrySelected:(id)sender;
 @property (weak) IBOutlet NSProgressIndicator *loginLoader;
+@property (weak) IBOutlet NSProgressIndicator *loaderView;
 
 @end
 
@@ -139,7 +140,7 @@ extern void *ctx;
 	// for empty State
 	[self setUserSignUp:NO];
 	// Show loader and disable text boxs
-	[self showLoginLoader:YES];
+	[self showLoaderView:YES];
 
 	if (!toggl_login(ctx, [email UTF8String], [pass UTF8String]))
 	{
@@ -350,6 +351,8 @@ extern void *ctx;
 
 	// for empty State
 	[self setUserSignUp:YES];
+	// Show loader and disable text boxs
+	[self showLoaderView:YES];
 
 	if (!toggl_signup(ctx, [email UTF8String], [pass UTF8String], self.selectedCountryID))
 	{
@@ -426,23 +429,30 @@ extern void *ctx;
 - (void)showLoginLoader:(BOOL)show 
 {
 	self.loginLoader.hidden = !show;
+}
+
+- (void)showLoaderView:(BOOL)show {
+	self.loaderView.hidden = !show;
 	if (show)
 	{
-		[self.loginLoader startAnimation:self.loginLoader];
+		[self.loaderView startAnimation:self.loaderView];
 	}
 	else
 	{
-		[self.loginLoader stopAnimation:self.loginLoader];
+		[self.loaderView stopAnimation:self.loaderView];
 	}
 
 	self.email.enabled = !show;
 	self.password.enabled = !show;
 	self.loginButton.enabled = !show;
+	self.SignupButton.enabled = !show;
 	self.googleLoginTextField.enabled = !show;
+	self.loginLink.enabled = !show;
+	self.signUpLink.enabled = !show;
 }
 
 - (void)resetLoader {
-	[self showLoginLoader:NO];
+	[self showLoaderView:NO];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -282,6 +282,9 @@ extern void *ctx;
 		return;
 	}
 
+	// Show loader and disable text boxs
+	[self showLoaderView:YES];
+
 	toggl_google_login(ctx, [auth.accessToken UTF8String]);
 }
 

--- a/src/ui/osx/TogglDesktop/LoginViewController.xib
+++ b/src/ui/osx/TogglDesktop/LoginViewController.xib
@@ -16,9 +16,11 @@
                 <outlet property="loginButton" destination="IjV-dM-dEc" id="tZ5-yj-hKl"/>
                 <outlet property="loginGooglBtn" destination="tJn-oc-LUz" id="B9S-uj-Ygi"/>
                 <outlet property="loginLink" destination="8Ya-xT-rzU" id="36m-NE-g6X"/>
+                <outlet property="loginLoaderView" destination="BLv-g2-Q0z" id="WB5-8X-iJh"/>
                 <outlet property="password" destination="es4-S9-8Od" id="mI1-u7-fNs"/>
                 <outlet property="privacyLink" destination="IVx-73-aIM" id="bg4-YH-NLO"/>
                 <outlet property="signUpLink" destination="vHA-Cd-ciE" id="IIF-Rc-Dys"/>
+                <outlet property="signUpLoaderView" destination="RjK-JO-aC4" id="Ags-gt-SEY"/>
                 <outlet property="signupButton" destination="ecN-Qd-Rfu" id="kAt-tp-tbN"/>
                 <outlet property="tabView" destination="Zob-zi-6R9" id="9Bv-SQ-s56"/>
                 <outlet property="tosCheckbox" destination="p8r-V5-a0Z" id="Vwo-iN-cni"/>
@@ -39,11 +41,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="THc-hA-qiD">
-                                <rect key="frame" x="89" y="285" width="50" height="16"/>
+                                <rect key="frame" x="50" y="173" width="128" height="128"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="toggl-logo" id="RqX-fO-r2O"/>
                             </imageView>
                             <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Z5-Nq-p4o">
-                                <rect key="frame" x="20" y="195" width="188" height="70"/>
+                                <rect key="frame" x="20" y="83" width="188" height="70"/>
                                 <subviews>
                                     <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KGi-ca-Yer">
                                         <rect key="frame" x="0.0" y="40" width="188" height="30"/>
@@ -84,19 +86,19 @@
                                 </customSpacing>
                             </stackView>
                             <tabView drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Zob-zi-6R9">
-                                <rect key="frame" x="0.0" y="0.0" width="228" height="195"/>
+                                <rect key="frame" x="0.0" y="0.0" width="228" height="83"/>
                                 <font key="font" metaFont="system"/>
                                 <tabViewItems>
                                     <tabViewItem label="Login" identifier="" id="hPv-Je-QMk">
                                         <view key="view" id="Rv2-bS-MTQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="228" height="195"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="228" height="83"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="ZIl-yh-uQ0">
-                                                    <rect key="frame" x="0.0" y="0.0" width="228" height="195"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="228" height="83"/>
                                                     <subviews>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dzR-Wz-TvW" customClass="NSTextFieldClickablePointer">
-                                                            <rect key="frame" x="18" y="169" width="108" height="16"/>
+                                                            <rect key="frame" x="18" y="57" width="108" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Forgot password?" id="X3a-gR-Caa">
                                                                 <font key="font" metaFont="systemMedium" size="12"/>
                                                                 <color key="textColor" name="login-text-color"/>
@@ -104,7 +106,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IjV-dM-dEc" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
-                                                            <rect key="frame" x="20" y="119" width="188" height="30"/>
+                                                            <rect key="frame" x="20" y="7" width="188" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="30" id="6Rk-yX-EJw"/>
                                                             </constraints>
@@ -129,7 +131,7 @@
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tJn-oc-LUz">
-                                                            <rect key="frame" x="18" y="76" width="192" height="35"/>
+                                                            <rect key="frame" x="18" y="-36" width="192" height="35"/>
                                                             <buttonCell key="cell" type="bevel" title="Log in with Google" bezelStyle="regularSquare" image="google-logo" imagePosition="left" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hE5-JZ-Nlh">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -155,9 +157,13 @@
                                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
+                                                        <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="BLv-g2-Q0z">
+                                                            <rect key="frame" x="144" y="14" width="16" height="16"/>
+                                                        </progressIndicator>
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstItem="IjV-dM-dEc" firstAttribute="top" secondItem="dzR-Wz-TvW" secondAttribute="bottom" constant="20" id="1hE-fs-K3O"/>
+                                                        <constraint firstItem="BLv-g2-Q0z" firstAttribute="centerY" secondItem="IjV-dM-dEc" secondAttribute="centerY" id="3Lv-Gl-IuK"/>
                                                         <constraint firstAttribute="trailing" secondItem="IjV-dM-dEc" secondAttribute="trailing" constant="20" id="4AX-AQ-hyZ"/>
                                                         <constraint firstItem="tJn-oc-LUz" firstAttribute="top" secondItem="IjV-dM-dEc" secondAttribute="bottom" constant="10" id="B3l-SH-NZj"/>
                                                         <constraint firstItem="Nf5-yf-qTk" firstAttribute="centerX" secondItem="ZIl-yh-uQ0" secondAttribute="centerX" id="Fp0-nB-fJ8"/>
@@ -169,6 +175,7 @@
                                                         <constraint firstAttribute="trailing" secondItem="tJn-oc-LUz" secondAttribute="trailing" constant="20" id="YAY-8A-PBU"/>
                                                         <constraint firstItem="vHA-Cd-ciE" firstAttribute="centerX" secondItem="ZIl-yh-uQ0" secondAttribute="centerX" id="gxD-tt-Wnn"/>
                                                         <constraint firstItem="tJn-oc-LUz" firstAttribute="leading" secondItem="ZIl-yh-uQ0" secondAttribute="leading" constant="20" id="nmv-A4-hub"/>
+                                                        <constraint firstAttribute="trailing" secondItem="BLv-g2-Q0z" secondAttribute="trailing" constant="68" id="rKO-hP-DYt"/>
                                                         <constraint firstItem="tJn-oc-LUz" firstAttribute="width" secondItem="IjV-dM-dEc" secondAttribute="width" id="x3D-el-UuG"/>
                                                         <constraint firstItem="IjV-dM-dEc" firstAttribute="leading" secondItem="ZIl-yh-uQ0" secondAttribute="leading" constant="20" id="zM6-Kr-3Ol"/>
                                                     </constraints>
@@ -184,14 +191,14 @@
                                     </tabViewItem>
                                     <tabViewItem label="Signup" identifier="" id="KMJ-Rd-V8x">
                                         <view key="view" id="nfe-ZO-kib">
-                                            <rect key="frame" x="0.0" y="0.0" width="228" height="195"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="228" height="83"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="41Y-oV-0ee">
-                                                    <rect key="frame" x="0.0" y="0.0" width="228" height="195"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="228" height="83"/>
                                                     <subviews>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="p8r-V5-a0Z" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
-                                                            <rect key="frame" x="18" y="139" width="76" height="18"/>
+                                                            <rect key="frame" x="18" y="27" width="76" height="18"/>
                                                             <buttonCell key="cell" type="check" title="I agree to" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="qm8-nf-Dce">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="cellTitle"/>
@@ -206,7 +213,7 @@
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ecN-Qd-Rfu" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
-                                                            <rect key="frame" x="20" y="79" width="188" height="30"/>
+                                                            <rect key="frame" x="20" y="-33" width="188" height="30"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="30" id="6y5-l6-bCL"/>
                                                             </constraints>
@@ -230,6 +237,9 @@
                                                                 <outlet property="nextKeyView" destination="KGi-ca-Yer" id="oXo-Ww-F4C"/>
                                                             </connections>
                                                         </button>
+                                                        <progressIndicator hidden="YES" wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="RjK-JO-aC4">
+                                                            <rect key="frame" x="144" y="-26" width="16" height="16"/>
+                                                        </progressIndicator>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Ya-xT-rzU" customClass="NSTextFieldClickablePointer">
                                                             <rect key="frame" x="71" y="16" width="86" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Back to Log in" id="WQs-7g-ifL">
@@ -239,7 +249,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-2k-VFz">
-                                                            <rect key="frame" x="36" y="123" width="25" height="16"/>
+                                                            <rect key="frame" x="36" y="11" width="25" height="16"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="and" id="6le-qK-Qps">
                                                                 <font key="font" metaFont="cellTitle"/>
                                                                 <color key="textColor" name="login-text-color"/>
@@ -247,7 +257,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Zx-Jg-kcg" customClass="NSCustomComboBox">
-                                                            <rect key="frame" x="20" y="161" width="191" height="26"/>
+                                                            <rect key="frame" x="20" y="49" width="191" height="26"/>
                                                             <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" focusRingType="none" placeholderString="Select country" drawsBackground="YES" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="XOG-e3-OcV">
                                                                 <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -259,7 +269,7 @@
                                                             </connections>
                                                         </comboBox>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fZp-Ag-MGC" customClass="NSTextFieldClickablePointer">
-                                                            <rect key="frame" x="92" y="140" width="109" height="17"/>
+                                                            <rect key="frame" x="92" y="28" width="109" height="17"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Terms of Service" id="yMx-7I-dta">
                                                                 <font key="font" metaFont="systemMedium" size="13"/>
                                                                 <color key="textColor" name="login-text-color"/>
@@ -267,7 +277,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IVx-73-aIM" customClass="NSTextFieldClickablePointer">
-                                                            <rect key="frame" x="59" y="123" width="94" height="17"/>
+                                                            <rect key="frame" x="59" y="11" width="94" height="17"/>
                                                             <textFieldCell key="cell" lineBreakMode="clipping" title="Privacy Policy." id="grP-VP-uk2">
                                                                 <font key="font" metaFont="systemMedium" size="13"/>
                                                                 <color key="textColor" name="login-text-color"/>
@@ -277,6 +287,7 @@
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstItem="IVx-73-aIM" firstAttribute="leading" secondItem="8ub-2k-VFz" secondAttribute="trailing" constant="2" id="088-9f-PLg"/>
+                                                        <constraint firstAttribute="trailing" secondItem="RjK-JO-aC4" secondAttribute="trailing" constant="68" id="11D-Jo-4Pc"/>
                                                         <constraint firstItem="8ub-2k-VFz" firstAttribute="top" secondItem="p8r-V5-a0Z" secondAttribute="bottom" constant="2" id="68W-Ux-rrt"/>
                                                         <constraint firstItem="p8r-V5-a0Z" firstAttribute="top" secondItem="4Zx-Jg-kcg" secondAttribute="bottom" constant="10" id="AKK-5g-2ce"/>
                                                         <constraint firstAttribute="trailing" secondItem="ecN-Qd-Rfu" secondAttribute="trailing" constant="20" id="Cqg-hs-7VU"/>
@@ -289,6 +300,7 @@
                                                         <constraint firstItem="8ub-2k-VFz" firstAttribute="leading" secondItem="p8r-V5-a0Z" secondAttribute="leading" constant="18" id="Q26-wy-gT1"/>
                                                         <constraint firstItem="4Zx-Jg-kcg" firstAttribute="leading" secondItem="41Y-oV-0ee" secondAttribute="leading" constant="20" id="heV-uz-hSM"/>
                                                         <constraint firstItem="fZp-Ag-MGC" firstAttribute="leading" secondItem="p8r-V5-a0Z" secondAttribute="trailing" constant="2" id="mnc-hR-2WM"/>
+                                                        <constraint firstItem="RjK-JO-aC4" firstAttribute="centerY" secondItem="ecN-Qd-Rfu" secondAttribute="centerY" id="q4M-4A-PVp"/>
                                                         <constraint firstItem="ecN-Qd-Rfu" firstAttribute="leading" secondItem="41Y-oV-0ee" secondAttribute="leading" constant="20" id="s3d-Ap-ckm"/>
                                                         <constraint firstAttribute="trailing" secondItem="4Zx-Jg-kcg" secondAttribute="trailing" constant="20" id="vne-ET-7Oc"/>
                                                         <constraint firstItem="fZp-Ag-MGC" firstAttribute="firstBaseline" secondItem="p8r-V5-a0Z" secondAttribute="firstBaseline" id="xOD-Ri-XS1"/>

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -143,6 +143,10 @@ extern void *ctx;
 			[self closeError];
 
 			self.loginViewController.view.hidden = YES;
+			// Reset login
+			[self.loginViewController resetLoader];
+
+			[self addErrorBoxConstraint];
 			[self.contentView addSubview:self.timeEntryListViewController.view];
 			[self.timeEntryListViewController.view setFrame:self.contentView.bounds];
 

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -186,6 +186,13 @@ extern void *ctx;
 
 	NSString *errorMessage = msg == nil ? @"Error" : msg;
 	[[SystemMessage shared] presentError:errorMessage subTitle:nil];
+
+	// Reset loader if there is error
+ 	// Have to check if login is present
+	if (self.loginViewController.view.superview != nil)
+	{
+		[self.loginViewController resetLoader];
+	}
 }
 
 - (void)startDisplayOnlineState:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -141,12 +141,9 @@ extern void *ctx;
 		{
 			// Close error when loging in
 			[self closeError];
-
-			self.loginViewController.view.hidden = YES;
-			// Reset login
 			[self.loginViewController resetLoader];
 
-			[self addErrorBoxConstraint];
+			self.loginViewController.view.hidden = YES;
 			[self.contentView addSubview:self.timeEntryListViewController.view];
 			[self.timeEntryListViewController.view setFrame:self.contentView.bounds];
 
@@ -192,7 +189,7 @@ extern void *ctx;
 	[[SystemMessage shared] presentError:errorMessage subTitle:nil];
 
 	// Reset loader if there is error
- 	// Have to check if login is present
+	// Have to check if login is present
 	if (self.loginViewController.view.superview != nil)
 	{
 		[self.loginViewController resetLoader];

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -324,7 +324,7 @@ extern void *ctx;
 		}
 		else
 		{
-            // It's for new Time Entry from Manual Timer
+			// It's for new Time Entry from Manual Timer
 			NSCollectionViewItem *firstItem = [self.collectionView itemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
 			if ([firstItem isKindOfClass:[TimeEntryCell class]])
 			{

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1571,7 +1571,11 @@ void on_pomodoro_break(const char *title, const char *informative_text)
 
 void on_url(const char *url)
 {
-	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:[NSString stringWithUTF8String:url]]];
+    // Capture url
+	NSString *reportURL = [NSString stringWithUTF8String:url];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:reportURL]];
+	});
 }
 
 void on_time_entry_list(const bool_t open,

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1571,8 +1571,9 @@ void on_pomodoro_break(const char *title, const char *informative_text)
 
 void on_url(const char *url)
 {
-    // Capture url
+	// Capture url
 	NSString *reportURL = [NSString stringWithUTF8String:url];
+
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:reportURL]];
 	});


### PR DESCRIPTION
### 📒 Description
There is currently issue that TogglDesktop is always frozen during login and sign-up in unreliable connection.
 
This PR will introduce the fix by executing those APIs in background thread.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Introduce async version for `Login`, `Sign-up`, `Report` and `GoggleLogin`, `PullCountry` in library.
- [x] Introduce Loader during fetching data on background in LoginViewController (mac).
- [x] Same functionality for Windows.
- [x] Same functionality for Linux.

### 👫 Relationships
Close #2765 

### 🔎 Review hints
1. Download [Network Conditioner](https://developer.apple.com/download/more/?q=Additional%20Tools)
2. Set **3G** profile
3. Open app and do actions, which execute the following APIs

- Login
- List Country in Sign up menu
- Sign up
- Login with Goggle
- Report (/api/v8/desktop_login_tokens)

=> The logic of Login, Signup, Login with Google and Report are remained => 💯 
=> The app doesn't frozen anymore (The loader is shown and hide appropriately) => 💯 