### PR TITLE
Fix/offline state

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -26,6 +26,7 @@
 #define kMaxTagsPerTimeEntry 50
 #define kMinimumAllowedYear 2006
 #define kMaximumAllowedYear 2030
+#define kMaximumDescriptionLength 3000
 
 #define kLostPasswordURL "https://toggl.com/forgot-password?desktop=true"
 #define kGeneralSupportURL "https://support.toggl.com/toggl-on-my-desktop/"
@@ -42,7 +43,9 @@
 #define kMaxTagsPerTimeEntryError "Tags are limited to 50 per task"
 #define kInvalidStartTimeError "Start time year must be between 2006 and 2030"
 #define kInvalidStopTimeError "Stop time year must be between 2006 and 2030"
+#define kInvalidDateError "Date year must be between 2006 and 2030"
 #define kStartNotBeforeStopError "Stop time must be after start time"
+#define kMaximumDescriptionLengthError "Maximum length for description (3000 chars) exceeded"
 
 #define kCheckYourSignupError "Signup failed - please check your details. The e-mail might be already taken."  // NOLINT
 #define kEndpointGoneError "The API endpoint used by this app is gone. Please contact Toggl support!"  // NOLINT

--- a/src/const.h
+++ b/src/const.h
@@ -22,6 +22,10 @@
 #define kTimelineUploadIntervalSeconds 60
 #define kTimelineUploadMaxBackoffSeconds (kTimelineUploadIntervalSeconds * 10)  // NOLINT
 #define kMaxFileSize 5242880  // 5MB
+#define kMaxDurationSeconds (999 * 3600)
+#define kMaxTagsPerTimeEntry 50
+#define kMinimumAllowedYear 2006
+#define kMaximumAllowedYear 2030
 
 #define kLostPasswordURL "https://toggl.com/forgot-password?desktop=true"
 #define kGeneralSupportURL "https://support.toggl.com/toggl-on-my-desktop/"
@@ -32,6 +36,13 @@
 
 #define kContentTypeMultipartFormData "multipart/form-data"
 #define kContentTypeApplicationJSON "application/json"
+
+// Data validation errors
+#define kOverMaxDurationError "Max allowed duration per 1 time entry is 999 hours"
+#define kMaxTagsPerTimeEntryError "Tags are limited to 50 per task"
+#define kInvalidStartTimeError "Start time year must be between 2006 and 2030"
+#define kInvalidStopTimeError "Stop time year must be between 2006 and 2030"
+#define kStartNotBeforeStopError "Stop time must be after start time"
 
 #define kCheckYourSignupError "Signup failed - please check your details. The e-mail might be already taken."  // NOLINT
 #define kEndpointGoneError "The API endpoint used by this app is gone. Please contact Toggl support!"  // NOLINT

--- a/src/context.cc
+++ b/src/context.cc
@@ -2897,7 +2897,7 @@ error Context::SetTimeEntryDate(
             Poco::Timestamp::fromEpochTime(te->Start()));
 
         // Validate date input
