### PR TITLE
Fix cursor placement issue #2097 (windows)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/SharedStyles.xaml
@@ -37,13 +37,11 @@
                                     BorderThickness="{TemplateBinding BorderThickness}">
 
                         <ScrollViewer 
-                                    Cursor="IBeam"
                                     Padding="{TemplateBinding Padding}"
                                     BorderThickness="0" 
                                     IsTabStop="False" 
                                     Margin="2" 
                                     Background="{x:Null}"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
 
                             <Decorator 


### PR DESCRIPTION
### 📒 Description
This PR fixes the issue with the TextBox when clicking to the right of the text did not change the cursor placement.
<!-- Describe your changes in detail -->

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
Closes #2097, #1862 
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
This change affects the base TextBox style of the application, but it is actually used only in EditView, other windows have their own styles. I did check all TextBoxes anyway, but you can also have a look just in case.

HorizontalAlignment of the ScrollViewer in TextBox's template has to be "Stretch" (default value) in order for the cursor placement to work properly. Setting HorizontalContentAlignment for TextBox still works properly, apparently it applies to a more internal element of the native template.

Overriding of cursor icon was removed so that the user is not fooled by thinking that cursor can be placed somewhere where it actually can not. This currently affects 2px of margin at the edges of the TextBox and 16px of margin to the right of the "tags" textboxes in the EditView. 

<!-- Tips to the reviewer about how this should be tested -->

