### PR TITLE
Fix idle time calculation for locked sessions

### DIFF
--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.cpp
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.cpp
@@ -13,6 +13,7 @@ IdleNotificationWidget::IdleNotificationWidget(QStackedWidget *parent)
   ui(new Ui::IdleNotificationWidget),
   idleStarted(0),
   dbusApiAvailable(true),
+  screenLocked(false),
   timeEntryGUID(""),
   idleHintTimer(new QTimer(this)) {
     ui->setupUi(this);
@@ -33,6 +34,8 @@ IdleNotificationWidget::IdleNotificationWidget(QStackedWidget *parent)
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
+
+    connect(screensaver, SIGNAL(ActiveChanged(bool)), this, SLOT(onScreensaverActiveChanged(bool)));
 
     connect(idleHintTimer, &QTimer::timeout, this, &IdleNotificationWidget::requestIdleHint);
     idleHintTimer->setInterval(5000);
@@ -81,6 +84,10 @@ void IdleNotificationWidget::idleHintReceived(QDBusPendingCallWatcher *watcher) 
     watcher->deleteLater();
 }
 
+void IdleNotificationWidget::onScreensaverActiveChanged(bool active) {
+    screenLocked = active;
+}
+
 void IdleNotificationWidget::display() {
     auto sw = qobject_cast<QStackedWidget*>(parent());
     if (sw->currentIndex() >= 0)
@@ -95,6 +102,10 @@ void IdleNotificationWidget::hide() {
         qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(previousView);
         previousView = nullptr;
     }
+}
+
+bool IdleNotificationWidget::isScreenLocked() const {
+    return screenLocked;
 }
 
 IdleNotificationWidget::~IdleNotificationWidget() {

--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.cpp
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.cpp
@@ -117,7 +117,6 @@ void IdleNotificationWidget::storeIdlePeriod(uint64_t period) {
         lastActiveTime = static_cast<uint64_t>(time(nullptr)) - period;
         TogglApi::instance->setIdleSeconds(period);
     }
-    qCritical() << "Setting period to" << period << "and screen is locked:" << isScreenLocked() << "; last active time is:" << lastActiveTime << "and that makes the period" << static_cast<uint64_t>(time(nullptr)) - lastActiveTime;
 }
 
 IdleNotificationWidget::~IdleNotificationWidget() {

--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.h
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.h
@@ -26,9 +26,13 @@ class IdleNotificationWidget : public QWidget {
     void display();
     void hide();
 
+    bool isScreenLocked() const;
+
  private slots:  // NOLINT
     void requestIdleHint();
     void idleHintReceived(QDBusPendingCallWatcher *watcher);
+
+    void onScreensaverActiveChanged(bool active);
 
     void displaySettings(const bool open, SettingsView *settings);
 
@@ -60,6 +64,8 @@ class IdleNotificationWidget : public QWidget {
     uint64_t idleStarted;
     QDBusInterface *screensaver;
     bool dbusApiAvailable;
+    bool screenLocked;
+    uint64_t lastIdleTime;
 
     QString timeEntryGUID;
 

--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.h
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.h
@@ -28,6 +28,9 @@ class IdleNotificationWidget : public QWidget {
 
     bool isScreenLocked() const;
 
+private:
+    void storeIdlePeriod(uint64_t period);
+
  private slots:  // NOLINT
     void requestIdleHint();
     void idleHintReceived(QDBusPendingCallWatcher *watcher);
@@ -65,7 +68,7 @@ class IdleNotificationWidget : public QWidget {
     QDBusInterface *screensaver;
     bool dbusApiAvailable;
     bool screenLocked;
-    uint64_t lastIdleTime;
+    uint64_t lastActiveTime;
 
     QString timeEntryGUID;
 


### PR DESCRIPTION
### 📒 Description
This PR adds locked screen detection and uses it to handle idle time calculation in its entirety, including periods of still-locked screen (like opening and closing the laptop without unlocking the screen).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
The idle time now includes periods when the screen was locked

### 👫 Relationships
Closes #2683
