### PR TITLE
Fix for Cursor Changing Text Field While an Entry is Still Syncing #2466 (windows)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/EditViewPopup.xaml.cs
@@ -56,7 +56,12 @@ namespace TogglDesktop
                 }
 
                 this.Show();
-                this.EditView.FocusField(focusedFieldName);
+
+                // focus field only if the edit popup was just open
+                if (open)
+                {
+                    this.EditView.FocusField(focusedFieldName);
+                }
             }
         }
 


### PR DESCRIPTION
### 📒 Description
Cursor will now change focus to some field in Edit popup only in combination when opening the Edit popup, so no jumping occurs for the user.

Fix also looks similar to what I've found in OS X code:
`if (self.cmd.open) { [self setFocus:nil]; }`
<!-- Describe your changes in detail -->

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2466 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

