### PR TITLE
Fix UnixFromDateTime method to properly account for time zone and day…

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -19,9 +19,9 @@ public static partial class Toggl
     public const string Description = "description";
 
     public const string TagSeparator = "\t";
-
-    private static readonly DateTime UnixEpoch =
-        new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    
+    private static readonly DateTimeOffset UnixEpoch = 
+        new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
     private static IntPtr ctx = IntPtr.Zero;
 
@@ -1366,12 +1366,12 @@ public static partial class Toggl
 
     public static DateTime DateTimeFromUnix(UInt64 unix_seconds)
     {
-        return UnixEpoch.AddSeconds(unix_seconds).ToLocalTime();
+        return UnixEpoch.AddSeconds(unix_seconds).ToLocalTime().DateTime;
     }
 
     public static Int64 UnixFromDateTime(DateTime value)
     {
-        TimeSpan span = (value - UnixEpoch.ToLocalTime());
+        var span = new DateTimeOffset(value) - UnixEpoch;
         return (Int64)span.TotalSeconds;
     }
 


### PR DESCRIPTION
…light savings data (win)

### 📒 Description
`UnixFromDateTime` method was not working correctly when there was a different local time zone offset between 1st of January and the date of current time entry.
Current `UnixEpoch` was converted to local time and subtracted from local `DateTime`. This is a logical error, as there is no guarantee that `UnixEpoch` local time conversion produces the same time zone offset as local `DateTime` currently has. The subtraction should be performed in UTC.

The .NET `DateTimeOffset` actually represents a `DateTime` + offset, not just some offset as its name could mistakenly indicate. It is somewhat analogous to Poco's `LocalDateTime`.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2936
Closes #2561
Closes #2455
Closes #2012
Closes #2160

### 🔎 Review hints
STR described in #2936.
Try different time zones, with daylight savings on and off.
I have attempted to thoroughly test the changed code before PR, but ofc I could miss some edge case.
Known bug related to future dates: #2968.
Note: When changing time zones during the time when Visual Studio is open, building stops working, even when no code has changed and you press F5. So restarting Visual Studio for every time zone change is recommended.