### PR TITLE
Fix Focus Jump when editing Time Entry

### DIFF
--- a/src/ui/osx/TogglDesktop/Diff/TogglDesktop-Bridging-Header.h
+++ b/src/ui/osx/TogglDesktop/Diff/TogglDesktop-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "TimeEntryViewItem.h"
+#import "UIEvents.h"

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
@@ -12,10 +12,12 @@
 #import "NSViewEscapable.h"
 #import "NSTextFieldClickable.h"
 
+@class EditorPopover;
+
 @interface TimeEntryListViewController : NSViewController
 @property (unsafe_unretained) IBOutlet NSView *headerView;
 @property (unsafe_unretained) IBOutlet NSUnstripedTableView *timeEntriesTableView;
-@property (strong) IBOutlet NSPopover *timeEntrypopover;
+@property (strong) IBOutlet EditorPopover *timeEntrypopover;
 @property (strong) IBOutlet NSViewController *timeEntrypopoverViewController;
 @property (strong) IBOutlet NSViewEscapable *timeEntryPopupEditView;
 @property (strong) IBOutlet NSScrollView *timeEntryListScrollView;

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -217,7 +217,7 @@ extern void *ctx;
 	{
 		if (self.timeEntrypopover.shown)
 		{
-			[self.timeEntrypopover close];
+			[self.timeEntrypopover closeWithFocusTimer:YES];
 			[self setDefaultPopupSize];
 		}
         // when timer not focused
@@ -659,7 +659,7 @@ extern void *ctx;
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 	if (cmd.open && self.timeEntrypopover.shown)
 	{
-		[self.timeEntrypopover close];
+		[self.timeEntrypopover closeWithFocusTimer:YES];
 		[self setDefaultPopupSize];
 	}
 }

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
@@ -25,7 +25,7 @@
                 <outlet property="view" destination="ozl-58-bBU" id="kIv-R4-Xca"/>
             </connections>
         </viewController>
-        <popover id="dIa-oe-UAP">
+        <popover id="dIa-oe-UAP" customClass="EditorPopover" customModule="TogglDesktop" customModuleProvider="target">
             <connections>
                 <outlet property="delegate" destination="-2" id="Za9-G4-27V"/>
             </connections>
@@ -63,7 +63,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="TQQ-db-grk">
                         <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="kSc-tv-Cw1" customClass="NSUnstripedTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="252" height="205"/>

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -321,7 +321,6 @@ NSString *kInactiveTimerColor = @"#999999";
 	[self.durationTextField setTextColor:[ConvertHexColor hexCodeToNSColor:kInactiveTimerColor]];
 	[self.tagFlag setHidden:YES];
 	[self.billableFlag setHidden:YES];
-	[self.view.window makeFirstResponder:self.autoCompleteInput];
 
 	self.time_entry = [[TimeEntryViewItem alloc] init];
 }
@@ -428,6 +427,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	{
 		[self clear];
 		[self showDefaultTimer];
+		[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
 		[self.projectTextField setHidden:YES];
 		if (self.constraintsAdded)
 		{
@@ -560,7 +560,7 @@ NSString *kInactiveTimerColor = @"#999999";
 {
 	[self.manualBox setHidden:NO];
 	[self.mainBox setHidden:YES];
-	[self.view.window makeFirstResponder:self.startButton];
+	[self.view.window makeFirstResponder:self.autoCompleteInput];
 }
 
 - (void)addButtonClicked

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -26,7 +26,6 @@
 @property NSTimer *timer;
 @property BOOL constraintsAdded;
 @property BOOL disableChange;
-@property BOOL focusNotSet;
 @end
 
 @implementation TimerEditViewController
@@ -41,16 +40,11 @@ NSString *kInactiveTimerColor = @"#999999";
 	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
 	if (self)
 	{
-		self.focusNotSet = YES;
 		self.liteAutocompleteDataSource = [[LiteAutoCompleteDataSource alloc] initWithNotificationName:kDisplayMinitimerAutocomplete];
 
 		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(startDisplayTimerState:)
 													 name:kDisplayTimerState
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startDisplayTimeEntryList:)
-													 name:kDisplayTimeEntryList
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(startDisplayTimeEntryEditor:)
@@ -164,23 +158,6 @@ NSString *kInactiveTimerColor = @"#999999";
 	else
 	{
 		[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
-	}
-}
-
-- (void)startDisplayTimeEntryList:(NSNotification *)notification
-{
-	[self displayTimeEntryList:notification.object];
-}
-
-- (void)displayTimeEntryList:(DisplayCommand *)cmd
-{
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-
-	if (cmd.open && self.time_entry && self.time_entry.duration_in_seconds >= 0
-		&& self.focusNotSet)
-	{
-		[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
-		self.focusNotSet = NO;
 	}
 }
 

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		BA2DA0C621A542E30027B7A5 /* NSTextField+Ext.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA0C521A542E30027B7A5 /* NSTextField+Ext.m */; };
 		BA2DA12021A691FF0027B7A5 /* TrackingService.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11F21A691FF0027B7A5 /* TrackingService.m */; };
 		BA2E3F2C22375E640035D034 /* NSView+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E3F2B22375E640035D034 /* NSView+Appearance.swift */; };
+		BA2E5FB1223787C300EB866E /* EditorPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E5FB0223787C300EB866E /* EditorPopover.swift */; };
 		BA6E873521DDC1E2005E2451 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; };
 		BA6E873621DDC1E2005E2451 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA6E86B621DDB331005E2451 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BA6F1B1A21EEE258009265E4 /* NSColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */; };
