### PR TITLE
Elide the text in the timer widget (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -45,6 +45,9 @@ selectedProjectId(0) {
             this, SLOT(descriptionBillableChanged(bool)));
     connect(ui->description, SIGNAL(tagsChanged(QString)),
             this, SLOT(descriptionTagsChanged(QString)));
+    connect(ui->description, &QComboBox::editTextChanged,
+            this, &TimerWidget::updateCoverLabel);
+
 
     connect(ui->deleteProject, &QPushButton::clicked, this, &TimerWidget::clearProject);
     connect(ui->deleteTask, &QPushButton::clicked, this, &TimerWidget::clearTask);
@@ -118,6 +121,14 @@ void TimerWidget::clearTask() {
     }
 }
 
+void TimerWidget::updateCoverLabel(const QString &text) {
+    QFont font;
+    font.setPointSize(14);
+    QFontMetrics metrics(font);
+
+    ui->descriptionCover->setText(metrics.elidedText(text, Qt::ElideRight, ui->descriptionCover->width() - 2));
+}
+
 void TimerWidget::focusChanged(QWidget *old, QWidget *now) {
     if (old == ui->description) {
         if (ui->description->currentText().length() == 0) {
@@ -139,6 +150,9 @@ void TimerWidget::displayRunningTimerState(
     selectedTaskId = te->TID;
     selectedProjectId = te->PID;
 
+    ui->description->setVisible(false);
+    ui->descriptionCover->setVisible(true);
+
     ui->start->setText("Stop");
     ui->start->setStyleSheet(
         "background-color: #e20000; color:'white'; font-weight: bold;");
@@ -146,6 +160,7 @@ void TimerWidget::displayRunningTimerState(
     QString description = (te->Description.length() > 0) ?
                           te->Description : "(no description)";
 
+    updateCoverLabel(description);
     ui->description->setEditText(description);
     ui->description->setEnabled(false);
 
@@ -206,6 +221,9 @@ void TimerWidget::displayStoppedTimerState() {
     guid = QString();
     selectedTaskId = 0;
     selectedProjectId = 0;
+
+    ui->descriptionCover->setVisible(false);
+    ui->description->setVisible(true);
 
     ui->start->setText("Start");
     ui->start->setStyleSheet(

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -123,7 +123,7 @@ void TimerWidget::clearTask() {
 
 void TimerWidget::updateCoverLabel(const QString &text) {
     QFont font;
-    font.setPointSize(14);
+    font.setPixelSize(14);
     QFontMetrics metrics(font);
 
     ui->descriptionCover->setText(metrics.elidedText(text, Qt::ElideRight, ui->descriptionCover->width() - 2));
@@ -339,6 +339,7 @@ void TimerWidget::resizeEvent(QResizeEvent* event)
 
 void TimerWidget::setEllipsisTextToLabel(QLabel *label, QString text)
 {
+    updateCoverLabel(ui->description->currentText());
     QFontMetrics metrix(label->font());
     int width = label->width() - 4;
     QString clippedText = metrix.elidedText(text, Qt::ElideRight, width);

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -58,6 +58,8 @@ class TimerWidget : public QFrame {
     void clearProject();
     void clearTask();
 
+    void updateCoverLabel(const QString &text);
+
  private:
     Ui::TimerWidget *ui;
 

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -24,12 +24,14 @@ class TimerWidget : public QFrame {
     explicit TimerWidget(QWidget *parent = 0);
     ~TimerWidget();
 
+private:
+
  signals:
     void buttonClicked();
 
  protected:
     void mousePressEvent(QMouseEvent *event);
-    virtual void resizeEvent(QResizeEvent *);
+    void resizeEvent(QResizeEvent *) override;
 
  private slots:  // NOLINT
     void displayStoppedTimerState();

--- a/src/ui/linux/TogglDesktop/timerwidget.ui
+++ b/src/ui/linux/TogglDesktop/timerwidget.ui
@@ -69,6 +69,25 @@
        <number>3</number>
       </property>
       <item>
+       <widget class="QLabel" name="descriptionCover">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">background-color: rgba(45, 45, 45, 255);
+color: rgb(200, 200, 200);
+combobox-popup: 0;
+font-size: 14px;</string>
+        </property>
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="AutocompleteComboBox" name="description">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">

--- a/src/ui/linux/TogglDesktop/timerwidget.ui
+++ b/src/ui/linux/TogglDesktop/timerwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>356</width>
+    <width>284</width>
     <height>59</height>
    </rect>
   </property>
@@ -53,7 +53,7 @@
    <item>
     <widget class="QFrame" name="DecrProjFrame">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>


### PR DESCRIPTION
### 📒 Description
The timer showed only the end of the current time entry's label. Now it will show the beginning and elide the end of the string if it's too long.
The dropdown arrow will be also hidden.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
The timer widget now contains a QLabel in addition to the AutocompleteComboBox that shows the current time entry text when the timer is running.

### 👫 Relationships
Closes #2661 

### 🔎 Review hints
Check if everything looks right and behaves as expected in the timer widget.

