### PR TITLE
Filter autocomplete based on entered text when setting controller if …

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
@@ -202,7 +202,7 @@ namespace TogglDesktop
             this.controller = controller;
             this.needsToRefreshList = true;
             if (this.popup.IsOpen)
-                this.ensureList();
+                this.open(true);
         }
 
         public void OpenAndShowAll()


### PR DESCRIPTION
…autocomplete popup is currently open #2839 (win)

### 📒 Description
When autocomplete is open and the library sends UI update request it resets the controller for auto completion popup, which makes the popup show entire updated list without applied filtering.

The fix is to apply to the list coming from UI update request the same filtering that is already applied to the existing autocompletion popup.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2839, #2589.
<!-- Mention your Issue or other PR, which connects with this PR -->

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
Steps to reproduce are in https://github.com/toggl/toggldesktop/issues/2839 (may not reproduce every time, have to click really fast)