### PR TITLE
Handle when the WM requests the app to quit (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -405,6 +405,12 @@ void MainWindowController::writeSettings() {
 
 void MainWindowController::closeEvent(QCloseEvent *event) {
 
+    // Window manager has requested the app to quit so just quit
+    if (powerManagement->aboutToShutdown()) {
+        QMainWindow::closeEvent(event);
+        return;
+    }
+
     // Save current windows frame
     TogglApi::instance->setWindowsFrameSetting(QRect(pos().x(),
             pos().y(),

--- a/src/ui/linux/TogglDesktop/powermanagement.cpp
+++ b/src/ui/linux/TogglDesktop/powermanagement.cpp
@@ -4,10 +4,18 @@
 
 #include "./toggl.h"
 
+#include <QGuiApplication>
+
 PowerManagement::PowerManagement(QObject *parent)
     : QObject(parent)
     , available(true)
+    , commitDataRequested(false)
 {
+    connect(qApp, &QGuiApplication::commitDataRequest, [this](QSessionManager &manager){
+        Q_UNUSED(manager);
+        commitDataRequested = true;
+    });
+
     login1 = new QDBusInterface("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", QDBusConnection::systemBus(), this);
 
     getInhibitor();
@@ -18,6 +26,10 @@ PowerManagement::PowerManagement(QObject *parent)
 
 bool PowerManagement::isAvailable() const {
     return available;
+}
+
+bool PowerManagement::aboutToShutdown() const {
+    return commitDataRequested;
 }
 
 void PowerManagement::onPrepareForShutdown(bool shuttingDown) {

--- a/src/ui/linux/TogglDesktop/powermanagement.h
+++ b/src/ui/linux/TogglDesktop/powermanagement.h
@@ -13,6 +13,7 @@ public:
     explicit PowerManagement(QObject *parent = nullptr);
 
     bool isAvailable() const;
+    bool aboutToShutdown() const;
 
 signals:
 
@@ -29,6 +30,7 @@ private:
     QDBusInterface *login1;
     bool available;
     QDBusUnixFileDescriptor inhibit;
+    bool commitDataRequested;
 };
 
 #endif // POWERMANAGEMENT_H


### PR DESCRIPTION
### 📒 Description
Handle the reuqest to store data as the signal that the window manager (and the whole user session) is about to quit. This fixes the issue of the app blocking the logout process.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
The app no longer blocks logout/shutdown in Linux

### 👫 Relationships
Fixes #1645

### 🔎 Review hints
Check if it is possible to log out properly (in at least GNOME and KDE but other environments would be good) when the timer is running in Toggl and the Toggl window is visible. Check the same if the Toggl window is not visible (closed by using the X button on the window).