### PR TITLE
Undo feature for new Time Entry Editor

### DIFF
--- a/src/ui/osx/TogglDesktop/AutocompleteItem.m
+++ b/src/ui/osx/TogglDesktop/AutocompleteItem.m
@@ -19,6 +19,8 @@
 		self.ProjectAndTaskLabel = snapshot.projectAndTaskLabel;
 		self.TaskID = snapshot.taskID;
 		self.ProjectID = snapshot.projectID;
+		self.ProjectLabel = snapshot.projectLabel;
+		self.ProjectColor = snapshot.projectColor;
 	}
 	return self;
 }

--- a/src/ui/osx/TogglDesktop/Diff/TogglDesktop-Bridging-Header.h
+++ b/src/ui/osx/TogglDesktop/Diff/TogglDesktop-Bridging-Header.h
@@ -12,3 +12,4 @@
 #import "ProjectTextField.h"
 #import "ViewItem.h"
 #import "DesktopLibraryBridge.h"
+#import "UndoTextField.h"

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -196,7 +196,9 @@ extension AutoCompleteTextField {
 
         // Enter
         if commandSelector == #selector(NSResponder.insertNewline(_:)) {
-            return autoCompleteView.tableView.handleKeyboardEvent(currentEvent)
+            if state == .expand {
+                return autoCompleteView.tableView.handleKeyboardEvent(currentEvent)
+            }
         }
 
         // Escape

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -17,7 +17,7 @@ protocol AutoCompleteTextFieldDelegate: class {
     func autoCompleteShouldCloseEditor(_ sender: AutoCompleteTextField)
 }
 
