### PR TITLE
Get rid of XAML errors and build warning on Windows

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -199,6 +199,7 @@
       <DependentUpon>TimeEntryCellDayHeader.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\controls\TimeEntryCellDragImposter.cs" />
+    <Compile Include="ui\Converters\StringToBrushConverter.cs" />
     <Compile Include="ui\Experiments\implementations\Experiment98.cs" />
     <Compile Include="ui\Experiments\implementations\Experiment98Screen2.xaml.cs">
       <DependentUpon>Experiment98Screen2.xaml</DependentUpon>
@@ -268,7 +269,7 @@
     <Compile Include="utilities\StaticObjectPool.cs" />
     <Compile Include="TogglApi.cs" />
     <Compile Include="ui\UIExtensions.cs" />
-    <Compile Include="ui\BooleanToVisibilityConverter.cs" />
+    <Compile Include="ui\Converters\BooleanToVisibilityConverter.cs" />
     <Compile Include="ui\controls\AutotrackerNotification.xaml.cs">
       <DependentUpon>AutotrackerNotification.xaml</DependentUpon>
     </Compile>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanToVisibilityConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/BooleanToVisibilityConverter.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Data;
 
-namespace TogglDesktop
+namespace TogglDesktop.Converters
 {
     class BooleanToVisibilityConverter : IValueConverter
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/StringToBrushConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/StringToBrushConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace TogglDesktop.Converters
+{
+    class StringToBrushConverter : IValueConverter
+    {
+        public Brush OnNullOrEmpty { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var inputString = value as string;
+            return string.IsNullOrEmpty(inputString)
+                ? OnNullOrEmpty
+                : (SolidColorBrush)(new BrushConverter().ConvertFrom(inputString));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml
@@ -6,11 +6,13 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:toggl="clr-namespace:TogglDesktop.AutoCompleteControls"
              xmlns:togglautocompletion="clr-namespace:TogglDesktop.AutoCompletion"
+             xmlns:converters="clr-namespace:TogglDesktop.Converters"
              mc:Ignorable="d"
              Height="0" Width="0">
     
     <UserControl.Resources>
         <togglautocompletion:AutocompleteTemplateSelector x:Key="autocompleteTemplateSelector"/>
+        <converters:StringToBrushConverter OnNullOrEmpty="Transparent" x:Key="ProjectColorConverter" />
         <DataTemplate x:Key="project-item-template">
             <StackPanel Height="25" Orientation="Horizontal">
                 <StackPanel.Style>
@@ -64,7 +66,7 @@
                 <Border Name="projectColor"
                 CornerRadius="100" Width="6" Height="6" BorderThickness="0"
                 Margin="6, 0, 6, 0" 
-                Background="{Binding ProjectColor}"/>
+                Background="{Binding ProjectColor, Converter={StaticResource ProjectColorConverter}}"/>
                 <TextBlock Name="project" VerticalAlignment="Center" Text="{Binding ProjectLabel}" ToolTip="{Binding Text}"/>
                 <TextBlock Name="client" Foreground="DimGray" VerticalAlignment="Center" Text="{Binding ClientLabel}" ToolTip="{Binding Text}" Margin="0,0,10,0"/>
             </StackPanel>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutoCompletionPopup.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
@@ -9,7 +8,6 @@ using System.Windows.Input;
 using TogglDesktop.AutoCompleteControls;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.Diagnostics;
-using TogglDesktop.AutoCompletion.Implementation;
 
 namespace TogglDesktop
 {
@@ -30,7 +28,6 @@ namespace TogglDesktop
         private ToggleButton dropDownButton;
 
         private bool needsToRefreshList;
-        private bool mouseClickedOnListBox = false;
 
         private AutoCompleteController controller;
 
@@ -432,8 +429,6 @@ namespace TogglDesktop
 
         private void listBox_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
-            mouseClickedOnListBox = true;
-
             DependencyObject dep = (DependencyObject)e.OriginalSource;
             while ((dep != null) && !(dep is System.Windows.Controls.ListBoxItem))
             {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectColorPicker.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ProjectColorPicker.xaml
@@ -29,9 +29,7 @@
 
             <ListBox ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                      BorderThickness="0" Margin="10" Padding="0" Background="White"
-                     Name="list" x:FieldModifier="private"
-                     ItemsSource="{Binding Colors}"
-                     >
+                     Name="list" x:FieldModifier="private">
 
                 <ListBox.Effect>
                     <DropShadowEffect BlurRadius="8" ShadowDepth="2" Opacity="0.3" Direction="270" />


### PR DESCRIPTION
### 📒 Description
Fixes XAML errors mentioned in #2039 and build warning about unused variable.
No changes to functionality.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2039 

### 🔎 Review hints
Everything should work as before.
Changed binding on the project color of an autocomplete item without a project. It is "Transparent", only now it's explicitly defined.