### PR TITLE
Preprocessor macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ src/ui/windows/TogglDesktop/TogglDesktop/bin
 src/ui/windows/TogglDesktop/Release
 src/lib/windows/TogglDesktopDLL/Release
 src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin
+src/lib/windows/TogglDesktopDLL/Debug
+src/lib/windows/TogglDesktopDLL/Release_VS
+src/lib/windows/TogglDesktopDLL/Release
 
 *.dSYM
 

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ obj
 src/ui/windows/TogglDesktop/TogglDesktop/bin
 src/ui/windows/TogglDesktop/Release
 src/lib/windows/TogglDesktopDLL/Release
+src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin
 
 *.dSYM
 

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,19 @@ ifeq ($(uname), Darwin)
 xcodebuild_command=xcodebuild \
 				  -scheme TogglDesktop \
 				  -project src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj  \
+				  -configuration Debug
+xcodebuild_command_release=xcodebuild \
+				  -scheme TogglDesktop \
+				  -project src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj  \
 				  -configuration Release
 executable=$(shell $(xcodebuild_command) \
 			 -showBuildSettings \
  			| grep -w 'BUILT_PRODUCTS_DIR' \
  			| cut -d'=' -f 2)/TogglDesktop.app/Contents/MacOS/TogglDesktop
+executable_release=$(shell $(xcodebuild_command_release) \
+			 -showBuildSettings \
+			| grep -w 'BUILT_PRODUCTS_DIR' \
+			| cut -d'=' -f 2)/TogglDesktop.app/Contents/MacOS/TogglDesktop
 pocolib=$(pocodir)/lib/Darwin/x86_64/
 osname=mac
 endif	
@@ -236,9 +244,13 @@ fmt: fmt_lib fmt_ui
 
 app: lib ui
 
+app_release: lib_release ui_release
+
 ifeq ($(osname), mac)
 lib:
-	xcodebuild -project src/lib/osx/TogglDesktopLibrary.xcodeproj
+	xcodebuild -project src/lib/osx/TogglDesktopLibrary.xcodeproj -configuration Debug
+lib_release:
+	xcodebuild -project src/lib/osx/TogglDesktopLibrary.xcodeproj -configuration Release build
 endif
 
 ifeq ($(osname), linux)
@@ -265,6 +277,8 @@ endif
 ifeq ($(osname), mac)
 ui:
 	$(xcodebuild_command)
+ui_release:
+	$(xcodebuild_command_release)
 endif
 
 ifeq ($(osname), linux)
@@ -288,6 +302,9 @@ bugsnag-qt: clean-bugsnag-qt
 
 run: app
 	$(executable)
+
+run_release: app_release
+	$(executable_release)
 
 clean_deps:
 	cd $(pocodir) && (make clean || true)

--- a/src/context.cc
+++ b/src/context.cc
@@ -72,11 +72,11 @@ Context::Context(const std::string app_name, const std::string app_version)
 , next_update_timeline_settings_at_(0)
 , next_wake_at_(0)
 , time_entry_editor_guid_("")
-, environment_("production")
+, environment_(APP_ENVIRONMENT)
 , idle_(&ui_)
 , last_sync_started_(0)
 , sync_interval_seconds_(0)
-, update_check_disabled_(false)
+, update_check_disabled_(UPDATE_CHECK_DISABLED)
 , trigger_sync_(false)
 , trigger_push_(false)
 , quit_(false)
@@ -92,8 +92,10 @@ Context::Context(const std::string app_name, const std::string app_version)
         Poco::Net::HTTPSStreamFactory::registerFactory();
     }
 
+#ifndef TOGGL_PRODUCTION_BUILD
     urls::SetUseStagingAsBackend(
         app_version.find("7.0.0") != std::string::npos);
+#endif
 
     Poco::ErrorHandler::set(&error_handler_);
     Poco::Net::initializeSSL();

--- a/src/context.h
+++ b/src/context.h
@@ -27,6 +27,18 @@
 #include "Poco/Timestamp.h"
 #include "Poco/Util/Timer.h"
 
