### PR TITLE
Feature/linux shortcuts

### DIFF
--- a/src/ui/linux/TogglDesktop/CMakeLists.txt
+++ b/src/ui/linux/TogglDesktop/CMakeLists.txt
@@ -43,8 +43,24 @@ set(BINARY_SOURCE_FILES
     timerwidget.cpp
     toggl.cpp
 
-    # Resources have to be listed, .ui files don't
+    # Resources have to be listed
     Resources.qrc
+
+    # it's better to list UI files
+    aboutdialog.ui
+    colorpicker.ui
+    errorviewcontroller.ui
+    feedbackdialog.ui
+    idlenotificationwidget.ui
+    loginwidget.ui
+    mainwindowcontroller.ui
+    overlaywidget.ui
+    preferencesdialog.ui
+    timeentrycellwidget.ui
+    timeentryeditorwidget.ui
+    timeentrylistwidget.ui
+    timerwidget.ui
+
 )
 
 # Set up compilation targets

--- a/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.cpp
@@ -32,13 +32,17 @@ bool AutocompleteComboBox::eventFilter(QObject *o, QEvent *e) {
     if (e->type() == QEvent::KeyPress) {
         auto ke = reinterpret_cast<QKeyEvent*>(e);
         switch (ke->key()) {
+        case Qt::Key_Tab:
         case Qt::Key_Escape:
-            setCurrentText(oldLabel);
-            oldLabel = QString();
-            listView->setVisible(false);
+            cancelSelection();
             return true;
         case Qt::Key_Enter:
         case Qt::Key_Return: {
+            if (ke->modifiers() & Qt::CTRL) {
+                cancelSelection();
+                e->ignore();
+                return true;
+            }
             if (listView->currentIndex().isValid()) {
                 listView->keyPressEvent(ke);
             }
@@ -76,6 +80,10 @@ void AutocompleteComboBox::keyPressEvent(QKeyEvent *event) {
     switch (event->key()) {
     case Qt::Key_Enter:
     case Qt::Key_Return:
+        if (event->modifiers() & Qt::CTRL) {
+            event->ignore();
+            return;
+        }
         emit returnPressed();
         break;
     case Qt::Key_Home:
@@ -122,6 +130,12 @@ void AutocompleteComboBox::onDropdownSelected(AutocompleteView *item) {
         }
     }
     emit activated(listView->currentIndex().row());
+}
+
+void AutocompleteComboBox::cancelSelection() {
+    setCurrentText(oldLabel);
+    oldLabel = QString();
+    listView->setVisible(false);
 }
 
 AutocompleteCompleter::AutocompleteCompleter(QWidget *parent)

--- a/src/ui/linux/TogglDesktop/autocompletecombobox.h
+++ b/src/ui/linux/TogglDesktop/autocompletecombobox.h
@@ -32,6 +32,8 @@ private slots:
     void onDropdownVisibleChanged();
     void onDropdownSelected(AutocompleteView *item);
 
+    void cancelSelection();
+
 signals:
     void returnPressed();
     void timeEntrySelected(const QString &name);

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -21,6 +21,9 @@
 #include <QPushButton>  // NOLINT
 
 #include "./toggl.h"
+#include "./timeentryeditorwidget.h"
+#include "./timeentrylistwidget.h"
+#include "./timerwidget.h"
 #include "./errorviewcontroller.h"
 
 MainWindowController::MainWindowController(
@@ -43,6 +46,7 @@ MainWindowController::MainWindowController(
   script(scriptPath),
   powerManagement(new PowerManagement(this)),
   networkManagement(new NetworkManagement(this)),
+  shortcutDelete(QKeySequence(Qt::CTRL + Qt::Key_Delete), this),
   ui_started(false) {
     ui->setupUi(this);
 
@@ -266,6 +270,15 @@ void MainWindowController::onOnlineStateChanged() {
     }
 }
 
+void MainWindowController::onShortcutDelete() {
+    if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
+        ui->timeEntryListWidget->timer()->deleteTimeEntry();
+    }
+    else if (ui->stackedWidget->currentWidget() == ui->timeEntryEditorWidget) {
+        ui->timeEntryEditorWidget->deleteTimeEntry();
+    }
+}
+
 void MainWindowController::setShortcuts() {
     showHide = new QxtGlobalShortcut(this);
     connect(showHide, SIGNAL(activated()),
@@ -278,6 +291,9 @@ void MainWindowController::setShortcuts() {
             this, SLOT(continueStopHotkeyPressed()));
 
     updateContinueStopShortcut();
+
+    connect(&shortcutDelete, &QShortcut::activated,
+            this, &MainWindowController::onShortcutDelete);
 }
 
 void MainWindowController::connectMenuActions() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -25,6 +25,7 @@
 #include "./timeentrylistwidget.h"
 #include "./timerwidget.h"
 #include "./errorviewcontroller.h"
+#include "./timeentrycellwidget.h"
 
 MainWindowController::MainWindowController(
     QWidget *parent,
@@ -272,7 +273,14 @@ void MainWindowController::onOnlineStateChanged() {
 
 void MainWindowController::onShortcutDelete() {
     if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
-        ui->timeEntryListWidget->timer()->deleteTimeEntry();
+        if (ui->timeEntryListWidget->focusWidget() &&
+            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->deleteTimeEntry();
+        }
+        else {
+            ui->timeEntryListWidget->timer()->deleteTimeEntry();
+        }
     }
     else if (ui->stackedWidget->currentWidget() == ui->timeEntryEditorWidget) {
         ui->timeEntryEditorWidget->deleteTimeEntry();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -49,6 +49,7 @@ MainWindowController::MainWindowController(
   networkManagement(new NetworkManagement(this)),
   shortcutDelete(QKeySequence(Qt::CTRL + Qt::Key_Delete), this),
   shortcutPause(QKeySequence(Qt::CTRL + Qt::Key_Space), this),
+  shortcutConfirm(QKeySequence(Qt::CTRL + Qt::Key_Return), this),
   ui_started(false) {
     ui->setupUi(this);
 
@@ -318,6 +319,29 @@ void MainWindowController::onShortcutPause() {
     }
 }
 
+void MainWindowController::onShortcutConfirm() {
+    auto w = focusWidget();
+    while (w) {
+        auto timer = qobject_cast<TimerWidget*>(w);
+        auto timeEntryList = qobject_cast<TimeEntryListWidget*>(w);
+        auto timeEntryEdit = qobject_cast<TimeEntryEditorWidget*>(w);
+        if (timer) {
+            TogglApi::instance->editRunningTimeEntry("");
+            return;
+        }
+        else if (timeEntryList) {
+            QString selectedGuid = timeEntryList->highlightedCell() ? timeEntryList->highlightedCell()->entryGuid() : QString();
+            TogglApi::instance->editTimeEntry(selectedGuid, "");
+            return;
+        }
+        else if (timeEntryEdit) {
+            timeEntryEdit->clickDone();
+            return;
+        }
+        w = w->parentWidget();
+    }
+}
+
 void MainWindowController::setShortcuts() {
     showHide = new QxtGlobalShortcut(this);
     connect(showHide, SIGNAL(activated()),
@@ -335,6 +359,8 @@ void MainWindowController::setShortcuts() {
             this, &MainWindowController::onShortcutDelete);
     connect(&shortcutPause, &QShortcut::activated,
             this, &MainWindowController::onShortcutPause);
+    connect(&shortcutConfirm, &QShortcut::activated,
+            this, &MainWindowController::onShortcutConfirm);
 }
 
 void MainWindowController::connectMenuActions() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -22,11 +22,6 @@
 
 #include "./toggl.h"
 #include "./errorviewcontroller.h"
-#include "./overlaywidget.h"
-#include "./loginwidget.h"
-#include "./timeentrylistwidget.h"
-#include "./timeentryeditorwidget.h"
-#include "./idlenotificationwidget.h"
 
 MainWindowController::MainWindowController(
     QWidget *parent,
@@ -52,19 +47,6 @@ MainWindowController::MainWindowController(
     ui->setupUi(this);
 
     ui->menuBar->setVisible(true);
-
-    QStackedWidget *stacked = new QStackedWidget;
-    stacked->addWidget(new OverlayWidget(stacked));
-    stacked->addWidget(new LoginWidget(stacked));
-    stacked->addWidget(new TimeEntryEditorWidget(stacked));
-    stacked->addWidget(new TimeEntryListWidget(stacked));
-    stacked->addWidget(new IdleNotificationWidget(stacked));
-    QVBoxLayout *verticalLayout = new QVBoxLayout;
-    verticalLayout->setContentsMargins(0, 0, 0, 0);
-    verticalLayout->setSpacing(0);
-    verticalLayout->addWidget(new ErrorViewController());
-    verticalLayout->addWidget(stacked);
-    centralWidget()->setLayout(verticalLayout);
 
     readSettings();
 

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -50,6 +50,8 @@ MainWindowController::MainWindowController(
   shortcutDelete(QKeySequence(Qt::CTRL + Qt::Key_Delete), this),
   shortcutPause(QKeySequence(Qt::CTRL + Qt::Key_Space), this),
   shortcutConfirm(QKeySequence(Qt::CTRL + Qt::Key_Return), this),
+  shortcutGroupOpen(QKeySequence(Qt::Key_Right), this),
+  shortcutGroupClose(QKeySequence(Qt::Key_Left), this),
   ui_started(false) {
     ui->setupUi(this);
 
@@ -342,6 +344,26 @@ void MainWindowController::onShortcutConfirm() {
     }
 }
 
+void MainWindowController::onShortcutGroupOpen() {
+    if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
+        if (ui->timeEntryListWidget->focusWidget() &&
+            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->toggleGroup(true);
+        }
+    }
+}
+
+void MainWindowController::onShortcutGroupClose() {
+    if (ui->stackedWidget->currentWidget() == ui->timeEntryListWidget) {
+        if (ui->timeEntryListWidget->focusWidget() &&
+            ui->timeEntryListWidget->focusWidget()->parentWidget() &&
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())) {
+            qobject_cast<TimeEntryCellWidget*>(ui->timeEntryListWidget->focusWidget()->parentWidget())->toggleGroup(false);
+        }
+    }
+}
+
 void MainWindowController::setShortcuts() {
     showHide = new QxtGlobalShortcut(this);
     connect(showHide, SIGNAL(activated()),
@@ -361,6 +383,10 @@ void MainWindowController::setShortcuts() {
             this, &MainWindowController::onShortcutPause);
     connect(&shortcutConfirm, &QShortcut::activated,
             this, &MainWindowController::onShortcutConfirm);
+    connect(&shortcutGroupOpen, &QShortcut::activated,
+            this, &MainWindowController::onShortcutGroupOpen);
+    connect(&shortcutGroupClose, &QShortcut::activated,
+            this, &MainWindowController::onShortcutGroupClose);
 }
 
 void MainWindowController::connectMenuActions() {

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -98,6 +98,7 @@ class MainWindowController : public QMainWindow {
 
     void onShortcutDelete();
     void onShortcutPause();
+    void onShortcutConfirm();
 
  private:
     Ui::MainWindowController *ui;
@@ -128,6 +129,7 @@ class MainWindowController : public QMainWindow {
 
     QShortcut shortcutDelete;
     QShortcut shortcutPause;
+    QShortcut shortcutConfirm;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -99,6 +99,8 @@ class MainWindowController : public QMainWindow {
     void onShortcutDelete();
     void onShortcutPause();
     void onShortcutConfirm();
+    void onShortcutGroupOpen();
+    void onShortcutGroupClose();
 
  private:
     Ui::MainWindowController *ui;
@@ -130,6 +132,8 @@ class MainWindowController : public QMainWindow {
     QShortcut shortcutDelete;
     QShortcut shortcutPause;
     QShortcut shortcutConfirm;
+    QShortcut shortcutGroupOpen;
+    QShortcut shortcutGroupClose;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -97,6 +97,7 @@ class MainWindowController : public QMainWindow {
     void onOnlineStateChanged();
 
     void onShortcutDelete();
+    void onShortcutPause();
 
  private:
     Ui::MainWindowController *ui;
@@ -126,6 +127,7 @@ class MainWindowController : public QMainWindow {
     NetworkManagement *networkManagement;
 
     QShortcut shortcutDelete;
+    QShortcut shortcutPause;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -11,8 +11,6 @@
 #include <stdint.h>
 
 #include "./toggl.h"
-#include "./loginwidget.h"
-#include "./timeentrylistwidget.h"
 #include "./preferencesdialog.h"
 #include "./aboutdialog.h"
 #include "./feedbackdialog.h"
@@ -20,6 +18,11 @@
 #include "./systemtray.h"
 #include "./powermanagement.h"
 #include "./networkmanagement.h"
+#include "./overlaywidget.h"
+#include "./loginwidget.h"
+#include "./timeentrylistwidget.h"
+#include "./timeentryeditorwidget.h"
+#include "./idlenotificationwidget.h"
 
 namespace Ui {
 class MainWindowController;

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.h
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.h
@@ -6,6 +6,7 @@
 #include <QMainWindow>
 #include <QSystemTrayIcon>
 #include <QMessageBox>  // NOLINT
+#include <QShortcut>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -95,6 +96,8 @@ class MainWindowController : public QMainWindow {
 
     void onOnlineStateChanged();
 
+    void onShortcutDelete();
+
  private:
     Ui::MainWindowController *ui;
 
@@ -121,6 +124,8 @@ class MainWindowController : public QMainWindow {
 
     PowerManagement *powerManagement;
     NetworkManagement *networkManagement;
+
+    QShortcut shortcutDelete;
 
     void readSettings();
     void writeSettings();

--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.ui
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.ui
@@ -29,6 +29,35 @@
    <property name="styleSheet">
     <string notr="true">background-color:#f2f1f0;</string>
    </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="ErrorViewController" name="widget" native="true"/>
+    </item>
+    <item>
+     <widget class="QStackedWidget" name="stackedWidget">
+      <widget class="OverlayWidget" name="overlayWidget"/>
+      <widget class="LoginWidget" name="loginWidget"/>
+      <widget class="TimeEntryEditorWidget" name="timeEntryEditorWidget"/>
+      <widget class="TimeEntryListWidget" name="timeEntryListWidget"/>
+      <widget class="IdleNotificationWidget" name="idleNotificationWidget"/>
+     </widget>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
@@ -36,7 +65,7 @@
      <x>0</x>
      <y>0</y>
      <width>350</width>
-     <height>25</height>
+     <height>29</height>
     </rect>
    </property>
    <property name="styleSheet">
@@ -157,6 +186,39 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>ErrorViewController</class>
+   <extends>QWidget</extends>
+   <header>errorviewcontroller.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>OverlayWidget</class>
+   <extends>QWidget</extends>
+   <header>overlaywidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>LoginWidget</class>
+   <extends>QWidget</extends>
+   <header>loginwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TimeEntryEditorWidget</class>
+   <extends>QWidget</extends>
+   <header>timeentryeditorwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TimeEntryListWidget</class>
+   <extends>QWidget</extends>
+   <header>timeentrylistwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>IdleNotificationWidget</class>
+   <extends>QWidget</extends>
+   <header>idlenotificationwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -3,6 +3,7 @@
 #include "./timeentrycellwidget.h"
 #include "./ui_timeentrycellwidget.h"
 
+#include <QKeyEvent>
 #include <QMessageBox>
 
 #include "./toggl.h"
@@ -102,6 +103,12 @@ void TimeEntryCellWidget::deleteTimeEntry() {
         "Deleted time entries cannot be restored.",
         QMessageBox::Ok|QMessageBox::Cancel).exec()) {
         TogglApi::instance->deleteTimeEntry(guid);
+    }
+}
+
+void TimeEntryCellWidget::keyPressEvent(QKeyEvent *event) {
+    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+        ui->dataFrame->click();
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -93,6 +93,10 @@ void TimeEntryCellWidget::setLoadMore(bool load_more) {
     }
 }
 
+QString TimeEntryCellWidget::entryGuid() {
+    return guid;
+}
+
 void TimeEntryCellWidget::deleteTimeEntry() {
     if (guid.isEmpty())
         return;

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -19,8 +19,8 @@ confirmlessDelete(false) {
     ui->setupUi(this);
     setStyleSheet(
         "* { font-size: 13px }"
-        "QFrame { background-color:transparent; border:none; margins:0 }"
-        "QPushButton#dataFrame { background-color:#fefefe; border: none; border-bottom:1px solid #cacaca; margins: 0 }"
+        "QFrame { background-color:transparent; border:none; margin:0 }"
+        "QPushButton#dataFrame { background-color:#fefefe; border: none; border-bottom:1px solid #cacaca; margin: 0 }"
         "QPushButton#dataFrame:flat { background-color:transparent; }"
     );
     ui->groupButton->setStyleSheet(

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -5,11 +5,13 @@
 
 #include <QKeyEvent>
 #include <QMessageBox>
+#include <QListWidgetItem>
 
 #include "./toggl.h"
 
-TimeEntryCellWidget::TimeEntryCellWidget() : QWidget(nullptr),
+TimeEntryCellWidget::TimeEntryCellWidget(QListWidgetItem *item) : QWidget(nullptr),
 ui(new Ui::TimeEntryCellWidget),
+item(item),
 description(""),
 project(""),
 guid(""),
@@ -17,6 +19,7 @@ group(false),
 groupName(""),
 confirmlessDelete(false) {
     ui->setupUi(this);
+    ui->dataFrame->installEventFilter(this);
     setStyleSheet(
         "* { font-size: 13px }"
         "QFrame { background-color:transparent; border:none; margin:0 }"
@@ -108,6 +111,17 @@ void TimeEntryCellWidget::deleteTimeEntry() {
         QMessageBox::Ok|QMessageBox::Cancel).exec()) {
         TogglApi::instance->deleteTimeEntry(guid);
     }
+}
+
+bool TimeEntryCellWidget::eventFilter(QObject *watched, QEvent *event) {
+    if (event->type() == QEvent::FocusIn) {
+        focusInEvent(reinterpret_cast<QFocusEvent*>(event));
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void TimeEntryCellWidget::focusInEvent(QFocusEvent *event) {
+    item->listWidget()->scrollToItem(item, QAbstractItemView::PositionAtCenter);
 }
 
 void TimeEntryCellWidget::keyPressEvent(QKeyEvent *event) {

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -16,6 +16,7 @@ description(""),
 project(""),
 guid(""),
 group(false),
+groupOpen(false),
 groupName(""),
 timeEntry(nullptr) {
     ui->setupUi(this);
@@ -186,6 +187,14 @@ QString TimeEntryCellWidget::getProjectColor(QString color) {
         return QString("#9d9d9d");
     }
     return color;
+}
+
+void TimeEntryCellWidget::toggleGroup(bool open)
+{
+    if (group && groupOpen != open) {
+        groupOpen = open;
+        TogglApi::instance->toggleEntriesGroup(groupName);
+    }
 }
 
 void TimeEntryCellWidget::on_groupButton_clicked()

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -124,12 +124,6 @@ void TimeEntryCellWidget::focusInEvent(QFocusEvent *event) {
     item->listWidget()->scrollToItem(item, QAbstractItemView::PositionAtCenter);
 }
 
-void TimeEntryCellWidget::keyPressEvent(QKeyEvent *event) {
-    if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
-        ui->dataFrame->click();
-    }
-}
-
 void TimeEntryCellWidget::setupGroupedMode(TimeEntryView *view) {
     // Grouped Mode Setup
     group = view->Group;

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -17,7 +17,7 @@ project(""),
 guid(""),
 group(false),
 groupName(""),
-confirmlessDelete(false) {
+timeEntry(nullptr) {
     ui->setupUi(this);
     ui->dataFrame->installEventFilter(this);
     setStyleSheet(
@@ -37,7 +37,7 @@ void TimeEntryCellWidget::display(TimeEntryView *view) {
     setLoadMore(false);
     guid = view->GUID;
     groupName = view->GroupName;
-    confirmlessDelete = view->ConfirmlessDelete;
+    timeEntry = view;
     description =
         (view->Description.length() > 0) ?
         view->Description : "(no description)";
@@ -104,7 +104,7 @@ void TimeEntryCellWidget::deleteTimeEntry() {
     if (guid.isEmpty())
         return;
 
-    if (confirmlessDelete || QMessageBox::Ok == QMessageBox(
+    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
         QMessageBox::Question,
         "Delete this time entry?",
         "Deleted time entries cannot be restored.",

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -3,6 +3,8 @@
 #include "./timeentrycellwidget.h"
 #include "./ui_timeentrycellwidget.h"
 
+#include <QMessageBox>
+
 #include "./toggl.h"
 
 TimeEntryCellWidget::TimeEntryCellWidget() : QWidget(nullptr),
@@ -11,7 +13,8 @@ description(""),
 project(""),
 guid(""),
 group(false),
-groupName("") {
+groupName(""),
+confirmlessDelete(false) {
     ui->setupUi(this);
     setStyleSheet(
         "* { font-size: 13px }"
@@ -30,6 +33,7 @@ void TimeEntryCellWidget::display(TimeEntryView *view) {
     setLoadMore(false);
     guid = view->GUID;
     groupName = view->GroupName;
+    confirmlessDelete = view->ConfirmlessDelete;
     description =
         (view->Description.length() > 0) ?
         view->Description : "(no description)";
@@ -85,6 +89,19 @@ void TimeEntryCellWidget::setLoadMore(bool load_more) {
     ui->dataFrame->setFocusPolicy(load_more ? Qt::NoFocus : Qt::StrongFocus);
     if (load_more) {
         ui->unsyncedicon->setVisible(false);
+    }
+}
+
+void TimeEntryCellWidget::deleteTimeEntry() {
+    if (guid.isEmpty())
+        return;
+
+    if (confirmlessDelete || QMessageBox::Ok == QMessageBox(
+        QMessageBox::Question,
+        "Delete this time entry?",
+        "Deleted time entries cannot be restored.",
+        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
+        TogglApi::instance->deleteTimeEntry(guid);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -27,6 +27,7 @@ class TimeEntryCellWidget : public QWidget {
     void setLoadMore(bool load_more);
 
     QString entryGuid();
+    void toggleGroup(bool open);
 
  public slots:
     void deleteTimeEntry();
@@ -50,6 +51,7 @@ class TimeEntryCellWidget : public QWidget {
     QString project;
     QString guid;
     bool group;
+    bool groupOpen;
     QString groupName;
     TimeEntryView *timeEntry;
     QString getProjectColor(QString color);

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -25,13 +25,13 @@ class TimeEntryCellWidget : public QWidget {
     void setLoadMore(bool load_more);
 
  protected:
-    virtual void mousePressEvent(QMouseEvent *event);
     virtual void resizeEvent(QResizeEvent *);
 
  private slots:  // NOLINT
     void on_continueButton_clicked();
     void on_groupButton_clicked();
     void on_loadMoreButton_clicked();
+    void on_dataFrame_clicked();
 
  private:
     Ui::TimeEntryCellWidget *ui;

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -24,6 +24,8 @@ class TimeEntryCellWidget : public QWidget {
     void labelClicked(QString field_name);
     void setLoadMore(bool load_more);
 
+    QString entryGuid();
+
  public slots:
     void deleteTimeEntry();
 

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -12,11 +12,13 @@ namespace Ui {
 class TimeEntryCellWidget;
 }
 
+class QListWidgetItem;
+
 class TimeEntryCellWidget : public QWidget {
     Q_OBJECT
 
  public:
-    TimeEntryCellWidget();
+    TimeEntryCellWidget(QListWidgetItem *item);
     ~TimeEntryCellWidget();
 
     void display(TimeEntryView *view);
@@ -30,6 +32,8 @@ class TimeEntryCellWidget : public QWidget {
     void deleteTimeEntry();
 
  protected:
+    virtual bool eventFilter(QObject *watched, QEvent *event) override;
+    virtual void focusInEvent(QFocusEvent *event) override;
     virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void resizeEvent(QResizeEvent *) override;
 
@@ -41,6 +45,7 @@ class TimeEntryCellWidget : public QWidget {
 
  private:
     Ui::TimeEntryCellWidget *ui;
+    QListWidgetItem *item;
 
     QString description;
     QString project;

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -51,7 +51,7 @@ class TimeEntryCellWidget : public QWidget {
     QString guid;
     bool group;
     QString groupName;
-    bool confirmlessDelete;
+    TimeEntryView *timeEntry;
     QString getProjectColor(QString color);
 
     void setupGroupedMode(TimeEntryView *view);

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -24,6 +24,9 @@ class TimeEntryCellWidget : public QWidget {
     void labelClicked(QString field_name);
     void setLoadMore(bool load_more);
 
+ public slots:
+    void deleteTimeEntry();
+
  protected:
     virtual void resizeEvent(QResizeEvent *);
 
@@ -41,6 +44,7 @@ class TimeEntryCellWidget : public QWidget {
     QString guid;
     bool group;
     QString groupName;
+    bool confirmlessDelete;
     QString getProjectColor(QString color);
 
     void setupGroupedMode(TimeEntryView *view);

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -28,7 +28,8 @@ class TimeEntryCellWidget : public QWidget {
     void deleteTimeEntry();
 
  protected:
-    virtual void resizeEvent(QResizeEvent *);
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void resizeEvent(QResizeEvent *) override;
 
  private slots:  // NOLINT
     void on_continueButton_clicked();

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.h
@@ -34,7 +34,6 @@ class TimeEntryCellWidget : public QWidget {
  protected:
     virtual bool eventFilter(QObject *watched, QEvent *event) override;
     virtual void focusInEvent(QFocusEvent *event) override;
-    virtual void keyPressEvent(QKeyEvent *event) override;
     virtual void resizeEvent(QResizeEvent *) override;
 
  private slots:  // NOLINT

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
+    <width>372</width>
     <height>138</height>
    </rect>
   </property>
@@ -26,7 +26,7 @@
    <string>Form</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">color:rgb(85, 85, 85);font-size:13px;</string>
+   <string notr="true"/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">
@@ -45,18 +45,9 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="headerFrame">
+    <widget class="QWidget" name="headerFrame" native="true">
      <property name="styleSheet">
-      <string notr="true">background-color: rgb(235, 235, 235);</string>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <property name="lineWidth">
-      <number>0</number>
+      <string notr="true"/>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -93,7 +84,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QFrame" name="dataFrame">
+    <widget class="QPushButton" name="dataFrame">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -107,13 +98,10 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true">background-color: rgb(250, 250, 250);border-bottom:1px solid #cacaca;</string>
+      <string notr="true"/>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::Box</enum>
-     </property>
-     <property name="lineWidth">
-      <number>0</number>
+     <property name="flat">
+      <bool>false</bool>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
@@ -152,7 +140,7 @@
          <string>Time Entry has not been synced to the server</string>
         </property>
         <property name="styleSheet">
-         <string notr="true">border:none;</string>
+         <string notr="true"/>
         </property>
         <property name="text">
          <string/>
@@ -205,13 +193,7 @@
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">border:none;background-color:transparent;</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="lineWidth">
-         <number>2</number>
+         <string notr="true"/>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
          <property name="sizeConstraint">
@@ -223,7 +205,7 @@
          <item>
           <widget class="ClickableLabel" name="description">
            <property name="styleSheet">
-            <string notr="true">border:none;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string>Blogpost about this</string>
@@ -236,7 +218,7 @@
          <item>
           <widget class="ClickableLabel" name="project">
            <property name="styleSheet">
-            <string notr="true">border:none;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string>NEW - TOGGL</string>
@@ -264,13 +246,7 @@
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">border:none;</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <string notr="true"/>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <property name="spacing">
@@ -308,8 +284,11 @@
              <height>32</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="styleSheet">
-            <string notr="true">border:none; background: url(:/images/group_icon_closed.svg) no-repeat;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string/>
@@ -319,6 +298,12 @@
              <width>32</width>
              <height>32</height>
             </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -340,13 +325,7 @@
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">border:none</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <string notr="true"/>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <property name="spacing">
@@ -376,13 +355,13 @@
             </size>
            </property>
            <property name="styleSheet">
-            <string notr="true">border:none;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string/>
            </property>
            <property name="pixmap">
-            <pixmap>:/images/icon-tags.png</pixmap>
+            <pixmap resource="Resources.qrc">:/images/icon-tags.png</pixmap>
            </property>
           </widget>
          </item>
@@ -401,13 +380,13 @@
             </size>
            </property>
            <property name="styleSheet">
-            <string notr="true">border:none;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string/>
            </property>
            <property name="pixmap">
-            <pixmap>:/images/icon-billable.png</pixmap>
+            <pixmap resource="Resources.qrc">:/images/icon-billable.png</pixmap>
            </property>
           </widget>
          </item>
@@ -425,14 +404,17 @@
              <height>32</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="styleSheet">
-            <string notr="true">border:none;outline:none;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string/>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="Resources.qrc">
              <normaloff>:/images/continue_regular.svg</normaloff>:/images/continue_regular.svg</iconset>
            </property>
            <property name="iconSize">
@@ -440,6 +422,9 @@
              <width>32</width>
              <height>32</height>
             </size>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -458,7 +443,7 @@
             </size>
            </property>
            <property name="styleSheet">
-            <string notr="true">border:none;margin:0;</string>
+            <string notr="true"/>
            </property>
            <property name="text">
             <string>00:00:00</string>
@@ -486,6 +471,8 @@
    <header>clickablelabel.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="Resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.ui
@@ -97,6 +97,9 @@
        <height>77</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
      <property name="styleSheet">
       <string notr="true"/>
      </property>

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -29,7 +29,9 @@ timer(new QTimer(this)),
 duration(0),
 previousTagList(""),
 descriptionModel(new AutocompleteListModel(this, QVector<AutocompleteView*>())),
-projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PROJECT)) {
+projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PROJECT)),
+shortcutDelete(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Delete), this))
+{
     ui->setupUi(this);
 
     ui->description->setModel(descriptionModel);
@@ -74,6 +76,8 @@ projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PR
             this, SLOT(setProjectColors(QVector<char*>)));  // NOLINT
 
     connect(timer, SIGNAL(timeout()), this, SLOT(timeout()));
+
+    connect(shortcutDelete, &QShortcut::activated, this, &TimeEntryEditorWidget::onShortcutDelete);
 
     TogglApi::instance->getProjectColors();
 }
@@ -347,13 +351,7 @@ void TimeEntryEditorWidget::keyPressEvent(QKeyEvent *event) {
 }
 
 void TimeEntryEditorWidget::on_deleteButton_clicked() {
-    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
-        QMessageBox::Question,
-        "Delete this time entry?",
-        "Deleted time entries cannot be restored.",
-        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
-        TogglApi::instance->deleteTimeEntry(guid);
-    }
+    onShortcutDelete();
 }
 
 void TimeEntryEditorWidget::on_addNewProject_clicked() {
@@ -457,6 +455,16 @@ void TimeEntryEditorWidget::timeout() {
             !ui->duration->hasFocus()) {
         ui->duration->setText(
             TogglApi::formatDurationInSecondsHHMMSS(duration));
+    }
+}
+
+void TimeEntryEditorWidget::onShortcutDelete() {
+    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
+        QMessageBox::Question,
+        "Delete this time entry?",
+        "Deleted time entries cannot be restored.",
+        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
+        TogglApi::instance->deleteTimeEntry(guid);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -102,6 +102,11 @@ void TimeEntryEditorWidget::deleteTimeEntry() {
     }
 }
 
+void TimeEntryEditorWidget::clickDone()
+{
+    on_doneButton_clicked();
+}
+
 void TimeEntryEditorWidget::displayClientSelect(
     QVector<GenericView *> list) {
     clientSelectUpdate = list;

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -337,31 +337,6 @@ bool TimeEntryEditorWidget::eventFilter(QObject *object, QEvent *event) {
     return false;
 }
 
-void TimeEntryEditorWidget::keyPressEvent(QKeyEvent *event) {
-    if (event->key() == Qt::Key_Return && event->modifiers() & Qt::CTRL) {
-        if (applyNewProject()) {
-            TogglApi::instance->viewTimeEntryList();
-        }
-    }
-    else if (event->key() == Qt::Key_Return) {
-        if (focusWidget() && focusWidget()->inherits("QAbstractButton")) {
-            auto button = qobject_cast<QAbstractButton*>(focusWidget());
-            button->click();
-        }
-        else if (focusWidget() && focusWidget()->inherits("QComboBox")) {
-            auto combobox = qobject_cast<QComboBox*>(focusWidget());
-            combobox->showPopup();
-        }
-        else {
-            focusNextChild();
-        }
-    }
-    else {
-        event->ignore();
-        //QWidget::keyPressEvent(event);
-    }
-}
-
 void TimeEntryEditorWidget::on_deleteButton_clicked() {
     deleteTimeEntry();
 }

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -29,8 +29,7 @@ timer(new QTimer(this)),
 duration(0),
 previousTagList(""),
 descriptionModel(new AutocompleteListModel(this, QVector<AutocompleteView*>())),
-projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PROJECT)),
-shortcutDelete(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Delete), this))
+projectModel(new AutocompleteListModel(this, QVector<AutocompleteView*>(), AC_PROJECT))
 {
     ui->setupUi(this);
 
@@ -77,8 +76,6 @@ shortcutDelete(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Delete), this))
 
     connect(timer, SIGNAL(timeout()), this, SLOT(timeout()));
 
-    connect(shortcutDelete, &QShortcut::activated, this, &TimeEntryEditorWidget::onShortcutDelete);
-
     TogglApi::instance->getProjectColors();
 }
 
@@ -93,6 +90,16 @@ void TimeEntryEditorWidget::setSelectedColor(QString color) {
 
 void TimeEntryEditorWidget::display() {
     qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
+}
+
+void TimeEntryEditorWidget::deleteTimeEntry() {
+    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
+        QMessageBox::Question,
+        "Delete this time entry?",
+        "Deleted time entries cannot be restored.",
+        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
+        TogglApi::instance->deleteTimeEntry(guid);
+    }
 }
 
 void TimeEntryEditorWidget::displayClientSelect(
@@ -351,7 +358,7 @@ void TimeEntryEditorWidget::keyPressEvent(QKeyEvent *event) {
 }
 
 void TimeEntryEditorWidget::on_deleteButton_clicked() {
-    onShortcutDelete();
+    deleteTimeEntry();
 }
 
 void TimeEntryEditorWidget::on_addNewProject_clicked() {
@@ -455,16 +462,6 @@ void TimeEntryEditorWidget::timeout() {
             !ui->duration->hasFocus()) {
         ui->duration->setText(
             TogglApi::formatDurationInSecondsHHMMSS(duration));
-    }
-}
-
-void TimeEntryEditorWidget::onShortcutDelete() {
-    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
-        QMessageBox::Question,
-        "Delete this time entry?",
-        "Deleted time entries cannot be restored.",
-        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
-        TogglApi::instance->deleteTimeEntry(guid);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -8,7 +8,6 @@
 #include <QTimer>
 #include <QListWidgetItem>
 #include <QStackedWidget>
-#include <QShortcut>
 
 #include <stdint.h>
 #include "./colorpicker.h"
@@ -31,6 +30,9 @@ class TimeEntryEditorWidget : public QWidget {
     void setSelectedColor(QString color);
 
     void display();
+
+ public slots:
+    void deleteTimeEntry();
 
  private:
     Ui::TimeEntryEditorWidget *ui;
@@ -61,8 +63,6 @@ class TimeEntryEditorWidget : public QWidget {
 
     AutocompleteListModel *descriptionModel;
     AutocompleteListModel *projectModel;
-
-    QShortcut *shortcutDelete;
 
     bool applyNewProject();
     bool eventFilter(QObject *object, QEvent *event);
@@ -99,8 +99,6 @@ class TimeEntryEditorWidget : public QWidget {
     void setProjectColors(QVector<char *> list);
 
     void timeout();
-
-    void onShortcutDelete();
 
     void on_doneButton_clicked();
     void on_deleteButton_clicked();

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -33,6 +33,7 @@ class TimeEntryEditorWidget : public QWidget {
 
  public slots:
     void deleteTimeEntry();
+    void clickDone();
 
  private:
     Ui::TimeEntryEditorWidget *ui;

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -67,7 +67,6 @@ class TimeEntryEditorWidget : public QWidget {
 
     bool applyNewProject();
     bool eventFilter(QObject *object, QEvent *event);
-    void keyPressEvent(QKeyEvent *event);
     void toggleNewClientMode(const bool visible);
 
  private slots:  // NOLINT

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include <QListWidgetItem>
 #include <QStackedWidget>
+#include <QShortcut>
 
 #include <stdint.h>
 #include "./colorpicker.h"
@@ -61,6 +62,8 @@ class TimeEntryEditorWidget : public QWidget {
     AutocompleteListModel *descriptionModel;
     AutocompleteListModel *projectModel;
 
+    QShortcut *shortcutDelete;
+
     bool applyNewProject();
     bool eventFilter(QObject *object, QEvent *event);
     void keyPressEvent(QKeyEvent *event);
@@ -96,6 +99,8 @@ class TimeEntryEditorWidget : public QWidget {
     void setProjectColors(QVector<char *> list);
 
     void timeout();
+
+    void onShortcutDelete();
 
     void on_doneButton_clicked();
     void on_deleteButton_clicked();

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -11,6 +11,9 @@ TimeEntryListWidget::TimeEntryListWidget(QStackedWidget *parent) : QWidget(paren
 ui(new Ui::TimeEntryListWidget) {
     ui->setupUi(this);
 
+    connect(ui->list, &QListWidget::currentRowChanged, [=](int row){
+        qCritical() << row;
+    });
 
     connect(TogglApi::instance, SIGNAL(displayLogin(bool,uint64_t)),  // NOLINT
             this, SLOT(displayLogin(bool,uint64_t)));  // NOLINT
@@ -79,7 +82,7 @@ void TimeEntryListWidget::displayTimeEntryList(
 
         if (!item) {
             item = new QListWidgetItem();
-            cell = new TimeEntryCellWidget();
+            cell = new TimeEntryCellWidget(item);
 
             ui->list->addItem(item);
             ui->list->setItemWidget(item, cell);
@@ -119,7 +122,7 @@ void TimeEntryListWidget::showLoadMoreButton(int size) {
 
     if (!item) {
         item = new QListWidgetItem();
-        cell = new TimeEntryCellWidget();
+        cell = new TimeEntryCellWidget(item);
 
         ui->list->addItem(item);
         ui->list->setItemWidget(item, cell);

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -29,6 +29,10 @@ void TimeEntryListWidget::display() {
     qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
 }
 
+TimerWidget *TimeEntryListWidget::timer() {
+    return ui->timer;
+}
+
 void TimeEntryListWidget::displayLogin(
     const bool open,
     const uint64_t user_id) {

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.cpp
@@ -29,6 +29,17 @@ void TimeEntryListWidget::display() {
     qobject_cast<QStackedWidget*>(parent())->setCurrentWidget(this);
 }
 
+TimeEntryCellWidget *TimeEntryListWidget::highlightedCell() {
+    auto w = focusWidget();
+    while (w) {
+        auto cell = qobject_cast<TimeEntryCellWidget*>(w);
+        if (cell)
+            return cell;
+        w = w->parentWidget();
+    }
+    return nullptr;
+}
+
 TimerWidget *TimeEntryListWidget::timer() {
     return ui->timer;
 }

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -16,6 +16,8 @@ namespace Ui {
 class TimeEntryListWidget;
 }
 
+class TimerWidget;
+
 class TimeEntryListWidget : public QWidget {
     Q_OBJECT
 
@@ -24,6 +26,8 @@ class TimeEntryListWidget : public QWidget {
     ~TimeEntryListWidget();
 
     void display();
+
+    TimerWidget *timer();
 
  private slots:  // NOLINT
 

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.h
@@ -16,6 +16,7 @@ namespace Ui {
 class TimeEntryListWidget;
 }
 
+class TimeEntryCellWidget;
 class TimerWidget;
 
 class TimeEntryListWidget : public QWidget {
@@ -27,6 +28,7 @@ class TimeEntryListWidget : public QWidget {
 
     void display();
 
+    TimeEntryCellWidget *highlightedCell();
     TimerWidget *timer();
 
  private slots:  // NOLINT

--- a/src/ui/linux/TogglDesktop/timeentrylistwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentrylistwidget.ui
@@ -72,6 +72,9 @@
    </item>
    <item>
     <widget class="QListWidget" name="list">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAsNeeded</enum>
      </property>

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -7,6 +7,7 @@
 #include <QCompleter>  // NOLINT
 #include <QKeyEvent>  // NOLINT
 #include <QMessageBox>  // NOLINT
+#include <QKeyEvent>  // NOLINT
 
 #include "./autocompletelistmodel.h"
 #include "./autocompleteview.h"

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -23,8 +23,7 @@ timeEntryAutocompleteNeedsUpdate(false),
 descriptionModel(new AutocompleteListModel(this)),
 timeEntry(nullptr),
 selectedTaskId(0),
-selectedProjectId(0),
-shortcutDelete(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Delete), this)) {
+selectedProjectId(0) {
     ui->setupUi(this);
 
     ui->start->installEventFilter(this);
@@ -57,8 +56,6 @@ shortcutDelete(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Delete), this)) {
     connect(ui->deleteProject, &QPushButton::clicked, this, &TimerWidget::clearProject);
     connect(ui->deleteTask, &QPushButton::clicked, this, &TimerWidget::clearTask);
 
-    connect(shortcutDelete, &QShortcut::activated, this, &TimerWidget::onShortcutDelete);
-
     ui->description->setModel(descriptionModel);
     ui->taskFrame->setVisible(false);
     ui->projectFrame->setVisible(false);
@@ -74,6 +71,19 @@ TimerWidget::~TimerWidget() {
     timer->stop();
 
     delete ui;
+}
+
+void TimerWidget::deleteTimeEntry() {
+    if (guid.isEmpty())
+        return;
+
+    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
+        QMessageBox::Question,
+        "Delete this time entry?",
+        "Deleted time entries cannot be restored.",
+        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
+        TogglApi::instance->deleteTimeEntry(guid);
+    }
 }
 
 void TimerWidget::descriptionReturnPressed() {
@@ -125,19 +135,6 @@ void TimerWidget::clearTask() {
                                                 selectedTaskId,
                                                 selectedProjectId,
                                                 "");
-    }
-}
-
-void TimerWidget::onShortcutDelete() {
-    if (guid.isEmpty())
-        return;
-
-    if (timeEntry->confirmlessDelete() || QMessageBox::Ok == QMessageBox(
-        QMessageBox::Question,
-        "Delete this time entry?",
-        "Deleted time entries cannot be restored.",
-        QMessageBox::Ok|QMessageBox::Cancel).exec()) {
-        TogglApi::instance->deleteTimeEntry(guid);
     }
 }
 

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -173,7 +173,7 @@ void TimerWidget::displayRunningTimerState(
 
     ui->start->setText("Stop");
     ui->start->setStyleSheet(
-        "background-color: #e20000; color:'white'; font-weight: bold;");
+        "background-color: #e20000; color:'white'; font-weight: bold; outline:1px dashed white; outline-radius:2px; padding:1px");
 
     QString description = (te->Description.length() > 0) ?
                           te->Description : "(no description)";
@@ -245,7 +245,7 @@ void TimerWidget::displayStoppedTimerState() {
 
     ui->start->setText("Start");
     ui->start->setStyleSheet(
-        "background-color: #47bc00; color:'white'; font-weight: bold;");
+        "background-color: #47bc00; color:'white'; font-weight: bold; outline:1px dashed white; outline-radius:2px; padding:1px");
 
     if (!ui->description->hasFocus()) {
         ui->description->setEditText(descriptionPlaceholder);

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -73,6 +73,10 @@ TimerWidget::~TimerWidget() {
     delete ui;
 }
 
+QString TimerWidget::currentEntryGuid() {
+    return guid;
+}
+
 void TimerWidget::deleteTimeEntry() {
     if (guid.isEmpty())
         return;

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -24,6 +24,8 @@ class TimerWidget : public QFrame {
     explicit TimerWidget(QWidget *parent = 0);
     ~TimerWidget();
 
+    QString currentEntryGuid();
+
  public slots:
     void deleteTimeEntry();
 

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include <QLabel>
 #include <QFrame>
+#include <QShortcut>
 
 namespace Ui {
 class TimerWidget;
@@ -61,6 +62,8 @@ class TimerWidget : public QFrame {
     void clearProject();
     void clearTask();
 
+    void onShortcutDelete();
+
     void updateCoverLabel(const QString &text);
 
  private:
@@ -78,10 +81,13 @@ class TimerWidget : public QFrame {
     QVector<AutocompleteView *> timeEntryAutocompleteUpdate;
     AutocompleteListModel *descriptionModel;
 
+    TimeEntryView *timeEntry;
     uint64_t selectedTaskId;
     uint64_t selectedProjectId;
 
     QString guid;
+
+    QShortcut *shortcutDelete;
 
     void setEllipsisTextToLabel(QLabel *label, QString text);
 };

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -8,7 +8,6 @@
 #include <QTimer>
 #include <QLabel>
 #include <QFrame>
-#include <QShortcut>
 
 namespace Ui {
 class TimerWidget;
@@ -25,7 +24,8 @@ class TimerWidget : public QFrame {
     explicit TimerWidget(QWidget *parent = 0);
     ~TimerWidget();
 
- private:
+ public slots:
+    void deleteTimeEntry();
 
  signals:
     void buttonClicked();
@@ -62,8 +62,6 @@ class TimerWidget : public QFrame {
     void clearProject();
     void clearTask();
 
-    void onShortcutDelete();
-
     void updateCoverLabel(const QString &text);
 
  private:
@@ -86,8 +84,6 @@ class TimerWidget : public QFrame {
     uint64_t selectedProjectId;
 
     QString guid;
-
-    QShortcut *shortcutDelete;
 
     void setEllipsisTextToLabel(QLabel *label, QString text);
 };

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -33,7 +33,7 @@ class TimerWidget : public QFrame {
     void buttonClicked();
 
  protected:
-    void mousePressEvent(QMouseEvent *event);
+    void mousePressEvent(QMouseEvent *event) override;
     void resizeEvent(QResizeEvent *) override;
     bool eventFilter(QObject *obj, QEvent *event);
 

--- a/src/ui/linux/TogglDesktop/timerwidget.ui
+++ b/src/ui/linux/TogglDesktop/timerwidget.ui
@@ -439,7 +439,7 @@ font-size: 14px;</string>
      </property>
      <property name="minimumSize">
       <size>
-       <width>0</width>
+       <width>60</width>
        <height>57</height>
       </size>
      </property>


### PR DESCRIPTION
### 📒 Description
This PR adds the possibility to navigate all features in the application using only the keyboard

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- Tabbing in the main window behaves as expected
- It's possible to navigate the list of time entries with arrow keys (or by tabbing)
- Ctrl + Enter opens/confirms the current view in all parts of the app
- Ctrl + Delete deletes the selected time entry in all parts of the app (I thought the delete key would be more suitable for this because it is used for deleting stuff in other apps, as compared to backspace that is usually used to return somewhere)

### 👫 Relationships
Related to #2823 (PR) - should be merged first, it also implements some remarks by @IndrekV  in the comments
Follow up on #2262 (issue)
Closes #2151

### 🔎 Review hints
Check if the keyboards behave as expected everywhere

