### PR TITLE
Use the absolute value of time to set confirmless delete (all)

### DIFF
--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -74,6 +74,8 @@ extern "C" {
         // If syncing a time entry ended with an error,
         // the error is attached to the time entry
         char_t *Error;
+        // Short time entries can be deleted without user confirmation
+        bool_t ConfirmlessDelete;
         bool_t Locked;
         // Indicates if time entry is not synced to server
         bool_t Unsynced;

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -316,6 +316,16 @@ TogglTimeEntryView *time_entry_view_item_init(
     view_item->CanSeeBillable = te.CanSeeBillable;
     view_item->DefaultWID = te.DefaultWID;
 
+    // negative means running time entry
+    if (view_item->DurationInSeconds < 0) {
+        // however we have to add current time to know the exact duration
+        int64_t actual_duration = view_item->DurationInSeconds + time(nullptr);
+        view_item->ConfirmlessDelete = actual_duration < 15;
+    }
+    else {
+        view_item->ConfirmlessDelete = view_item->DurationInSeconds < 15;
+    }
+
     view_item->Unsynced = te.Unsynced;
     view_item->Locked = te.Locked;
 

--- a/src/ui/linux/TogglDesktop/timeentryview.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryview.cpp
@@ -36,7 +36,7 @@ TimeEntryView *TimeEntryView::importOne(TogglTimeEntryView *view) {
     result->DefaultWID = view->DefaultWID;
     result->WorkspaceName = QString(view->WorkspaceName);
     result->Error = QString(view->Error);
-    result->ConfirmlessDelete = (view->DurationInSeconds < 15);
+    result->ConfirmlessDelete = view->ConfirmlessDelete;
     result->Unsynced = view->Unsynced;
     // Grouped entries mode
     result->Group = view->Group;

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
@@ -136,7 +136,7 @@
 		self.Error = nil;
 	}
 	// If duration is less than 15 seconds delete without confirmation
-	self.confirmlessDelete = (self.duration_in_seconds < 15);
+	self.confirmlessDelete = te->ConfirmlessDelete;
 
 	// Grouped mode
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -107,6 +107,8 @@ public static partial class Toggl
         public         UInt64 GroupItemCount;
         // Next in list
         public         IntPtr Next;
+        [MarshalAs(UnmanagedType.I1)]
+        public          bool ConfirmlessDelete;
 
         public override string ToString()
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -62,8 +62,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release_VS|AnyCPU'">
     <OutputPath>bin\Release_VS\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
@@ -152,7 +152,7 @@ namespace TogglDesktop
             this.labelDuration.Text = item.Duration;
             this.billabeIcon.ShowOnlyIf(item.Billable);
 
-            this.confirmlessDelete = (item.DurationInSeconds < 15);
+            this.confirmlessDelete = item.ConfirmlessDelete;
 
             if (string.IsNullOrEmpty(item.Tags))
             {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -102,7 +102,7 @@ namespace TogglDesktop
 
                 this.timeEntry = timeEntry;
 
-                this.confirmlessDelete = (timeEntry.DurationInSeconds < 15);
+                this.confirmlessDelete = timeEntry.ConfirmlessDelete;
 
                 var isCurrentlyRunning = timeEntry.DurationInSeconds < 0;
 


### PR DESCRIPTION
### 📒 Description
This changes the way confirmless delete is determined on all three platforms.
To be determined: Should we do this in the library?

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
Deleting currently running time entries (longer than 15s) will issue a prompt asking if the user is sure to delete them.

### 👫 Relationships
Closes #2825