+#ifdef TOGGL_ALLOW_UPDATE_CHECK
+# define UPDATE_CHECK_DISABLED false
+#else
+# define UPDATE_CHECK_DISABLED true
+#endif
+
+#if defined(TOGGL_PRODUCTION_BUILD) && !defined(APP_ENVIRONMENT)
+# define APP_ENVIRONMENT "production"
+#elif !defined(APP_ENVIRONMENT)
+# define APP_ENVIRONMENT "development"
+#endif
+
 namespace toggl {
 
 class Database;

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -699,6 +699,10 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = B227VTMZ94;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"TOGGL_ALLOW_UPDATE_CHECK=1",
+					"TOGGL_PRODUCTION_BUILD=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -5,6 +5,10 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_VS|Win32">
+      <Configuration>Release_VS</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -29,6 +33,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -38,11 +49,19 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
@@ -64,6 +83,32 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>TOGGL_PRODUCTION_BUILD;TOGGL_ALLOW_UPDATE_CHECK;WIN32;NDEBUG;_WINDOWS;_USRDLL;TOGGLDESKTOPDLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\..\third_party\poco\openssl;$(ProjectDir)..\..\..\..\third_party\openssl\include;$(ProjectDir)..\..\..\..\third_party\jsoncpp\dist;$(ProjectDir)..\..\..\..\third_party\poco\Foundation\include;$(ProjectDir)..\..\..\..\third_party\poco\Util\include;$(ProjectDir)..\..\..\..\third_party\poco\Crypto\include;$(ProjectDir)..\..\..\..\third_party\poco\Net\include;$(ProjectDir)..\..\..\..\third_party\poco\NetSSL_OpenSSL\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\include;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\src;$(ProjectDir)..\..\..\..\third_party\lua\src;$(ProjectDir)..\..\..\..\third_party\luafar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnablePREfast>false</EnablePREfast>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\src\ui\windows\TogglDesktop\Release\;$(ProjectDir)..\..\..\..\third_party\poco\Data\SQLite\obj\SQLite\release_shared;$(ProjectDir)..\..\..\..\third_party\openssl\out32dll;$(ProjectDir)..\..\..\..\third_party\poco\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>PocoFoundation.lib;PocoUtil.lib;PocoXML.lib;PocoNet.lib;PocoCrypto.lib;PocoNetSSL.lib;PocoData.lib;PocoDataSQLite.lib;sqlite3;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -239,12 +284,16 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
       </PrecompiledHeader>
       <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</CompileAsManaged>
+      <CompileAsManaged Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'">false</CompileAsManaged>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'">
       </PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release_VS|Win32'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
+++ b/src/lib/windows/TogglDesktopDLL/TogglDesktopDLL.vcxproj
@@ -65,6 +65,7 @@
     <LinkIncremental>false</LinkIncremental>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
+    <OutDir>$(SolutionDir)\TogglDesktop\bin\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/src/ui/osx/TogglDesktop/AboutWindowController.m
+++ b/src/ui/osx/TogglDesktop/AboutWindowController.m
@@ -55,9 +55,13 @@ extern void *ctx;
 
 - (BOOL)updateCheckEnabled
 {
-	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
+#ifdef DEBUG
+	return NO;
 
-	return [infoDict[@"KopsikCheckForUpdates"] boolValue];
+#else
+	return YES;
+
+#endif
 }
 
 - (void)checkForUpdates

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1212,11 +1212,14 @@ const NSString *appName = @"osx_native_app";
 {
 	self = [super init];
 
-	#ifdef DEBUG
+	BOOL logUIToFile;
+#ifdef DEBUG
 	self.environment = @"development";
-	#else
+	logUIToFile = NO;
+#else
 	self.environment = @"production";
-	#endif
+	logUIToFile = YES;
+#endif
 
 	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
 	self.version = infoDict[@"CFBundleShortVersionString"];
@@ -1299,8 +1302,7 @@ const NSString *appName = @"osx_native_app";
 		return nil;
 	}
 
-	id logToFile = infoDict[@"KopsikLogUserInterfaceToFile"];
-	if ([logToFile boolValue])
+	if (logUIToFile)
 	{
 		NSLog(@"Redirecting UI log to file");
 		NSString *logPath =

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -367,10 +367,13 @@ BOOL onTop = NO;
 	{
 		return NO;
 	}
+#ifdef DEBUG
+	return NO;
 
-	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
+#else
+	return YES;
 
-	return [infoDict[@"KopsikCheckForUpdates"] boolValue];
+#endif
 }
 
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1209,8 +1209,13 @@ const NSString *appName = @"osx_native_app";
 {
 	self = [super init];
 
+	#ifdef DEBUG
+	self.environment = @"development";
+	#else
+	self.environment = @"production";
+	#endif
+
 	NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
-	self.environment = infoDict[@"KopsikEnvironment"];
 	self.version = infoDict[@"CFBundleShortVersionString"];
 
 	// Disallow duplicate instances in production

--- a/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
@@ -44,8 +44,6 @@
 	<string>1010</string>
 	<key>DTXcodeBuild</key>
 	<string>10B61</string>
-	<key>KopsikLogUserInterfaceToFile</key>
-	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
@@ -46,8 +46,6 @@
 	<string>10B61</string>
 	<key>KopsikCheckForUpdates</key>
 	<false/>
-	<key>KopsikEnvironment</key>
-	<string>development</string>
 	<key>KopsikLogUserInterfaceToFile</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
+++ b/src/ui/osx/TogglDesktop/test2/TogglDesktop-Info.plist
@@ -44,8 +44,6 @@
 	<string>1010</string>
 	<key>DTXcodeBuild</key>
 	<string>10B61</string>
-	<key>KopsikCheckForUpdates</key>
-	<false/>
 	<key>KopsikLogUserInterfaceToFile</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.sln
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.sln
@@ -206,8 +206,8 @@ Global
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.release_static_mt|Win32.Build.0 = Release|Win32
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Any CPU.ActiveCfg = Release|Win32
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Any CPU.Build.0 = Release|Win32
-		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Mixed Platforms.ActiveCfg = Release|Win32
-		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Mixed Platforms.Build.0 = Release|Win32
+		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Mixed Platforms.ActiveCfg = Release_VS|Win32
+		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Mixed Platforms.Build.0 = Release_VS|Win32
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Win32.ActiveCfg = Release|Win32
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release_VS|Win32.Build.0 = Release|Win32
 		{3ACE25DD-04CE-47D8-9658-3D0546521DA2}.Release|Any CPU.ActiveCfg = Release|Win32

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -66,10 +66,10 @@ static class Program
 
             bugsnag = new Bugsnag.Clients.BaseClient("aa13053a88d5133b688db0f25ec103b7");
 
-#if INVS
-            bugsnag.Config.ReleaseStage = "development";
-#else
+#if TOGGL_PRODUCTION_BUILD
             bugsnag.Config.ReleaseStage = "production";
+#else
+            bugsnag.Config.ReleaseStage = "development";
 #endif
 
             Toggl.OnLogin += delegate(bool open, UInt64 user_id)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -32,12 +32,12 @@ public static partial class Toggl
     public static string ScriptPath;
     public static string DatabasePath;
     public static string LogPath;
-#if INVS
-    public static string Env = "development";
-#else
-    public static string Env = "production";
-#endif
 
+#if TOGGL_PRODUCTION_BUILD
+    public static string Env = "production";
+#else
+    public static string Env = "development";
+#endif
 
     #endregion
 
@@ -1082,7 +1082,7 @@ public static partial class Toggl
 
         updatePath = Path.Combine(path, "updates");
 
-#if !INVS
+#if TOGGL_ALLOW_UPDATE_CHECK
         installPendingUpdates();
 #endif
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -45,7 +45,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;TOGGL_PRODUCTION_BUILD;TOGGL_ALLOW_UPDATE_CHECK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release_VS|AnyCPU'">
     <OutputPath>bin\Release_VS\</OutputPath>
-    <DefineConstants>TRACE;INVS</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
### 📒 Description
Updated the build logic to use preprocessor defines instead of just values that are changed by build script

### 🕶️ Types of changes
 **Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- Added preprocessor defines logic to library
- Updated Mac code to use the preprocessor defines (added defines to build configurations)
- Updated Windows code to use the preprocessor defines (added defines to build configurations)

### 👫 Relationships
Closes #2696
Connected:https://github.com/toggl/toggldesktop-branding/pull/22

### 🔎 Review hints
Mac:
- Run as debug (just run from Xcode) for `development` release
- Run as `make app_release` to build `production` release

Windows:
- build with conf `Release`, builds for production
- build with conf `Release_VS`, builds for development


