### PR TITLE
Fix for Windows app crash when pressing Left arrow key #2959 (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
@@ -274,7 +274,11 @@ namespace TogglDesktop
             if (this.selectedDay != null)
                 return false;
 
-            this.keyboardHighlightedCell.DayHeader.Collapse();
+            if (this.keyboardSelectedId >= 0 && this.keyboardSelectedId < cells.Count)
+            {
+                this.keyboardHighlightedCell.DayHeader.Collapse();
+            }
+
             this.refreshKeyboardHighlight();
 
             return true;


### PR DESCRIPTION
### 📒 Description
Simple fix. Indexer was called directly through the keyboardHighlightedCell property without the boundary check.
<!-- Describe your changes in detail -->

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2959.

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

