### PR TITLE
Fix linux notification detection and warning layout

### DIFF
--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -307,13 +307,8 @@ bool PreferencesDialog::setProxySettings() {
             ui->proxyPassword->text());
 }
 
-void PreferencesDialog::resizeEvent(QResizeEvent *event) {
-    QDialog::resizeEvent(event);
-    ui->reminderWarning->setGeometry(ui->tab_reminder->geometry());
-}
-
-void PreferencesDialog::showEvent(QShowEvent *event) {
-    QDialog::showEvent(event);
+void PreferencesDialog::paintEvent(QPaintEvent *event) {
+    QDialog::paintEvent(event);
     ui->reminderWarning->setGeometry(ui->tab_reminder->geometry());
 }
 

--- a/src/ui/linux/TogglDesktop/preferencesdialog.h
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.h
@@ -28,8 +28,7 @@ class PreferencesDialog : public QDialog {
     bool setSettings();
     bool setProxySettings();
 
-    void resizeEvent(QResizeEvent *event) override;
-    void showEvent(QShowEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 
  private slots:  // NOLINT
     void displaySettings(const bool open,

--- a/src/ui/linux/TogglDesktop/systemtray.cpp
+++ b/src/ui/linux/TogglDesktop/systemtray.cpp
@@ -21,9 +21,10 @@ SystemTray::SystemTray(MainWindowController *parent, QIcon defaultIcon) :
             this, SLOT(displayReminder(QString,QString)));  // NOLINT
 
     notifications = new QDBusInterface("org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications", QDBusConnection::sessionBus(), this);
+    notificationsPresent = notifications->isValid();
 
-    notificationsPresent = notificationsPresent && connect(notifications, SIGNAL(NotificationClosed(uint,uint)), this, SLOT(notificationClosed(uint,uint)));
-    notificationsPresent = notificationsPresent && connect(notifications, SIGNAL(ActionInvoked(uint,QString)), this, SLOT(notificationActionInvoked(uint,QString)));
+    connect(notifications, SIGNAL(NotificationClosed(uint,uint)), this, SLOT(notificationClosed(uint,uint)));
+    connect(notifications, SIGNAL(ActionInvoked(uint,QString)), this, SLOT(notificationActionInvoked(uint,QString)));
 
     auto pendingCall = notifications->asyncCall("GetCapabilities");
     auto watcher = new QDBusPendingCallWatcher(pendingCall, this);


### PR DESCRIPTION
### 📒 Description
Fix how notification possibility is detected (by checking the very presence of the Notifications interface on DBus)
Also fix the alignment of the warning in the preferences dialog.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2818 
Closes #2817 

