### PR TITLE
Disable date picker for the currently running time entry #2974 (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Resources/EditViewControllerStyles.xaml
@@ -183,6 +183,11 @@
                                                     </ControlTemplate>
                                                 </Setter.Value>
                                             </Setter>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsEnabled" Value="False">
+                                                    <Setter Property="Foreground" Value="#B2252525"></Setter>
+                                                </Trigger>
+                                            </Style.Triggers>
                                         </Style>
                                     </DatePickerTextBox.Style>
                                 </DatePickerTextBox>
@@ -190,6 +195,11 @@
                                     <Button.Style>
                                         <Style TargetType="Button" BasedOn="{StaticResource EditViewTextFieldImageButtonBase}">
                                             <Setter Property="Margin" Value="0"/>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsEnabled" Value="False">
+                                                    <Setter Property="Visibility" Value="Hidden" />
+                                                </Trigger>
+                                            </Style.Triggers>
                                         </Style>
                                     </Button.Style>
                                 </Button>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -106,6 +106,7 @@ namespace TogglDesktop
                 var isCurrentlyRunning = timeEntry.DurationInSeconds < 0;
 
                 this.endTimeTextBox.IsEnabled = !isCurrentlyRunning;
+                this.startDatePicker.IsEnabled = !isCurrentlyRunning;
 
                 setText(this.descriptionTextBox, timeEntry.Description, open);
                 setTime(this.durationTextBox, timeEntry.Duration, open);


### PR DESCRIPTION
### 📒 Description
Disable date picker for the currently running time entry
Hide the calendar button when it is disabled 
Gray out the date when date picker is disabled

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #2974