-        if (date_part.year() < kMinimumAllowedYear || date_part.year() > kMinimumAllowedYear) {
+        if (date_part.year() < kMinimumAllowedYear || date_part.year() > kMaximumAllowedYear) {
             return displayError(error(kInvalidDateError));
         }
 
@@ -2953,7 +2953,7 @@ error Context::SetTimeEntryStart(
     Poco::LocalDateTime local(Poco::Timestamp::fromEpochTime(te->Start()));
 
     // Validate time input
-    if (local.year() < kMinimumAllowedYear || local.year() > kMinimumAllowedYear) {
+    if (local.year() < kMinimumAllowedYear || local.year() > kMaximumAllowedYear) {
         return displayError(error(kInvalidStartTimeError));
     }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -4358,6 +4358,7 @@ void Context::syncerActivity() {
                 err = pushChanges(&client, &trigger_sync_);
                 trigger_push_ = false;
                 if (err != noError) {
+                    user_->ConfirmLoadedMore();
                     displayError(err);
                     return;
                 } else {
@@ -4385,6 +4386,7 @@ void Context::syncerActivity() {
 
                 error err = pushChanges(&client, &trigger_sync_);
                 if (err != noError) {
+                    user_->ConfirmLoadedMore();
                     displayError(err);
                 } else {
                     setOnline("Data pushed");
@@ -4709,6 +4711,8 @@ error Context::pushChanges(
                 api_token,
                 *toggl_client);
             if (err != noError) {
+                // Hide load more button when offline
+                user_->ConfirmLoadedMore();
                 // Reload list to show unsynced icons in items
                 UIElements render;
                 render.display_time_entries = true;

--- a/src/context.cc
+++ b/src/context.cc
@@ -4709,6 +4709,10 @@ error Context::pushChanges(
                 api_token,
                 *toggl_client);
             if (err != noError) {
+                // Reload list to show unsynced icons in items
+                UIElements render;
+                render.display_time_entries = true;
+                updateUI(render);
                 return err;
             }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -2788,7 +2788,7 @@ error Context::SetTimeEntryDuration(
 
     // validate the value
     int seconds = Formatter::ParseDurationString(duration);
-    if (seconds > kMaxDurationSeconds) {
+    if (seconds >= kMaxDurationSeconds) {
         return displayError(error(kOverMaxDurationError));
     }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -4351,14 +4351,15 @@ void Context::syncerActivity() {
                 error err = pullAllUserData(&client);
                 if (err != noError) {
                     displayError(err);
-                    return;
                 }
 
                 setOnline("Data pulled");
 
                 err = pushChanges(&client, &trigger_sync_);
+                trigger_push_ = false;
                 if (err != noError) {
                     displayError(err);
+                    return;
                 } else {
                     setOnline("Data pushed");
                 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -2786,6 +2786,12 @@ error Context::SetTimeEntryDuration(
         return logAndDisplayUserTriedEditingLockedEntry();
     }
 
+    // validate the value
+    int seconds = Formatter::ParseDurationString(duration);
+    if (seconds > kMaxDurationSeconds) {
+        return displayError(error(kOverMaxDurationError));
+    }
+
     te->SetDurationUserInput(duration);
     return displayError(save());
 }
@@ -2890,6 +2896,11 @@ error Context::SetTimeEntryDate(
         Poco::LocalDateTime time_part(
             Poco::Timestamp::fromEpochTime(te->Start()));
 
+        // Validate date input
+        if (date_part.year() < kMinimumAllowedYear || date_part.year() > kMinimumAllowedYear) {
+            return displayError(error(kInvalidDateError));
+        }
+
         dt = Poco::LocalDateTime(
             date_part.year(), date_part.month(), date_part.day(),
             time_part.hour(), time_part.minute(), time_part.second());
@@ -2940,6 +2951,11 @@ error Context::SetTimeEntryStart(
     }
 
     Poco::LocalDateTime local(Poco::Timestamp::fromEpochTime(te->Start()));
+
+    // Validate time input
+    if (local.year() < kMinimumAllowedYear || local.year() > kMinimumAllowedYear) {
+        return displayError(error(kInvalidStartTimeError));
+    }
 
     int hours(0), minutes(0);
     if (!toggl::Formatter::ParseTimeInput(value, &hours, &minutes)) {
@@ -3127,6 +3143,11 @@ error Context::SetTimeEntryDescription(
         if (isTimeEntryLocked(te)) {
             return logAndDisplayUserTriedEditingLockedEntry();
         }
+    }
+
+    // Validate description length
+    if (value.length() > kMaximumDescriptionLength) {
+        return displayError(error(kMaximumDescriptionLengthError));
     }
 
     te->SetDescription(value);

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -372,7 +372,7 @@ int Formatter::ParseDurationString(const std::string value) {
     if (input.find(".") == std::string::npos) {
         Poco::Int64 minutes = 0;
         if (Poco::NumberParser::tryParse64(input, minutes)) {
-            if (minutes > kMaxDurationSeconds) {
+            if ((minutes * 60) > kMaxDurationSeconds) {
                 return kMaxDurationSeconds;
             }
             return static_cast<int>(seconds + (minutes * 60));

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -370,9 +370,12 @@ int Formatter::ParseDurationString(const std::string value) {
 
     // 15
     if (input.find(".") == std::string::npos) {
-        int minutes = 0;
-        if (Poco::NumberParser::tryParse(input, minutes)) {
-            return seconds + (minutes * 60);
+        Poco::Int64 minutes = 0;
+        if (Poco::NumberParser::tryParse64(input, minutes)) {
+            if (minutes > kMaxDurationSeconds) {
+                return kMaxDurationSeconds;
+            }
+            return static_cast<int>(seconds + (minutes * 60));
         }
     }
 


### PR DESCRIPTION
### 📒 Description
App should work offline exactly the same as online. No functionality should be missing. This mostly goes to data validation and syncing errors.

### 🕶️ Types of changes

**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Render entries list right away after sync fails. This means that you see unsynced icons right when the sync fails
- ... To be added

### 👫 Relationships

Closes #2884

### 🔎 Review hints

- Turn off internet connection
- Do a bunch of actions. (edit entries, start, stop, delete)
- See if unsynced icons are shown properly. Or if validation errors are displayed.
- If the internet is turned off the app should show unsynced icons for entries right after app start
- The app should not allow saving duration larger than 999 hrs. (3 596 400 seconds). It makes the duration 999hrs if the value is bigger.
- Error should be shown if the selected date is not between the year 2006 and 2030.
- Error should be shown if the description text is longer than 3000 characters.