### PR TITLE
Fix: Unrecognized selector KVO in TimeEntryController

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -165,14 +165,18 @@ extern void *ctx;
 	{
 		CGRect oldFrame = CGRectZero;
 		CGRect newFrame = CGRectZero;
-		if ([change objectForKey:@"old"] != [NSNull null])
+		id oldValue = change[NSKeyValueChangeOldKey];
+		id newValue = change[NSKeyValueChangeNewKey];
+
+		if ([oldValue respondsToSelector:@selector(CGRectValue)])
 		{
-			oldFrame = [[change objectForKey:@"old"] CGRectValue];
+			oldFrame = [oldValue CGRectValue];
 		}
-		if ([object valueForKeyPath:keyPath] != [NSNull null])
+		if ([newValue respondsToSelector:@selector(CGRectValue)])
 		{
-			newFrame = [[object valueForKeyPath:keyPath] CGRectValue];
+			newFrame = [newValue CGRectValue];
 		}
+
 		if (oldFrame.size.width != newFrame.size.width)
 		{
 			// HACK


### PR DESCRIPTION
### 📒 Description
This PR will fix the crash, which causes by "Unrecognized selector" when KVO is triggered.

## Problem
Rather sending the message `[-CGRectValue]` to `id`in https://github.com/toggl/toggldesktop/blob/b5064ec91eafd104b1d1c7d6baab59da3fe5db42/src/ui/osx/TogglDesktop/TimeEntryListViewController.m#L174 

This PR implements the safe-check to determine that if the instance actually has this selector in runtime.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Refactor how we get new / old value with safer approach

### 👫 Relationships
Close #2895 

### 🔎 Review hints
- The Time Entry List is rendered properly after the width of CollectionView changes (for instance, enable Scroller Bar in System Preference, or resize the Windows)
