### PR TITLE
initial fix for blurry text issue (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/chrome/ChromelessWindow.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/chrome/ChromelessWindow.cs
@@ -118,7 +118,7 @@ namespace TogglDesktop
             {
                 CaptionHeight = this.WindowHeaderHeight,
                 CornerRadius = new CornerRadius(0),
-                GlassFrameThickness = new Thickness(1),
+                GlassFrameThickness = new Thickness(0),
                 UseAeroCaptionButtons = false
             };
 
@@ -130,6 +130,7 @@ namespace TogglDesktop
             if (this.WindowState == WindowState.Maximized)
             {
                 chrome.ResizeBorderThickness = new Thickness(0);
+                chrome.GlassFrameThickness = new Thickness(1);
             }
 
             WindowChrome.SetWindowChrome(this, chrome);


### PR DESCRIPTION
### 📒 Description
Fixes text blurriness.
Turned out that Glass frame thickness has to be zero in order for Windows to re-enable the ClearType support.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2935 

### 🔎 Review hints
The blurry text is the easiest to reproduce when trying to write a multi-line text in a feedback window.