-class AutoCompleteTextField: NSTextField, NSTextFieldDelegate, AutoCompleteViewDelegate {
+class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteViewDelegate {
 
     enum State {
         case expand

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -36,9 +36,9 @@ final class EditorViewController: NSViewController {
     @IBOutlet weak var dayNameButton: CursorButton!
     @IBOutlet weak var nextDateBtn: NSButton!
     @IBOutlet weak var previousDateBtn: NSButton!
-    @IBOutlet weak var durationTextField: NSTextField!
-    @IBOutlet weak var startAtTextField: NSTextField!
-    @IBOutlet weak var endAtTextField: NSTextField!
+    @IBOutlet weak var durationTextField: UndoTextField!
+    @IBOutlet weak var startAtTextField: UndoTextField!
+    @IBOutlet weak var endAtTextField: UndoTextField!
     @IBOutlet weak var dateSelectionBox: NSBox!
     @IBOutlet weak var workspaceLbl: NSTextField!
 
@@ -47,6 +47,7 @@ final class EditorViewController: NSViewController {
     var timeEntry: TimeEntryViewItem! {
         didSet {
             fillData()
+            registerUndoForAllFields()
         }
     }
     private var selectedProjectItem: ProjectContentItem?
@@ -541,5 +542,27 @@ extension EditorViewController: CalendarViewControllerDelegate {
 
     func calendarViewControllerDidSelect(date: Date) {
         DesktopLibraryBridge.shared().updateTimeEntry(withStart: date, guid: timeEntry.guid)
+    }
+}
+
+// MARK: Undo
+
+extension EditorViewController {
+
+    fileprivate func registerUndoForAllFields() {
+        guard let timeEntry = timeEntry else { return }
+
+        if let snapshot = UndoManager.shared.getSnapshot(for: timeEntry) {
+            descriptionTextField.registerUndo(withValue: snapshot.descriptionUndoValue)
+            durationTextField.registerUndo(withValue: snapshot.durationUndoValue)
+            startAtTextField.registerUndo(withValue: snapshot.startTimeUndoValue)
+            endAtTextField.registerUndo(withValue: snapshot.endTimeUndoValue)
+            
+        } else {
+            descriptionTextField.undoManager?.removeAllActions()
+            durationTextField.undoManager?.removeAllActions()
+            startAtTextField.undoManager?.removeAllActions()
+            endAtTextField.undoManager?.removeAllActions()
+        }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -574,14 +574,22 @@ extension EditorViewController {
     private func registerUndoForProject(with snapshot: ProjectSnapshot?) {
         guard let snapshot = snapshot else { return }
         let item = AutocompleteItem(snapshot: snapshot)
-        projectTextField.undoManager?.removeAllActions()
+        projectTextField.undoManager?.removeAllActions(withTarget: self)
         projectTextField.undoManager?.registerUndo(withTarget: self,
                                                    selector: #selector(self.updateProjectUndoValue(_:)),
                                                    object: item)
     }
 
     @objc private func updateProjectUndoValue(_ item: AutocompleteItem) {
+        let oldValue = selectedProjectItem?.item
         let project = ProjectContentItem(item: item)
         updateProjectSelection(with: project)
+
+        // Register to redo
+        if let oldValue = oldValue {
+            projectTextField.undoManager?.registerUndo(withTarget: self,
+                                                       selector: #selector(self.updateProjectUndoValue(_:)),
+                                                       object: oldValue)
+        }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -189,7 +189,7 @@
                                     <rect key="frame" x="1" y="1" width="78" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q9U-uY-bOj">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q9U-uY-bOj" customClass="UndoTextField">
                                             <rect key="frame" x="-2" y="0.0" width="82" height="28"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="0:00:00" placeholderString="0:00:00" id="dJu-5a-D7u" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                 <font key="font" metaFont="system" size="14"/>
@@ -445,7 +445,7 @@
                             <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Wyt-sv-sZR">
                                 <rect key="frame" x="98" y="159" width="168" height="18"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-ON-SgR">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-ON-SgR" customClass="UndoTextField">
                                         <rect key="frame" x="-2" y="0.0" width="74" height="18"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="center" title="09:20 AM" id="XRL-p8-r7I">
                                             <font key="font" metaFont="system" size="14"/>
@@ -466,7 +466,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
-                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8yt-KD-lKA">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8yt-KD-lKA" customClass="UndoTextField">
                                         <rect key="frame" x="96" y="0.0" width="74" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="70" id="l2i-Ea-wbs"/>

--- a/src/ui/osx/TogglDesktop/Feature/Undo/TimeEntrySnapshot.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Undo/TimeEntrySnapshot.swift
@@ -70,16 +70,20 @@ extension TimeEntrySnapshot {
 	}
 }
 
-@objc class ProjectSnapshot: NSObject {
+@objcMembers class ProjectSnapshot: NSObject {
 
-	@objc let projectAndTaskLabel: String
-	@objc let taskID: UInt64
-	@objc let projectID: UInt64
+	let projectAndTaskLabel: String
+	let taskID: UInt64
+	let projectID: UInt64
+    let projectLabel: String
+    let projectColor: String
 
 	init(timeEntry: TimeEntryViewItem) {
 		self.projectAndTaskLabel = timeEntry.projectAndTaskLabel.safeUnwrapped
 		self.taskID = timeEntry.taskID
 		self.projectID = timeEntry.projectID
+        self.projectLabel = timeEntry.projectLabel
+        self.projectColor = timeEntry.projectColor
 		super.init()
 	}
 

--- a/src/ui/osx/TogglDesktop/test2/UndoTextField.h
+++ b/src/ui/osx/TogglDesktop/test2/UndoTextField.h
@@ -8,10 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface UndoTextField : NSTextField
-- (void)registerUndoWithValue:(NSString *)value;
+- (void)registerUndoWithValue:(NSString *_Nullable)value;
 @end
-
-NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/UndoTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/UndoTextField.m
@@ -22,7 +22,7 @@
 	return self.undo;
 }
 
-- (void)registerUndoWithValue:(NSString *)value
+- (void)registerUndoWithValue:(NSString *_Nullable)value
 {
 	if (value == nil)
 	{


### PR DESCRIPTION
### 📒 Description
This PR will bring our Undo functionality to the new Time Entry Editor.

Undo feature will support on Description, Project, Duration, Start and End textfield.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality

### 🤯 List of changes
- [x] Bring old undo logic from TimeEntryListViewController to EditorViewController
- [x] AutoCompleteTextField now is a subclass of UndoTextField
- [x] Implement logic to undo / redo for all text fields in Editor

### 👫 Relationships
Close #2983 

### 🔎 Review hints
- Able to Undo (Cmd+Z) and Redo (Cmd+Shift+Z) in Description, Project, Duration, Start and End textfield.
- Be able to redo / undo old value for different Time Entry.