### PR TITLE
Make opening running TEs by keyboard possible on Linux

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -38,6 +38,12 @@ projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PR
     ui->description->installEventFilter(this);
     ui->project->installEventFilter(this);
 
+    connect(ui->description, &AutocompleteComboBox::returnPressed, [this]() { focusNextChild(); });
+    connect(ui->project, &AutocompleteComboBox::returnPressed, [this]() { focusNextChild(); });
+
+    connect(ui->newProjectWorkspace, QOverload<int>::of(&QComboBox::activated), [this](int) { focusNextChild(); });
+    connect(ui->newProjectClient, QOverload<int>::of(&QComboBox::activated), [this](int) { focusNextChild(); });
+
     toggleNewClientMode(false);
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
@@ -315,13 +321,27 @@ bool TimeEntryEditorWidget::eventFilter(QObject *object, QEvent *event) {
 }
 
 void TimeEntryEditorWidget::keyPressEvent(QKeyEvent *event) {
-    if (event->key() == Qt::Key_Return) {
+    if (event->key() == Qt::Key_Return && event->modifiers() & Qt::CTRL) {
         if (applyNewProject()) {
             TogglApi::instance->viewTimeEntryList();
         }
     }
+    else if (event->key() == Qt::Key_Return) {
+        if (focusWidget() && focusWidget()->inherits("QAbstractButton")) {
+            auto button = qobject_cast<QAbstractButton*>(focusWidget());
+            button->click();
+        }
+        else if (focusWidget() && focusWidget()->inherits("QComboBox")) {
+            auto combobox = qobject_cast<QComboBox*>(focusWidget());
+            combobox->showPopup();
+        }
+        else {
+            focusNextChild();
+        }
+    }
     else {
-        QWidget::keyPressEvent(event);
+        event->ignore();
+        //QWidget::keyPressEvent(event);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -5,6 +5,7 @@
 
 #include <QApplication>  // NOLINT
 #include <QCompleter>  // NOLINT
+#include <QKeyEvent>  // NOLINT
 
 #include "./autocompletelistmodel.h"
 #include "./autocompleteview.h"
@@ -22,6 +23,8 @@ descriptionModel(new AutocompleteListModel(this)),
 selectedTaskId(0),
 selectedProjectId(0) {
     ui->setupUi(this);
+
+    ui->start->installEventFilter(this);
 
     connect(TogglApi::instance, SIGNAL(displayStoppedTimerState()),
             this, SLOT(displayStoppedTimerState()));
@@ -335,6 +338,25 @@ void TimerWidget::resizeEvent(QResizeEvent* event)
 {
     setEllipsisTextToLabel(ui->project, project);
     QWidget::resizeEvent(event);
+}
+
+bool TimerWidget::eventFilter(QObject *obj, QEvent *event) {
+    if (obj == ui->start && event->type() == QEvent::KeyPress) {
+        auto keyEvent = static_cast<QKeyEvent*>(event);
+        switch (keyEvent->key()) {
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+        case Qt::Key_Space:
+            if (keyEvent->modifiers() & (Qt::CTRL)) {
+                TogglApi::instance->editRunningTimeEntry("");
+                return true;
+            }
+            return false;
+        default:
+            return QFrame::eventFilter(obj, event);
+        }
+    }
+    return QFrame::eventFilter(obj, event);
 }
 
 void TimerWidget::setEllipsisTextToLabel(QLabel *label, QString text)

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -32,6 +32,7 @@ private:
  protected:
     void mousePressEvent(QMouseEvent *event);
     void resizeEvent(QResizeEvent *) override;
+    bool eventFilter(QObject *obj, QEvent *event);
 
  private slots:  // NOLINT
     void displayStoppedTimerState();


### PR DESCRIPTION
### 📒 Description
With this PR, it will be possible to use Ctrl+Enter to enter a running Time Entry from the title screen (timer widget).
It also changes enter behavior on the Time Entry Editor: Every element that's not a button of some sort (that means: regular comboboxes, checkboxes and actual buttons) will move the focus to the next element in chain with every Enter keypress. Ctrl+Enter on this screen will click the DONE button.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
Enter on the timer widget opens a running Time Entry
Enter on the Time Entry Editor will now move focus to the next element if the current focused item is not a button. If it is a button, it will activate it.

### 👫 Relationships
Closes #2262 - except the deleting part, I consider it too easy to destroy something. I'm open to suggestions though.

### 🔎 Review hints
Check if behavior of all elements is as expected and predictable.

