### PR TITLE
Disable autocomplete in Description if the timer is running

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -424,7 +424,6 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.autoCompleteInput.stringValue = self.time_entry.Description;
 
 	// Make descriptionLabel is editable and focus
-	self.descriptionLabel.editable = YES;
 	self.descriptionLabel.stringValue = self.time_entry.Description;
 	self.displayMode = DisplayModeTimer;
 	[self.view.window makeFirstResponder:self.descriptionLabel];

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -239,6 +239,7 @@ NSString *kInactiveTimerColor = @"#999999";
 		}
 
 		self.durationTextField.toolTip = [NSString stringWithFormat:@"Started: %@", self.time_entry.startTimeString];
+		self.descriptionLabel.editable = NO;
 	}
 	else
 	{
@@ -424,6 +425,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.autoCompleteInput.stringValue = self.time_entry.Description;
 
 	// Make descriptionLabel is editable and focus
+	self.descriptionLabel.editable = (item.Type != 0);
 	self.descriptionLabel.stringValue = self.time_entry.Description;
 	self.displayMode = DisplayModeTimer;
 	[self.view.window makeFirstResponder:self.descriptionLabel];


### PR DESCRIPTION
### 📒 Description
There is a confusing behavior that the AutoComplete appears during the Timer is active

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Disable editable capability of Description AutoComplete

### 👫 Relationships
Close #2957 

### 🔎 Review hints
- The autocomplete won't show if the timer is running 
- The Editor popover presents -> Able to type the name of Time Entry 
