### PR TITLE
Fixed updating timer after start stop actions with global shortcuts

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -95,6 +95,10 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(startDisplayLogin:)
 													 name:kDisplayLogin
 												   object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(stop:)
+													 name:kCommandStop
+												   object:nil];
 
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
@@ -164,6 +168,13 @@ NSString *kInactiveTimerColor = @"#999999";
 - (void)startDisplayTimerState:(NSNotification *)notification
 {
 	[self displayTimerState:notification.object];
+}
+
+- (void)stop:(NSNotification *)notification
+{
+	self.descriptionLabel.editable = NO;
+	[self clear];
+	[self showDefaultTimer];
 }
 
 - (void)displayTimerState:(TimeEntryViewItem *)te
@@ -330,9 +341,6 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 	if (self.time_entry.duration_in_seconds < 0)
 	{
-		self.descriptionLabel.editable = NO;
-		[self clear];
-		[self showDefaultTimer];
 		[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandStop
 																	object:nil];
 		return;


### PR DESCRIPTION
…mac), #2961

### 📒 Description
Fixes the issue where timer state was not updated when doing actions with global shortcuts.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)
**New feature** (non-breaking change which adds functionality)
**Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
Moved timer clear actions to `kCommandStop` notification so timer is always cleared when stop is triggered

### 👫 Relationships
Closes #2961 

### 🔎 Review hints
Define global shortcut for start/stop.
Do actions with start/stop global keyboard shortcuts and see how they work.

Try starting and stopping entries from menubar menu.

