### PR TITLE
clear undo history when switching between time entries (windows)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using Hardcodet.Wpf.TaskbarNotification;
 using Hardcodet.Wpf.TaskbarNotification.Interop;
@@ -111,6 +112,11 @@ static class UIExtensions
         }
     }
 
+    public static void ClearUndoHistory(this TextBoxBase textBox)
+    {
+        textBox.IsUndoEnabled = false;
+        textBox.IsUndoEnabled = true;
+    }
 
     public static int CountSubstrings(this string s, string searchString)
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TagList.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TagList.xaml.cs
@@ -182,6 +182,11 @@ namespace TogglDesktop
             return this.tags.ContainsKey(tag);
         }
 
+        public void ClearUndoHistory()
+        {
+            this.textBox.ClearUndoHistory();
+        }
+
         private void autoComplete_OnConfirmCompletion(object sender, AutoCompleteItem e)
         {
             var asStringItem = e as StringItem;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -99,6 +99,8 @@ namespace TogglDesktop
                     this.confirmNewProject();
                 }
 
+                var isDifferentTimeEntry = this.timeEntry.GUID != timeEntry.GUID;
+
                 this.timeEntry = timeEntry;
 
                 var isCurrentlyRunning = timeEntry.DurationInSeconds < 0;
@@ -110,6 +112,10 @@ namespace TogglDesktop
                 setTime(this.startTimeTextBox, timeEntry.StartTimeString, open);
                 setTime(this.endTimeTextBox, timeEntry.EndTimeString, open);
                 this.startDatePicker.SelectedDate = Toggl.DateTimeFromUnix(timeEntry.Started);
+                if (isDifferentTimeEntry)
+                {
+                    this.clearUndoHistory();
+                }
 
                 if (isCurrentlyRunning)
                 {
@@ -1053,6 +1059,15 @@ namespace TogglDesktop
             {
                 return this.timeEntry.DurationInSeconds < 15;
             }
+        }
+
+        private void clearUndoHistory()
+        {
+            descriptionTextBox.ClearUndoHistory();
+            startTimeTextBox.ClearUndoHistory();
+            endTimeTextBox.ClearUndoHistory();
+            durationTextBox.ClearUndoHistory();
+            tagList.ClearUndoHistory();
         }
 
         #endregion


### PR DESCRIPTION
### 📒 Description
Erases the undo history of textboxes in the Edit View when the user is opening a time entry which differs from the previous open time entry.
<!-- Describe your changes in detail -->

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

 **Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2409 

### 🔎 Review hints
For ComboBox and DatePicker there is no public API to erase the undo history. There are hacky ways to do it even for these, either by finding necessary element in the visual tree or via reflection. 
I haven't applied the fix to those because I believe people are rarely using Ctrl+Z with ComboBox or DatePicker, but if necessary I can add a fix to them as well.
<!-- Tips to the reviewer about how this should be tested -->

