### PR TITLE
Improve and flatten menu bar handling (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -38,15 +38,6 @@ MainWindowController::MainWindowController(
   togglApi(new TogglApi(nullptr, logPathOverride, dbPathOverride)),
   tracking(false),
   loggedIn(false),
-  actionEmail(nullptr),
-  actionNew(nullptr),
-  actionContinue(nullptr),
-  actionStop(nullptr),
-  actionSync(nullptr),
-  actionLogout(nullptr),
-  actionClear_Cache(nullptr),
-  actionSend_Feedback(nullptr),
-  actionReports(nullptr),
   preferencesDialog(new PreferencesDialog(this)),
   aboutDialog(new AboutDialog(this)),
   feedbackDialog(new FeedbackDialog(this)),
@@ -237,15 +228,15 @@ void MainWindowController::displayStoppedTimerState() {
 }
 
 void MainWindowController::enableMenuActions() {
-    actionNew->setEnabled(loggedIn);
-    actionContinue->setEnabled(loggedIn && !tracking);
-    actionStop->setEnabled(loggedIn && tracking);
-    actionSync->setEnabled(loggedIn);
-    actionLogout->setEnabled(loggedIn);
-    actionClear_Cache->setEnabled(loggedIn);
-    actionSend_Feedback->setEnabled(loggedIn);
-    actionReports->setEnabled(loggedIn);
-    actionEmail->setText(TogglApi::instance->userEmail());
+    ui->actionNew->setEnabled(loggedIn);
+    ui->actionContinue->setEnabled(loggedIn && !tracking);
+    ui->actionStop->setEnabled(loggedIn && tracking);
+    ui->actionSync->setEnabled(loggedIn);
+    ui->actionLogout->setEnabled(loggedIn);
+    ui->actionClear_Cache->setEnabled(loggedIn);
+    ui->actionSend_Feedback->setEnabled(loggedIn);
+    ui->actionReports->setEnabled(loggedIn);
+    ui->actionEmail->setText(TogglApi::instance->userEmail());
     if (tracking) {
         setWindowIcon(icon);
         trayIcon->setIcon(icon);
@@ -301,56 +292,26 @@ void MainWindowController::setShortcuts() {
 }
 
 void MainWindowController::connectMenuActions() {
-    foreach(QMenu *menu, ui->menuBar->findChildren<QMenu *>()) {
-        if (trayIcon) {
-            trayIcon->setContextMenu(menu);
-        }
-        foreach(QAction *action, menu->actions()) {
-            connectMenuAction(action);
-        }
-    }
-}
+    connect(ui->actionNew, &QAction::triggered, this, &MainWindowController::onActionNew);
+    connect(ui->actionContinue,  &QAction::triggered, this, &MainWindowController::onActionContinue);
+    connect(ui->actionStop,  &QAction::triggered, this, &MainWindowController::onActionStop);
+    connect(ui->actionSync,  &QAction::triggered, this, &MainWindowController::onActionSync);
+    connect(ui->actionLogout,  &QAction::triggered, this, &MainWindowController::onActionLogout);
+    connect(ui->actionClear_Cache,  &QAction::triggered, this, &MainWindowController::onActionClear_Cache);
+    connect(ui->actionSend_Feedback,  &QAction::triggered, this, &MainWindowController::onActionSend_Feedback);
+    connect(ui->actionReports,  &QAction::triggered, this, &MainWindowController::onActionReports);
+    connect(ui->actionShow,  &QAction::triggered, this, &MainWindowController::onActionShow);
+    connect(ui->actionPreferences,  &QAction::triggered, this, &MainWindowController::onActionPreferences);
+    connect(ui->actionAbout,  &QAction::triggered, this, &MainWindowController::onActionAbout);
+    connect(ui->actionQuit,  &QAction::triggered, this, &MainWindowController::onActionQuit);
+    connect(ui->actionHelp,  &QAction::triggered, this, &MainWindowController::onActionHelp);
 
-void MainWindowController::connectMenuAction(
-    QAction *action) {
-    if ("actionEmail" == action->objectName()) {
-        actionEmail = action;
-    } else if ("actionNew" == action->objectName()) {
-        actionNew = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionNew()));
-    } else if ("actionContinue" == action->objectName()) {
-        actionContinue = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionContinue()));
-    } else if ("actionStop" == action->objectName()) {
-        actionStop = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionStop()));
-    } else if ("actionSync" == action->objectName()) {
-        actionSync = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionSync()));
-    } else if ("actionLogout" == action->objectName()) {
-        actionLogout = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionLogout()));
-    } else if ("actionClear_Cache" == action->objectName()) {
-        actionClear_Cache = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionClear_Cache()));
-    } else if ("actionSend_Feedback" == action->objectName()) {
-        actionSend_Feedback = action;
-        connect(action, SIGNAL(triggered()),
-                this, SLOT(onActionSend_Feedback()));
-    } else if ("actionReports" == action->objectName()) {
-        actionReports = action;
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionReports()));
-    } else if ("actionShow" == action->objectName()) {
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionShow()));
-    } else if ("actionPreferences" == action->objectName()) {
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionPreferences()));
-    } else if ("actionAbout" == action->objectName()) {
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionAbout()));
-    } else if ("actionQuit" == action->objectName()) {
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionQuit()));
-    } else if ("actionHelp" == action->objectName()) {
-        connect(action, SIGNAL(triggered()), this, SLOT(onActionHelp()));
+    QMenu *trayMenu = new QMenu(this);
+    for (auto act : ui->menuToggl_Desktop->actions()) {
+        trayMenu->addAction(act);
     }
+
+    trayIcon->setContextMenu(trayMenu);
 }
 
 void MainWindowController::onActionNew() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -101,16 +101,6 @@ class MainWindowController : public QMainWindow {
     QxtGlobalShortcut* showHide;
     QxtGlobalShortcut* continueStop;
 
-    QAction *actionEmail;
-    QAction *actionNew;
-    QAction *actionContinue;
-    QAction *actionStop;
-    QAction *actionSync;
-    QAction *actionLogout;
-    QAction *actionClear_Cache;
-    QAction *actionSend_Feedback;
-    QAction *actionReports;
-
     PreferencesDialog *preferencesDialog;
     AboutDialog *aboutDialog;
     FeedbackDialog *feedbackDialog;
@@ -129,7 +119,6 @@ class MainWindowController : public QMainWindow {
     void writeSettings();
 
     void connectMenuActions();
-    void connectMenuAction(QAction *action);
     void enableMenuActions();
 
     bool ui_started;


### PR DESCRIPTION
### 📒 Description
This fixes the tray icon menu to display just as one level instead of two (in some environments where that happened). It also simplifies the menu creation process by quite a bit.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
The weird reassignment of QActions in MainWindowController is not present anymore and the actions are now accessed directly through the `ui` member.

### 👫 Relationships
Closes #2660

### 🔎 Review hints
See if the tray has only 1 level and is the same as the menu in the main application (not like in #2660)

