### PR TITLE
Make the General tab the default in Preferences (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <attribute name="title">


### PR DESCRIPTION
### 📒 Description
While reworking the settings view I accidentally set the default page index to 2, this makes it 0 (General tab)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Nothing to review, really.
