### PR TITLE
Update new color scheme for title in Login/Signup

### DIFF
--- a/src/ui/osx/TogglDesktop/LoginViewController.xib
+++ b/src/ui/osx/TogglDesktop/LoginViewController.xib
@@ -348,7 +348,7 @@
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="login-text-color">
-            <color red="0.4823529411764706" green="0.4823529411764706" blue="0.4823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Media.xcassets/login-text-color.colorset/Contents.json
+++ b/src/ui/osx/TogglDesktop/Media.xcassets/login-text-color.colorset/Contents.json
@@ -9,28 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x7B",
+          "red" : "0x55",
           "alpha" : "1.000",
-          "blue" : "0x7B",
-          "green" : "0x7B"
-        }
-      }
-    },
-    {
-      "idiom" : "mac",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "light"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0x7B",
-          "alpha" : "1.000",
-          "blue" : "0x7B",
-          "green" : "0x7B"
+          "blue" : "0x55",
+          "green" : "0x55"
         }
       }
     },
@@ -46,7 +28,7 @@
         "color-space" : "srgb",
         "components" : {
           "red" : "1.000",
-          "alpha" : "0.850",
+          "alpha" : "0.600",
           "blue" : "1.000",
           "green" : "1.000"
         }


### PR DESCRIPTION
### 📒 Description
According to Silvia, our talent designer, we have to change the Text color due to contrast issue. 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Update the text color to new color #555555 

### 👫 Relationships
Closes #2791 

### 🔎 Review hints
- The text color of buttons in Login / Signup change to #555555 (light) and #ffffff 0.6 (dark)
