### PR TITLE
Parse error message if response is JSON (lib), #2431

### DIFF
--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -490,6 +490,16 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
         }
 
         resp.err = statusCodeToError(resp.status_code);
+
+        // Parse human-readable error message from response if Content Type JSON
+        if (resp.err != noError &&
+                response.getContentType().find(kContentTypeApplicationJSON) != std::string::npos) {
+            Json::Value root;
+            Json::Reader reader;
+            if (reader.parse(resp.body, root)) {
+                resp.body = root["error_message"].asString();
+            }
+        }
     } catch(const Poco::Exception& exc) {
         resp.err = exc.displayText();
         return resp;


### PR DESCRIPTION
### 📒 Description
Adds support for getting error message from JSON response

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Detect if response is JSON and extract the error message

### 👫 Relationships
Closes #2431
Closes #2770 


