### PR TITLE
Unsync Project

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1134,7 +1134,7 @@ error Context::LoadUpdateFromJSONString(const std::string json) {
         resetLastTrackingReminderTime();
     }
 
-    return displayError(save());
+    return displayError(save(false));
 }
 
 void Context::switchWebSocketOn() {
@@ -2173,7 +2173,7 @@ error Context::attemptOfflineLogin(const std::string email,
 
     updateUI(UIElements::Reset());
 
-    return save();
+    return save(false);
 }
 
 error Context::AsyncLogin(const std::string email,
@@ -2235,7 +2235,7 @@ error Context::Login(
             }
         }
         overlay_visible_ = false;
-        return displayError(save());
+        return displayError(save(false));
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {
@@ -2399,7 +2399,7 @@ error Context::SetLoggedInUserFromJSON(
 
     updateUI(UIElements::Reset());
 
-    err = save();
+    err = save(false);
     if (err != noError) {
         return displayError(err);
     }
@@ -2532,7 +2532,7 @@ TimeEntry *Context::Start(
                           tags);
     }
 
-    error err = save();
+    error err = save(true);
     if (err != noError) {
         displayError(err);
         return nullptr;
@@ -2649,7 +2649,7 @@ TimeEntry *Context::ContinueLatest(const bool prevent_on_app) {
 
 
 
-    error err = save();
+    error err = save(true);
     if (noError != err) {
         displayError(err);
         return nullptr;
@@ -2715,7 +2715,7 @@ TimeEntry *Context::Continue(
             settings_.manual_mode);
     }
 
-    error err = save();
+    error err = save(true);
     if (err != noError) {
         displayError(err);
         return nullptr;
@@ -2778,7 +2778,7 @@ error Context::DeleteTimeEntryByGUID(const std::string GUID) {
     }
     te->ClearValidationError();
     te->Delete();
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryDuration(
@@ -2810,7 +2810,7 @@ error Context::SetTimeEntryDuration(
     }
 
     te->SetDurationUserInput(duration);
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryProject(
@@ -2876,7 +2876,7 @@ error Context::SetTimeEntryProject(
     } catch(const std::string& ex) {
         return displayError(ex);
     }
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryDate(
@@ -2935,7 +2935,7 @@ error Context::SetTimeEntryDate(
 
     te->SetStartUserInput(s, false);
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 
@@ -2995,7 +2995,7 @@ error Context::SetTimeEntryStart(
 
     te->SetStartUserInput(s, GetKeepEndTimeFixed());
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryStop(
@@ -3058,7 +3058,7 @@ error Context::SetTimeEntryStop(
 
     te->SetStopUserInput(s);
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryTags(
@@ -3095,7 +3095,7 @@ error Context::SetTimeEntryTags(
         te->SetUIModified();
     }
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryBillable(
@@ -3132,7 +3132,7 @@ error Context::SetTimeEntryBillable(
         te->SetUIModified();
     }
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::SetTimeEntryDescription(
@@ -3174,7 +3174,7 @@ error Context::SetTimeEntryDescription(
         te->SetUIModified();
     }
 
-    return displayError(save());
+    return displayError(save(true));
 }
 
 error Context::Stop(const bool prevent_on_app) {
@@ -3243,7 +3243,7 @@ error Context::DiscardTimeAt(
         split = user_->DiscardTimeAt(guid, at, split_into_new_entry);
     }
 
-    error err = save();
+    error err = save(true);
     if (err != noError) {
         return displayError(err);
     }
@@ -3282,7 +3282,7 @@ TimeEntry *Context::DiscardTimeAndContinue(
         user_->DiscardTimeAt(guid, at, false);
     }
 
-    error err = save();
+    error err = save(true);
     if (err != noError) {
         displayError(err);
         return nullptr;
@@ -3309,7 +3309,7 @@ error Context::ToggleTimelineRecording(const bool record_timeline) {
     try {
         user_->SetRecordTimeline(record_timeline);
 
-        error err = save();
+        error err = save(false);
         if (err != noError) {
             return displayError(err);
         }
@@ -3395,7 +3395,7 @@ error Context::SetDefaultProject(
                 user_->SetDefaultTID(0);
             }
         }
-        return displayError(save());
+        return displayError(save(false));
     } catch(const Poco::Exception& exc) {
         return displayError(exc.displayText());
     } catch(const std::exception& ex) {
@@ -3545,7 +3545,7 @@ error Context::AddAutotrackerRule(
         user_->related.AutotrackerRules.push_back(rule);
     }
 
-    error err = save();
+    error err = save(false);
     if (noError != err) {
         return displayError(err);
     }
@@ -3577,7 +3577,7 @@ error Context::DeleteAutotrackerRule(
         }
     }
 
-    return displayError(save());
+    return displayError(save(false));
 }
 
 Project *Context::CreateProject(
@@ -3668,7 +3668,7 @@ Project *Context::CreateProject(
             billable);
     }
 
-    err = save();
+    err = save(false);
     if (err != noError) {
         displayError(err);
         return nullptr;
@@ -3715,7 +3715,7 @@ error Context::AddObmAction(
         action->SetValue(trimmed_value);
         user_->related.ObmActions.push_back(action);
     }
-    return displayError(save());
+    return displayError(save(false));
 }
 
 Client *Context::CreateClient(
@@ -3758,7 +3758,7 @@ Client *Context::CreateClient(
         result = user_->CreateClient(workspace_id, trimmed_client_name);
     }
 
-    err = save();
+    err = save(false);
     if (err != noError) {
         displayError(err);
         return nullptr;
@@ -3917,7 +3917,7 @@ error Context::runObmExperiments() {
             }
         }
         // Save the (seen/unseen) state
-        error err = save();
+        error err = save(false);
         if (err != noError) {
             return err;
         }
@@ -4810,7 +4810,7 @@ error Context::pushClients(
         if (resp.err != noError) {
             // if we're able to solve the error
             if ((*it)->ResolveError(resp.body)) {
-                displayError(save());
+                displayError(save(false));
             }
             continue;
         }
@@ -4867,7 +4867,7 @@ error Context::pushProjects(
         if (resp.err != noError) {
             // if we're able to solve the error
             if ((*it)->ResolveError(resp.body)) {
-                displayError(save());
+                displayError(save(false));
             }
             continue;
         }
@@ -4956,7 +4956,7 @@ error Context::pushEntries(
         if (resp.err != noError) {
             // if we're able to solve the error
             if ((*it)->ResolveError(resp.body)) {
-                displayError(save());
+                displayError(save(false));
             }
 
             // Not found on server. Probably deleted already.

--- a/src/context.cc
+++ b/src/context.cc
@@ -2856,7 +2856,8 @@ error Context::SetTimeEntryProject(
             // If user re-assigns project, don't mess with the billable
             // flag any more. (User selected billable project, unchecked
             // billable, // then selected the same project again).
-            if (p->ID() != te->PID()) {
+            if (p->ID() != te->PID()
+                    || (!project_guid.empty() && p->GUID().compare(te->ProjectGUID()) != 0)) {
                 te->SetBillable(p->Billable());
             }
             te->SetWID(p->WID());

--- a/src/gui.h
+++ b/src/gui.h
@@ -123,7 +123,8 @@ class Autocomplete {
     , Billable(false)
     , Tags("")
     , WorkspaceName("")
-    , ClientID(0) {}
+    , ClientID(0)
+    , ProjectGUID("") {}
 
     bool IsTimeEntry() const {
         return kAutocompleteItemTE == Type;
@@ -178,6 +179,7 @@ class Autocomplete {
     std::string Tags;
     std::string WorkspaceName;
     uint64_t ClientID;
+    std::string ProjectGUID;
 
     bool operator == (const Autocomplete& other) const;
 };

--- a/src/project.cc
+++ b/src/project.cc
@@ -7,6 +7,7 @@
 
 #include "Poco/UTF8String.h"
 #include "Poco/NumberParser.h"
+#include "Poco/UTF8String.h"
 
 #include "./formatter.h"
 
@@ -85,7 +86,7 @@ void Project::SetBillable(const bool value) {
 
 void Project::SetColor(const std::string value) {
     if (color_ != value) {
-        color_ = value;
+        color_ = Poco::UTF8::toLower(value);
         SetDirty();
     }
 }
@@ -154,7 +155,7 @@ Json::Value Project::SaveToJSON() const {
     // There is no way to set it in UI and free ws gets error when it's sent
     // n["billable"] = Billable();
     n["is_private"] = IsPrivate();
-    n["color"] = Color();
+    n["color"] = Poco::UTF8::toLower(Color());
     n["active"] = Active();
 
     return n;

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -262,6 +262,7 @@ void RelatedData::timeEntryAutocompleteItems(
         if (p) {
             autocomplete_item.ProjectColor = p->ColorCode();
             autocomplete_item.ProjectID = p->ID();
+            autocomplete_item.ProjectGUID = p->GUID();
             autocomplete_item.ProjectLabel = p->Name();
             if (p->CID()) {
                 autocomplete_item.ClientLabel = p->ClientName();
@@ -344,6 +345,7 @@ void RelatedData::taskAutocompleteItems(
         if (p) {
             autocomplete_item.ProjectColor = p->ColorCode();
             autocomplete_item.ProjectID = p->ID();
+            autocomplete_item.ProjectGUID = p->GUID();
             autocomplete_item.ProjectLabel = p->Name();
             autocomplete_item.Billable = p->Billable();
             if (p->CID()) {
@@ -411,6 +413,7 @@ void RelatedData::projectAutocompleteItems(
             autocomplete_item.ClientID = c->ID();
         }
         autocomplete_item.ProjectID = p->ID();
+        autocomplete_item.ProjectGUID = p->GUID();
         autocomplete_item.ProjectColor = p->ColorCode();
         if (ws_names) {
             autocomplete_item.WorkspaceName = (*ws_names)[p->WID()];

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -98,6 +98,7 @@ extern "C" {
         char_t *ProjectLabel;
         char_t *ClientLabel;
         char_t *ProjectColor;
+        char_t *ProjectGUID;
         uint64_t TaskID;
         uint64_t ProjectID;
         uint64_t WorkspaceID;

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -26,6 +26,7 @@ TogglAutocompleteView *autocomplete_item_init(
     result->ClientLabel = copy_string(item.ClientLabel);
     result->ProjectColor = copy_string(item.ProjectColor);
     result->WorkspaceName = copy_string(item.WorkspaceName);
+    result->ProjectGUID = copy_string(item.ProjectGUID);
     result->TaskID = static_cast<unsigned int>(item.TaskID);
     result->ProjectID = static_cast<unsigned int>(item.ProjectID);
     result->WorkspaceID = static_cast<unsigned int>(item.WorkspaceID);

--- a/src/ui/osx/TogglDesktop/AutocompleteItem.h
+++ b/src/ui/osx/TogglDesktop/AutocompleteItem.h
@@ -27,6 +27,7 @@
 @property NSString *WorkspaceName;
 @property uint64_t ID;
 @property uint64_t ProjectID;
+@property (copy, nonatomic) NSString *ProjectGUID;
 @property uint64_t WorkspaceID;
 @property uint64_t TaskID;
 @property int64_t Type;

--- a/src/ui/osx/TogglDesktop/AutocompleteItem.m
+++ b/src/ui/osx/TogglDesktop/AutocompleteItem.m
@@ -96,6 +96,14 @@
 	{
 		self.tags = nil;
 	}
+	if (data->ProjectGUID)
+	{
+		self.ProjectGUID = [NSString stringWithUTF8String:data->ProjectGUID];
+	}
+	else
+	{
+		self.ProjectGUID = @"";
+	}
 
 	if (data->Billable)
 	{

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -410,7 +410,14 @@ extension EditorViewController: AutoCompleteViewDataSourceDelegate {
 
         // Update
         let item = projectItem.item
-        let projectGUID = projectTextField.lastProjectGUID ?? ""
+
+        var projectGUID = ""
+        if let guid = item.projectGUID, !guid.isEmpty {
+            projectGUID = guid
+        } else if let lastProjectGUID = projectTextField.lastProjectGUID {
+            projectGUID = lastProjectGUID
+        }
+
         DesktopLibraryBridge.shared().setProjectForTimeEntryWithGUID(timeEntry.guid,
                                                                      taskID: item.taskID,
                                                                      projectID: item.projectID,

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
@@ -124,7 +124,7 @@ extension ColorPickerView: ChangeColorDelegate {
     }
 
     private func notifySelectedColorChange(with color: HSV) {
-        let hex = color.toNSColor().hexString
+        let hex = color.toNSColor().hexString.lowercased()
         let color = ProjectColor(colorHex: hex)
         delegate?.colorPickerDidSelectColor(color)
     }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
@@ -134,7 +134,7 @@ extension NSColor {
 
     var hexString: String {
         guard let rgbColor = usingColorSpaceName(NSColorSpaceName.calibratedRGB) else {
-            return "FFFFFF"
+            return "#ffffff"
         }
         let red = Int(round(rgbColor.redComponent * 0xFF))
         let green = Int(round(rgbColor.greenComponent * 0xFF))

--- a/src/user.cc
+++ b/src/user.cc
@@ -244,6 +244,7 @@ TimeEntry *User::Continue(
     result->SetDescription(existing->Description());
     result->SetWID(existing->WID());
     result->SetPID(existing->PID());
+    result->SetProjectGUID(existing->ProjectGUID());
     result->SetTID(existing->TID());
     result->SetBillable(existing->Billable());
     result->SetTags(existing->Tags());


### PR DESCRIPTION
### 📒 Description
This PR is a dedication to solve the unsync project. Project sometime doesn't sync appropriately, and results in the empty project in Time Entry when selecting them from Editor.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Use ProjectGUID when assigning project to TimeEntry if the Project ID is absent.
- [x] Add ProjectGUID into AutocompleteItem struct in Library
- [x] Force save unsync project (Indrek)
- [x] Lowercase all project color hex before sending
- [ ] Unable to force those unsync projects

### 👫 Relationships
Close #2986 

### 🔎 Review hints
- Check database that if those unsync projects are able to sync properly 
- Create project and sync to server properly
- No empty Project state in Time Entry when selecting projects 

