### PR TITLE
Fix Crash when filtering text in AutoComplete #2872 (windows)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/AutoCompleteController.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/AutoCompletion/AutoCompleteController.cs
@@ -365,7 +365,7 @@ namespace TogglDesktop.AutoCompletion
                 return;
 
             var i = this.selectedIndex + 1;
-            if (i == this.visibleItems.Count)
+            if (i >= this.visibleItems.Count)
             {
                 i = 0;
                 LB.UpdateLayout();
@@ -387,7 +387,7 @@ namespace TogglDesktop.AutoCompletion
                 return;
 
             var i = this.selectedIndex - 1;
-            if (i < 0)
+            if (i < 0 || i >= this.visibleItems.Count)
             {
                 i = this.visibleItems.Count - 1;   
             }


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
There was an error during autocomplete in case when index of previously selected item was higher than the number of items after the updated filtering. Pressing up/down caused the crash.
The fix adds the check for the case when index is higher than the items count.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2872, #2508 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

