### PR TITLE
Focus jump on Time Editor if there is any running entry

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -840,9 +840,6 @@ void Context::updateUI(const UIElements &what) {
     // Render data
     if (what.display_time_entry_editor
             && !editor_time_entry_view.GUID.empty()) {
-        if (what.open_time_entry_editor) {
-            UI()->DisplayApp();
-        }
         UI()->DisplayTags(tag_views);
         UI()->DisplayTimeEntryEditor(
             what.open_time_entry_editor,

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -190,10 +190,13 @@ NSString *kInactiveTimerColor = @"#999999";
 	{
 		// Start/stop button title and color depend on
 		// whether time entry is running
+		if (self.displayMode == DisplayModeManual)
+		{
+			toggl_set_settings_manual_mode(ctx, NO);
+		}
 		self.displayMode = DisplayModeTimer;
 		self.startButton.toolTip = @"Stop";
 		self.startButton.state = NSOnState;
-		toggl_set_settings_manual_mode(ctx, NO);
 
 		[self.durationTextField setDelegate:self];
 		// Time entry has a description

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1103,8 +1103,6 @@ BOOL onTop = NO;
 - (IBAction)onShowMenuItem:(id)sender
 {
 	[self.mainWindowController showWindow:self];
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
-																object:nil];
 	[NSApp activateIgnoringOtherApps:YES];
 }
 

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1103,6 +1103,8 @@ BOOL onTop = NO;
 - (IBAction)onShowMenuItem:(id)sender
 {
 	[self.mainWindowController showWindow:self];
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
+																object:nil];
 	[NSApp activateIgnoringOtherApps:YES];
 }
 


### PR DESCRIPTION
### 📒 Description
- Continue from #2854 PR, it's completely fixed for Focus Jump whether there is any running jump.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Don't override the TimerMode when the running entry is running. If there is any running entry, the Desktop Library constantly posts `kDisplayTimerState`, and it accidentally override the TimerMode Setting. Thus, it focus to the Timer Bar again -> Lost jump focus if we're editing
- [x] Remove focus jump when selecting different TimeEntry if the Editor is opening.

### 👫 Relationships
Related to PR #2854

### 🔎 Review hints
- There is no jump any more in 2 scenarios: No running entry and running entry.
