### PR TITLE
Feature/gray out controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ src/ui/windows/TogglDesktop/TogglDesktopUpdater/bin
 src/lib/windows/TogglDesktopDLL/Debug
 src/lib/windows/TogglDesktopDLL/Release_VS
 src/lib/windows/TogglDesktopDLL/Release
+src/ui/windows/TogglDesktop/.vs
 
 *.dSYM
 
@@ -164,3 +165,10 @@ src/ui/windows/TogglDesktop/TogglDesktopDLLInteropTest/bin
 
 # Qt Creator
 .*.swp
+
+# poco binaries
+third_party/poco/bin
+third_party/poco/lib
+
+# Resharper user settings
+*.DotSettings.user

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/PreferencesWindowStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/PreferencesWindowStyles.xaml
@@ -94,6 +94,9 @@
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="border" Property="Background" Value="#F4F4F4"/>
                                 </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="checkMark" Property="Stroke" Value="Gray"/>
+                                </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -241,7 +241,7 @@
                     </Grid.RowDefinitions>
                     <CheckBox Name="enableAutotrackerCheckbox" x:FieldModifier="private"
                               Grid.Row="0" Margin="5" Content="Enable autotracker"/>
-                    <toggl:AutotrackerSettings Grid.Row="1" Margin="5" />
+                    <toggl:AutotrackerSettings Grid.Row="1" Margin="5" IsEnabled="{Binding ElementName=enableAutotrackerCheckbox, Path=IsChecked}"/>
                 </Grid>
             </TabItem>
             <TabItem Header="REMINDER">
@@ -253,14 +253,16 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <CheckBox Name="remindToTrackCheckBox" x:FieldModifier="private"
                                       Grid.Column="0" Grid.Row="0" Margin="5">Remind me to track time every</CheckBox>
-                    <TextBlock Grid.Column="0" Grid.Row="1" Margin="5">Reminder start time</TextBlock>
-                    <TextBlock Grid.Column="0" Grid.Row="2" Margin="5">Reminder end time</TextBlock>
-                    <TextBlock Grid.Column="0" Grid.Row="3" Margin="5">Reminder days</TextBlock>
+
+                    <StackPanel Grid.Row="1"
+                                IsEnabled="{Binding ElementName=remindToTrackCheckBox, Path=IsChecked}">
+                        <TextBlock Margin="5">Reminder start time</TextBlock>
+                        <TextBlock Margin="5">Reminder end time</TextBlock>
+                        <TextBlock Margin="5">Reminder days</TextBlock>
+                    </StackPanel>
 
                     <Grid Grid.Column="1" Grid.Row="0" Margin="5" HorizontalAlignment="Right"
                                   IsEnabled="{Binding ElementName=remindToTrackCheckBox, Path=IsChecked}">
@@ -273,29 +275,32 @@
                         <TextBlock Grid.Column="1" Margin="4 0 0 0">minutes</TextBlock>
                     </Grid>
 
-                    <TextBox Name="reminderStartTimeTextBox" x:FieldModifier="private"
-                                     Grid.Column="1" Grid.Row="1" Margin="5"
-                                 Width="50" HorizontalContentAlignment="Right"
+                    <StackPanel Grid.Row="1" Grid.Column="1"
+                                IsEnabled="{Binding ElementName=remindToTrackCheckBox, Path=IsChecked}">
+                        <TextBox Name="reminderStartTimeTextBox" x:FieldModifier="private"
+                                 Margin="5" Width="50"
+                                 HorizontalContentAlignment="Right"
                                  HorizontalAlignment="Left">8:30</TextBox>
-                    <TextBox Name="reminderEndTimeTextBox" x:FieldModifier="private"
-                                     Grid.Column="1" Grid.Row="2" Margin="5"
-                                 Width="50" HorizontalContentAlignment="Right"
+                        <TextBox Name="reminderEndTimeTextBox" x:FieldModifier="private"
+                                 Margin="5" Width="50"
+                                 HorizontalContentAlignment="Right"
                                  HorizontalAlignment="Left">16:30</TextBox>
-                    <StackPanel Grid.Column="1" Grid.Row="3" Margin="3">
-                        <CheckBox Name="remindOnMondayTextBox" x:FieldModifier="private"
-                                          Margin="2">Mon</CheckBox>
-                        <CheckBox Name="remindOnTuesdayTextBox" x:FieldModifier="private"
-                                          Margin="2">Tue</CheckBox>
-                        <CheckBox Name="remindOnWednesdayTextBox" x:FieldModifier="private"
-                                          Margin="2">Wed</CheckBox>
-                        <CheckBox Name="remindOnThursdayTextBox" x:FieldModifier="private"
-                                          Margin="2">Thu</CheckBox>
-                        <CheckBox Name="remindOnFridayTextBox" x:FieldModifier="private"
-                                          Margin="2">Fri</CheckBox>
-                        <CheckBox Name="remindOnSaturdayTextBox" x:FieldModifier="private"
-                                          Margin="2">Sat</CheckBox>
-                        <CheckBox Name="remindOnSundayTextBox" x:FieldModifier="private"
-                                          Margin="2">Sun</CheckBox>
+                        <StackPanel Margin="3">
+                            <CheckBox Name="remindOnMondayTextBox" x:FieldModifier="private"
+                                      Margin="2">Mon</CheckBox>
+                            <CheckBox Name="remindOnTuesdayTextBox" x:FieldModifier="private"
+                                      Margin="2">Tue</CheckBox>
+                            <CheckBox Name="remindOnWednesdayTextBox" x:FieldModifier="private"
+                                      Margin="2">Wed</CheckBox>
+                            <CheckBox Name="remindOnThursdayTextBox" x:FieldModifier="private"
+                                      Margin="2">Thu</CheckBox>
+                            <CheckBox Name="remindOnFridayTextBox" x:FieldModifier="private"
+                                      Margin="2">Fri</CheckBox>
+                            <CheckBox Name="remindOnSaturdayTextBox" x:FieldModifier="private"
+                                      Margin="2">Sat</CheckBox>
+                            <CheckBox Name="remindOnSundayTextBox" x:FieldModifier="private"
+                                      Margin="2">Sun</CheckBox>
+                        </StackPanel>
                     </StackPanel>
                 </Grid>
             </TabItem>


### PR DESCRIPTION
…racking/reminding is disabled #2904 (windows)

### 📒 Description
<!-- Describe your changes in detail -->
Make all the controls in the Autotracker tab disabled when the "Enable autotracker" checkbox is unchecked.
Make all the controls in the Reminder tab disabled when "Remind me to track time" checkbox is unchecked.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->

**Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
- IsEnabled property is set to False for all the controls that should be disabled.
- Disabled checkbox style - Gray color for the checkmark (default Windows color which is used in Disabled styles for other controls like textboxes, textblocks, etc.)
- Updated .gitignore for more convenient work with Windows dev setup

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2904 

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Only UI changes in Autotracker and Reminder tabs.