@@ -682,6 +683,7 @@
 		BA2DA11E21A691FF0027B7A5 /* TrackingService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackingService.h; sourceTree = "<group>"; };
 		BA2DA11F21A691FF0027B7A5 /* TrackingService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TrackingService.m; sourceTree = "<group>"; };
 		BA2E3F2B22375E640035D034 /* NSView+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Appearance.swift"; sourceTree = "<group>"; };
+		BA2E5FB0223787C300EB866E /* EditorPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorPopover.swift; sourceTree = "<group>"; };
 		BA6E86A521DDB331005E2451 /* Sparkle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sparkle.xcodeproj; path = ../../../../third_party/Sparkle/Sparkle.xcodeproj; sourceTree = "<group>"; };
 		BA6F1B1921EEE258009265E4 /* NSColor+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Utils.swift"; sourceTree = "<group>"; };
 		BA6F1B3721EEE998009265E4 /* Theme+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Theme+Notification.swift"; sourceTree = "<group>"; };
@@ -992,6 +994,7 @@
 				BA03725421FE9FD400FC277B /* FlatButton.swift */,
 				BA03727C21FEB46500FC277B /* FloatingErrorView.swift */,
 				BA03729A21FEB48900FC277B /* FloatingErrorView.xib */,
+				BA2E5FB0223787C300EB866E /* EditorPopover.swift */,
 			);
 			name = ui;
 			path = test2;
@@ -1774,6 +1777,7 @@
 				BA03727D21FEB46500FC277B /* FloatingErrorView.swift in Sources */,
 				749BD0BD1833E28400980494 /* NSBoxClickable.m in Sources */,
 				BA0CEC6521BE590200F1BF01 /* NSTableView+Diff.swift in Sources */,
+				BA2E5FB1223787C300EB866E /* EditorPopover.swift in Sources */,
 				74AA9474180909F50000539F /* GTMOAuth2SignIn.m in Sources */,
 				3C07B75A193C88AE00ED6E6F /* NSCustomTimerComboBox.m in Sources */,
 				74BAD31E18BD7D83002FD4CF /* ViewItem.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/test2/EditorPopover.swift
@@ -1,0 +1,29 @@
+//
+//  EditorPopover.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 3/12/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+final class EditorPopover: NSPopover {
+
+    private struct Constants {
+        static let FocusTimerNotification = NSNotification.Name(kFocusTimer)
+    }
+
+    // MARK: Public
+
+    @objc func close(focusTimer: Bool) {
+
+        // Close and notify delegate if need
+        performClose(self)
+
+        // Focus on timer bar
+        if focusTimer {
+            NotificationCenter.default.post(name: Constants.FocusTimerNotification, object: nil)
+        }
+    }
+}


### PR DESCRIPTION
### 📒 Description
During editing the Time Entry, the focus always is lost and focus on the TimerBar Input.

### Problem
- We accidentally focus on TimerBar many time when the TimeEntryList is rendering => During editing the Time Entry, the focus will be lost if the TimeEntryList is executed.

### 💯 Expected behavior
- [x] During editing the Time Entry, make sure **100%** that the Focus on Edit View shouldn't be lost.
- [x] After closing the Edit Popover, we should focus on Timer Bar
- [x] During editing the Time Entry, the focus is still remaining even we click "Load More" (In current build, the focus is lost)
- [x] After switching Manual / Timer Mode, the Timer Bar should be focus on AutoCompleteInput.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Remove focus TimerBar during TimeEntyList displays
- [x] Introduce EditorPopover and provide func to close and focus on Timerbar if need
- [x] Work on macOS
- [x] Work on Window (WIP 🚧 )

### 👫 Relationships
Closes #2833 

### 🔎 Review hints
- Check the Expected behavior 
- When editing the Time Entry in Popover -> 100% not lost focus.
- No jump anymore.