### PR TITLE
Incorrect selected on the first Time Entry

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -520,24 +520,21 @@ extern void *ctx;
 		return nil;
 	}
 
-	NSView *latestView = [self.timeEntriesTableView rowViewAtRow:row
-												 makeIfNecessary  :YES];
+	NSView *cellView = [self.timeEntriesTableView viewAtColumn:0 row:row makeIfNecessary:YES];
 
-	if (latestView == nil)
+	if (cellView == nil)
 	{
 		return nil;
 	}
 
 	self.selectedEntryCell = nil;
 
-	for (NSView *subview in [latestView subviews])
+	if ([cellView isKindOfClass:[TimeEntryCell class]] || [cellView isKindOfClass:[TimeEntryCellWithHeader class]])
 	{
-		if ([subview isKindOfClass:[TimeEntryCell class]] || [subview isKindOfClass:[TimeEntryCellWithHeader class]])
-		{
-			self.selectedEntryCell = (TimeEntryCell *)subview;
-			return self.selectedEntryCell;
-		}
+		self.selectedEntryCell = (TimeEntryCell *)cellView;
+		return self.selectedEntryCell;
 	}
+
 	return nil;
 }
 


### PR DESCRIPTION
### 📒 Description
There are many [reports](https://github.com/toggl/toggldesktop/issues/2933) that the users couldn't select the first Time Entry after using the app awhile.

This bug isn't 100% reproducible, it took me couple minutes to reproduce it by playing around the app (create new Time Entry, select different row, open/close popover, ...)

### Problem
After carefully investigation, it turns out that this following logic will return wrong cell. 
Although the `row = 0`, but the `RowView` isn't the first row. It's the second row during debugging.
https://github.com/toggl/toggldesktop/blob/9077fd0aa5ef2a9ed464cd52aae2fd5b81f38ec9/src/ui/osx/TogglDesktop/TimeEntryListViewController.m#L523-L524

I believe that this logic isn't the good way to get the cellRow from given row index. 

### Solution
By using `-[NSTableView viewAtColumn:row:makeIfNecessary]`, we can get the cell directly.
```objc
NSView *cellView = [self.timeEntriesTableView viewAtColumn:0 row:row makeIfNecessary:YES];
```
=> The bug is gone.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Replace the `[NSTableView rowViewAtRow:]` with `-[NSTableView viewAtColumn:row:makeIfNecessary]`

### 👫 Relationships
Closes #2933 

### 🔎 Review hints
- Select first Time Entry should open the Time Popover correctly.

### Warning
In the master, we don't use old `TimeEntryListViewController.m` anymore, so this bug doesn't affect on the version in `master`, which has new Time Entry design.

So, if we gonna release the hot-fix for `v.7.4.373`, we could merge this ticket. Otherwise, we can close it, since it's unnecessary @IndrekV 