### PR TITLE
Make sure idle notification window hides instead of closing when pres…

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace TogglDesktop
 {
@@ -14,7 +16,7 @@ namespace TogglDesktop
         public IdleNotificationWindow()
         {
             this.InitializeComponent();
-
+            this.Closing += OnClosing;
             Toggl.OnIdleNotification += this.onIdleNotification;
             Toggl.OnStoppedTimerState += this.onStoppedTimerState;
         }
@@ -34,6 +36,13 @@ namespace TogglDesktop
             this.Show();
             this.Topmost = true;
             this.Activate();
+        }
+
+        private void OnClosing(object sender, CancelEventArgs e)
+        {
+            e.Cancel = true;
+            Action hideAction = () => this.Hide();
+            Dispatcher.BeginInvoke(DispatcherPriority.Background, hideAction);
         }
 
         protected override void OnDeactivated(EventArgs e)
@@ -60,11 +69,6 @@ namespace TogglDesktop
                 this.Hide();
                 e.Handled = true;
             }
-        }
-
-        protected override void onCloseButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.Hide();
         }
 
         private void onKeepTimeClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
…sing Alt+F4 (win)

### 📒 Description
Hides idle notification window when user tries to close it.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2429 

### 🔎 Review hints
**STR**
- Wait for idle notification window
- Close it with Alt+F4
- Wait for the time when another idle notification window should appear

**Actual Result**
Crash

Previously we only covered the case when user clicked the close button and didn't cover the Alt+F4 case, which, based on Bugsnag, caused plenty of crashes.