### PR TITLE
Add at least some form of backtrace generation to Bugsnag in Linux

### DIFF
--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -10,6 +10,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <iostream>
+#include <unistd.h>
 
 #include "singleapplication.h"  // NOLINT
 
@@ -18,6 +21,8 @@
 #include "./genericview.h"
 #include "./mainwindowcontroller.h"
 #include "./toggl.h"
+
+MainWindowController *w = nullptr;
 
 class TogglApplication : public SingleApplication {
  public:
@@ -40,8 +45,17 @@ bool TogglApplication::notify(QObject *receiver, QEvent *event) {
     return true;
 }
 
+[[ noreturn ]] void handler(int sig) {
+    TogglApi::notifyBugsnag("crash", "signal", "SIGSEGV");
+    delete w;
+    QApplication::exit(1);
+    exit(1);
+}
+
+
 int main(int argc, char *argv[]) try {
     Bugsnag::apiKey = "aa13053a88d5133b688db0f25ec103b7";
+    signal(SIGSEGV, handler);
 
     TogglApplication::setQuitOnLastWindowClosed(false);
 
@@ -107,19 +121,20 @@ int main(int argc, char *argv[]) try {
 
     parser.process(a);
 
-    MainWindowController w(nullptr,
-                           parser.value(logPathOption),
-                           parser.value(dbPathOption),
-                           parser.value(scriptPathOption));
+    w = new MainWindowController(nullptr,
+                                 parser.value(logPathOption),
+                                 parser.value(dbPathOption),
+                                 parser.value(scriptPathOption));
 
-    a.w = &w;
+    a.w = w;
 
     if (parser.isSet(forceOption)) {
-        w.hide();
+        w->hide();
     } else {
-        w.show();
+        w->show();
     }
 
+    signal(SIGSEGV, handler);
     return a.exec();
 } catch (std::exception &e) {  // NOLINT
     TogglApi::notifyBugsnag("std::exception", e.what(), "main");

--- a/src/ui/linux/TogglDesktop/main.cpp
+++ b/src/ui/linux/TogglDesktop/main.cpp
@@ -45,17 +45,8 @@ bool TogglApplication::notify(QObject *receiver, QEvent *event) {
     return true;
 }
 
-[[ noreturn ]] void handler(int sig) {
-    TogglApi::notifyBugsnag("crash", "signal", "SIGSEGV");
-    delete w;
-    QApplication::exit(1);
-    exit(1);
-}
-
-
 int main(int argc, char *argv[]) try {
     Bugsnag::apiKey = "aa13053a88d5133b688db0f25ec103b7";
-    signal(SIGSEGV, handler);
 
     TogglApplication::setQuitOnLastWindowClosed(false);
 
@@ -133,8 +124,6 @@ int main(int argc, char *argv[]) try {
     } else {
         w->show();
     }
-
-    signal(SIGSEGV, handler);
     return a.exec();
 } catch (std::exception &e) {  // NOLINT
     TogglApi::notifyBugsnag("std::exception", e.what(), "main");

--- a/third_party/bugsnag-qt/bugsnag.h
+++ b/third_party/bugsnag-qt/bugsnag.h
@@ -18,6 +18,11 @@
 #include <QDebug>
 #include <QNetworkReply>
 
+#include <execinfo.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 class Notifier {
  public:
     Notifier()
@@ -258,14 +263,23 @@ class BUGSNAGQTSHARED_EXPORT Bugsnag : public QObject {
         exception.message = message;
         exception.errorClass = errorClass;
 
-	// Bugsnag will reject notifications without a 
-	// stack trace. So just send something to get
-	// things going.
-        StackTrace trace;
-	trace.file = "somefile";
-	trace.lineNumber = 123;
-	trace.method = "somemethod";
-        exception.stacktrace << trace;
+        // Bugsnag will reject notifications without a
+        // stack trace. So just send something to get
+        // things going.
+        void *buffer[64];
+        char **strings;
+        int size;
+
+        size = backtrace(buffer, 64);
+        strings = backtrace_symbols(buffer, size);
+        if (strings) {
+            for (int i = 0; i < size; i++) {
+                StackTrace trace;
+                trace.method = strings[i];
+                exception.stacktrace << trace;
+            }
+            free(strings);
+        }
 
         Event event;
         event.context = context;


### PR DESCRIPTION
### 📒 Description
This patch adds a basic backtrace generation to our Linux app, so we know at least something about the crashes our Linux users are experiencing. Some more work related to this should be done in the future though, especially for other signals (SIGABRT, SIGILL, etc) and especially for exceptions, quite often there are crashes coming from POCO.
In the case of exceptions, we could, however, look into doing this as a part of our library code.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Reported Linux crashes now contain backtrace information

### 🔎 Review hints
Listing the reports from the past hour on Bugsnag helps a lot. 

