### PR TITLE
Handle adding tags inside the app (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -498,8 +498,12 @@ void TimeEntryEditorWidget::on_tags_itemClicked(QListWidgetItem *item) {
             tags.push_back(widgetItem->text());
         }
     }
+    if (item) {
+        tags.push_back(item->text());
+    }
     tags.sort();
     QString list = tags.join("\t");
+
     if (previousTagList != list) {
         TogglApi::instance->setTimeEntryTags(guid, list);
     }

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -202,6 +202,7 @@ void TimeEntryEditorWidget::displayTimeEntryEditor(
 
         // Reset adding new client
         toggleNewClientMode(false);
+        toggleNewTagMode(false);
 
         if (focused_field_name == TogglApi::Duration) {
             ui->duration->setFocus();
@@ -440,8 +441,25 @@ void TimeEntryEditorWidget::on_dateEdit_editingFinished() {
 void TimeEntryEditorWidget::displayTags(
     QVector<GenericView*> tags) {
     ui->tags->clear();
+    QStringList tagList;
     foreach(GenericView *view, tags) {
-        QListWidgetItem *item = new QListWidgetItem(view->Name, ui->tags);
+        tagList << view->Name;
+    }
+
+    QSet<QString> actuallyAddedTags;
+    for (auto recentlyAddedTag : recentlyAddedTags) {
+        if (!recentlyAddedTag.isEmpty() && !tagList.contains(recentlyAddedTag)) {
+            tagList << recentlyAddedTag;
+        }
+        if (!recentlyAddedTag.isEmpty() && tagList.contains(recentlyAddedTag)) {
+            actuallyAddedTags.insert(recentlyAddedTag);
+        }
+    }
+    tagList.sort();
+    recentlyAddedTags = recentlyAddedTags - actuallyAddedTags;
+
+    for(auto tag : tagList) {
+        QListWidgetItem *item = new QListWidgetItem(tag, ui->tags);
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         item->setCheckState(Qt::Unchecked);
     }
@@ -458,6 +476,17 @@ void TimeEntryEditorWidget::timeout() {
         ui->duration->setText(
             TogglApi::formatDurationInSecondsHHMMSS(duration));
     }
+}
+
+void TimeEntryEditorWidget::toggleNewTagMode(bool visible) {
+    ui->addNewTagButton->setVisible(!visible);
+    ui->newTagLabel->setVisible(visible);
+    ui->newTagButton->setVisible(visible);
+    ui->newTag->setVisible(visible);
+    if (visible)
+        ui->newTag->setFocus();
+    else
+        ui->addNewTagButton->setFocus();
 }
 
 void TimeEntryEditorWidget::on_tags_itemClicked(QListWidgetItem *item) {
@@ -535,6 +564,60 @@ void TimeEntryEditorWidget::on_colorButton_clicked()
 
     colorPicker->move(newX, newY);
     colorPicker->show();
+}
+
+void TimeEntryEditorWidget::on_newTagButton_clicked() {
+    QStringList tags;
+    QStringList allTags;
+    QString newTag = ui->newTag->text();
+
+    if (!newTag.isEmpty()) {
+        ui->newTag->clear();
+        for (int i = 0; i < ui->tags->count(); i++) {
+            QListWidgetItem *widgetItem = ui->tags->item(i);
+            if (widgetItem->text() == newTag) {
+                if (widgetItem->checkState() != Qt::Checked)
+                    on_tags_itemClicked(widgetItem);
+                return;
+            }
+            allTags << widgetItem->text();
+            if (widgetItem->checkState() == Qt::Checked) {
+                tags.push_back(widgetItem->text());
+            }
+        }
+        tags.push_back(newTag);
+        tags.sort();
+        allTags.push_back(newTag);
+        allTags.sort();
+
+        QString list = tags.join("\t");
+        if (previousTagList != list) {
+            TogglApi::instance->setTimeEntryTags(guid, list);
+            recentlyAddedTags.insert(newTag);
+        }
+        previousTagList = list;
+
+        ui->tags->clear();
+        for (int i = 0; i < allTags.count(); i++) {
+            auto item = new QListWidgetItem(allTags[i], ui->tags);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            if (tags.contains(allTags[i]))
+                item->setCheckState(Qt::Checked);
+            else
+                item->setCheckState(Qt::Unchecked);
+            ui->tags->addItem(item);
+        }
+    }
+
+    QTimer::singleShot(0, [this]() { toggleNewTagMode(false); });
+}
+
+void TimeEntryEditorWidget::on_newTag_returnPressed() {
+    on_newTagButton_clicked();
+}
+
+void TimeEntryEditorWidget::on_addNewTagButton_clicked() {
+    toggleNewTagMode(true);
 }
 
 void TimeEntryEditorWidget::setProjectColors(QVector<char *> list) {

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -55,6 +55,7 @@ class TimeEntryEditorWidget : public QWidget {
     int64_t duration;
 
     QString previousTagList;
+    QSet<QString> recentlyAddedTags;
 
     TimeEntryView *timeEntry;
 
@@ -65,6 +66,7 @@ class TimeEntryEditorWidget : public QWidget {
     bool eventFilter(QObject *object, QEvent *event);
     void keyPressEvent(QKeyEvent *event);
     void toggleNewClientMode(const bool visible);
+    void toggleNewTagMode(bool visible);
 
  private slots:  // NOLINT
     void displayLogin(
@@ -113,6 +115,9 @@ class TimeEntryEditorWidget : public QWidget {
     void on_addClientButton_clicked();
     void on_cancelNewClient_clicked();
     void on_colorButton_clicked();
+    void on_newTagButton_clicked();
+    void on_newTag_returnPressed();
+    void on_addNewTagButton_clicked();
 };
 
 #endif  // SRC_UI_LINUX_TOGGLDESKTOP_TIMEENTRYEDITORWIDGET_H_

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
@@ -566,7 +566,7 @@
          <string notr="true">padding:1px;text-align:right;color:palette(link);text-decoration:underline</string>
         </property>
         <property name="text">
-         <string>Add new client</string>
+         <string>Add new tag</string>
         </property>
         <property name="flat">
          <bool>true</bool>

--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>346</width>
-    <height>595</height>
+    <width>387</width>
+    <height>674</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -328,29 +328,8 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="timeDetails" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>350</width>
-       <height>125</height>
-      </size>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetMinimumSize</enum>
-      </property>
+    <widget class="QFrame" name="tagsFrame">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,200,1">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -363,238 +342,234 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="1" column="0">
-       <widget class="QFrame" name="timeFrame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_6">
-           <property name="minimumSize">
-            <size>
-             <width>130</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>130</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Start-end time:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="start">
-           <property name="styleSheet">
-            <string notr="true">background-color:#ffffff;</string>
-           </property>
-           <property name="text">
-            <string>08:57 PM</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="timeSeparator">
-           <property name="minimumSize">
-            <size>
-             <width>18</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="stop">
-           <property name="styleSheet">
-            <string notr="true">background-color:#ffffff;</string>
-           </property>
-           <property name="text">
-            <string>09:01 PM</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QFrame" name="dateFrame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_8">
-           <property name="minimumSize">
-            <size>
-             <width>130</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>130</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Date:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDateEdit" name="dateEdit">
-           <property name="styleSheet">
-            <string notr="true">background-color:#ffffff;</string>
-           </property>
-           <property name="calendarPopup">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
+      <property name="horizontalSpacing">
+       <number>6</number>
+      </property>
       <item row="0" column="0">
-       <widget class="QFrame" name="durationFrame">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+       <widget class="QLabel" name="label_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_7">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="label_5">
-           <property name="minimumSize">
-            <size>
-             <width>130</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>130</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Duration:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="duration">
-           <property name="styleSheet">
-            <string notr="true">background-color:#ffffff;</string>
-           </property>
-           <property name="text">
-            <string>00:03:05</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="tagsWidget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>15</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="label_3">
         <property name="minimumSize">
          <size>
-          <width>116</width>
+          <width>0</width>
           <height>0</height>
          </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Duration:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="duration">
+        <property name="styleSheet">
+         <string notr="true">background-color:#ffffff;</string>
+        </property>
+        <property name="text">
+         <string>00:03:05</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Start-end time:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLineEdit" name="start">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background-color:#ffffff;</string>
+          </property>
+          <property name="text">
+           <string>08:57 PM</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="timeSeparator">
+          <property name="minimumSize">
+           <size>
+            <width>18</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="stop">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background-color:#ffffff;</string>
+          </property>
+          <property name="text">
+           <string>09:01 PM</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Date:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QDateEdit" name="dateEdit">
+        <property name="styleSheet">
+         <string notr="true">background-color:#ffffff;</string>
+        </property>
+        <property name="calendarPopup">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="tagsLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
         <property name="text">
          <string>Tags:</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
        </widget>
       </item>
-      <item>
+      <item row="3" column="1" colspan="2">
        <widget class="QListWidget" name="tags">
         <property name="styleSheet">
          <string notr="true">background-color:#ffffff;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="newTagLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>New Tag:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="newTag">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">background-color: white;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QPushButton" name="newTagButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QPushButton" name="addNewTagButton">
+        <property name="styleSheet">
+         <string notr="true">padding:1px;text-align:right;color:palette(link);text-decoration:underline</string>
+        </property>
+        <property name="text">
+         <string>Add new client</string>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -789,6 +764,9 @@
   <tabstop>stop</tabstop>
   <tabstop>dateEdit</tabstop>
   <tabstop>tags</tabstop>
+  <tabstop>newTag</tabstop>
+  <tabstop>newTagButton</tabstop>
+  <tabstop>addNewTagButton</tabstop>
   <tabstop>billable</tabstop>
   <tabstop>doneButton</tabstop>
   <tabstop>deleteButton</tabstop>


### PR DESCRIPTION
### 📒 Description
A hacky, workaround-y solution that stores the newly created tags until they actually come from the server side.

This is to prevent them being overwritten (and flashing) inside the app, because after creating a new tag, the library or the backend sends multiple updates with old ones before they start to contain the newly created one.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Adding tags is now possible inside the Linux app
- Spacing and layout inside the Linux Time Entry edit view is now more consistent

### 👫 Relationships
Closes #1973

### 🔎 Review hints
Check if tags are added correctly and the UI behaves as expected

