### PR TITLE
Time Entry list action is executed twice

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2438,6 +2438,7 @@ error Context::Logout() {
         overlay_visible_ = false;
         setUser(nullptr);
 
+        UI()->resetFirstLaunch();
         UI()->DisplayApp();
 
         Shutdown();

--- a/src/context.cc
+++ b/src/context.cc
@@ -2326,8 +2326,6 @@ void Context::setUser(User *value, const bool logged_in) {
 
     UI()->DisplayLogin(false, user_id);
 
-    OpenTimeEntryList();
-
     {
         Poco::Mutex::ScopedLock l(window_change_recorder_m_);
         if (window_change_recorder_) {

--- a/src/gui.h
+++ b/src/gui.h
@@ -625,6 +625,10 @@ class GUI : public SyncStateMonitor {
         }
     }
 
+    void resetFirstLaunch() {
+        isFirstLaunch = true;
+    }
+
  private:
     error findMissingCallbacks();
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -373,7 +373,8 @@ class GUI : public SyncStateMonitor {
     , lastDisplayLoginOpen(false)
     , lastDisplayLoginUserID(0)
     , lastOnlineState(-1)
-    , lastErr(noError) {}
+    , lastErr(noError)
+    , isFirstLaunch(true) {}
 
     ~GUI() {}
 
@@ -666,7 +667,7 @@ class GUI : public SyncStateMonitor {
     uint64_t lastDisplayLoginUserID;
     Poco::Int64 lastOnlineState;
     error lastErr;
-
+    bool isFirstLaunch;
     Poco::Logger &logger() const;
 };
 

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -208,7 +208,7 @@ extern void *ctx;
 - (void)displayTimeEntryList:(DisplayCommand *)cmd
 {
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	NSLog(@"TimeEntryListViewController displayTimeEntryList, thread %@", [NSThread currentThread]);
+	NSLog(@"❌ TimeEntryListViewController displayTimeEntryList, Total Count %lu, show_load_more %@", (unsigned long)cmd.timeEntries.count, cmd.show_load_more ? @"YES" : @"NO");
 
 	NSArray<TimeEntryViewItem *> *newTimeEntries = [cmd.timeEntries copy];
 


### PR DESCRIPTION
### 📒 Description
Our current implementation in Library cause the TimeEntry reloads **twice** for every following actions:
+ App Start
+ Load More button

Additionally, there is the unexpected jump when launching the app. See GIF at (https://github.com/toggl/toggldesktop/issues/2667)

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Don't reload Time Entry List when `setUser`
- [x] Render Time Entry List **once** when clicking on LoadMore
- [x] Load last 9 days from database
- [x] Able to "Load More" => ~I got the error as a SQL Constraints~
- [x] Double check on Windows and Linux

### Current Problem
~By adding https://github.com/toggl/toggldesktop/commit/73f6dcddcc4d2d1bda7957a1930e2979cb7cd088 commit, the app doesn't appear all of list anymore 💯. However, the app is no longer able to do "Load More"~

<img width="588" alt="Screen Shot 2019-05-23 at 17 13 52" src="https://user-images.githubusercontent.com/5878421/58245461-0a61a200-7d7f-11e9-9531-41d4b1cd4de7.png">

~I tried couple solution, but no one of them work without impacting to other part. @IndrekV Do you have any suggestion on that?~

This issue is fixed by https://github.com/toggl/toggldesktop/pull/2977/commits/2d7e01d7e1e6a34d398ac06c8f797421886ebb46

### 👫 Relationships
Close #2667 

### 🔎 Review hints
- Double check that only 1 TimeEntryReload action when doing two actions: Launch app and LoadMore
- No more "Jump" when launching the app