### PR TITLE
Color picker visibility for Free / Premium workspace

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -596,6 +596,7 @@ void Context::updateUI(const UIElements &what) {
                 view.WID = ws->ID();
                 view.Name = ws->Name();
                 view.WorkspaceName = ws->Name();
+                view.Premium = ws->Premium();
                 workspace_views.push_back(view);
             }
         }
@@ -616,6 +617,7 @@ void Context::updateUI(const UIElements &what) {
                     Workspace *ws = user_->related.WorkspaceByID(c->WID());
                     if (ws) {
                         view.WorkspaceName = ws->Name();
+                        view.Premium = ws->Premium();
                     }
                 }
                 client_views.push_back(view);

--- a/src/gui.h
+++ b/src/gui.h
@@ -191,13 +191,15 @@ class Generic {
     , WID(0)
     , GUID("")
     , Name("")
-    , WorkspaceName("") {}
+    , WorkspaceName("")
+    , Premium(false) {}
 
     uint64_t ID;
     uint64_t WID;
     std::string GUID;
     std::string Name;
     std::string WorkspaceName;
+    bool_t Premium;
 
     bool operator == (const Generic& other) const;
 };

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -118,6 +118,7 @@ extern "C" {
         char_t *GUID;
         char_t *Name;
         char_t *WorkspaceName;
+        bool_t Premium;
         void *Next;
     } TogglGenericView;
 

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -107,6 +107,7 @@ TogglGenericView *generic_to_view_item(
     result->GUID = copy_string(c.GUID);
     result->Name = copy_string(c.Name);
     result->WorkspaceName = copy_string(c.WorkspaceName);
+    result->Premium = c.Premium;
     return result;
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/WorkspaceDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/WorkspaceDataSource.swift
@@ -14,12 +14,14 @@ final class Workspace {
     let WID: UInt64
     let name: String
     let guid: String?
+    let isPremium: Bool
 
     init(viewItem: ViewItem) {
         self.ID = viewItem.id
         self.WID = viewItem.wid
         self.name = viewItem.name ?? ""
         self.guid = viewItem.guid ?? nil
+        self.isPremium = viewItem.premium
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.swift
@@ -25,7 +25,8 @@ final class ColorPickerView: NSView {
     @IBOutlet weak var collectionView: NSCollectionView!
     @IBOutlet weak var colorWheelView: ColorGraphicsView!
     @IBOutlet weak var colorWheelContainerView: NSView!
-    
+    @IBOutlet weak var resetBtnTop: NSLayoutConstraint!
+
     // MARK: Variables
 
     weak var delegate: ColorPickerViewDelegate?
@@ -54,6 +55,11 @@ final class ColorPickerView: NSView {
 
     @IBAction func resetBtnOnTap(_ sender: Any) {
         delegate?.colorPickerShouldResetColor()
+    }
+
+    func setColorWheelHidden(_ isHidden: Bool) {
+        resetBtnTop.constant = isHidden ? 0 : 5
+        colorWheelContainerView.isHidden = isHidden
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
@@ -11,14 +11,14 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe" customClass="ColorPickerView" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="220" height="190"/>
+            <rect key="frame" x="0.0" y="0.0" width="220" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FZc-LL-v7b">
-                    <rect key="frame" x="0.0" y="26" width="220" height="164"/>
+                    <rect key="frame" x="0.0" y="26" width="220" height="70"/>
                     <subviews>
                         <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="mxV-pt-2uu">
-                            <rect key="frame" x="0.0" y="94" width="220" height="70"/>
+                            <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xTa-DE-szS">
                                 <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -46,8 +46,8 @@
                                 <autoresizingMask key="autoresizingMask"/>
                             </scroller>
                         </scrollView>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
-                            <rect key="frame" x="0.0" y="0.0" width="220" height="94"/>
+                        <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
+                            <rect key="frame" x="0.0" y="-24" width="220" height="94"/>
                             <subviews>
                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="ekt-4K-GjN" customClass="ColorGraphicsView" customModule="TogglDesktop" customModuleProvider="target">
                                     <rect key="frame" x="5" y="0.0" width="210" height="94"/>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
@@ -11,35 +11,69 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe" customClass="ColorPickerView" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="220" height="190"/>
+            <rect key="frame" x="0.0" y="0.0" width="220" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="mxV-pt-2uu">
-                    <rect key="frame" x="0.0" y="120" width="220" height="70"/>
-                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xTa-DE-szS">
-                        <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView selectable="YES" id="52y-nX-aep">
+                <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FZc-LL-v7b">
+                    <rect key="frame" x="0.0" y="26" width="220" height="70"/>
+                    <subviews>
+                        <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="mxV-pt-2uu">
+                            <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
+                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xTa-DE-szS">
                                 <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="jeB-XW-ECn">
-                                    <size key="itemSize" width="50" height="50"/>
-                                </collectionViewFlowLayout>
-                                <color key="primaryBackgroundColor" name="color-picker-background"/>
-                            </collectionView>
-                        </subviews>
-                        <color key="backgroundColor" name="color-picker-background"/>
-                    </clipView>
-                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Zo6-MO-MYG">
-                        <rect key="frame" x="-100" y="-100" width="218" height="16"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="aVa-2w-HKQ">
-                        <rect key="frame" x="204" y="0.0" width="16" height="70"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                </scrollView>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <subviews>
+                                    <collectionView selectable="YES" id="52y-nX-aep">
+                                        <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                                        <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="jeB-XW-ECn">
+                                            <size key="itemSize" width="50" height="50"/>
+                                        </collectionViewFlowLayout>
+                                        <color key="primaryBackgroundColor" name="color-picker-background"/>
+                                    </collectionView>
+                                </subviews>
+                                <color key="backgroundColor" name="color-picker-background"/>
+                            </clipView>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="70" id="Ogv-f6-yDi"/>
+                            </constraints>
+                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Zo6-MO-MYG">
+                                <rect key="frame" x="-100" y="-100" width="218" height="16"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </scroller>
+                            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="aVa-2w-HKQ">
+                                <rect key="frame" x="204" y="0.0" width="16" height="70"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </scroller>
+                        </scrollView>
+                        <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
+                            <rect key="frame" x="0.0" y="-24" width="220" height="94"/>
+                            <subviews>
+                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="ekt-4K-GjN" customClass="ColorGraphicsView" customModule="TogglDesktop" customModuleProvider="target">
+                                    <rect key="frame" x="5" y="0.0" width="210" height="94"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="210" id="0EG-UJ-IN8"/>
+                                    </constraints>
+                                </customView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="ekt-4K-GjN" firstAttribute="top" secondItem="Bng-FC-0Ya" secondAttribute="top" id="aLF-uO-FMS"/>
+                                <constraint firstAttribute="trailing" secondItem="ekt-4K-GjN" secondAttribute="trailing" constant="5" id="lR2-ff-s1E"/>
+                                <constraint firstAttribute="height" constant="94" id="mJP-wd-r6t"/>
+                                <constraint firstAttribute="bottom" secondItem="ekt-4K-GjN" secondAttribute="bottom" id="n8m-d2-TrO"/>
+                                <constraint firstItem="ekt-4K-GjN" firstAttribute="leading" secondItem="Bng-FC-0Ya" secondAttribute="leading" constant="5" id="oOO-Cg-AeH"/>
+                            </constraints>
+                        </customView>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uIm-iS-FNW">
                     <rect key="frame" x="10" y="5" width="37" height="16"/>
                     <buttonCell key="cell" type="bevel" title="Reset" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="Upl-pY-Pye">
@@ -51,37 +85,20 @@
                         <action selector="resetBtnOnTap:" target="c22-O7-iKe" id="siu-nZ-gaK"/>
                     </connections>
                 </button>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
-                    <rect key="frame" x="0.0" y="26" width="220" height="94"/>
-                    <subviews>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="ekt-4K-GjN" customClass="ColorGraphicsView" customModule="TogglDesktop" customModuleProvider="target">
-                            <rect key="frame" x="5" y="0.0" width="210" height="94"/>
-                        </customView>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="trailing" secondItem="ekt-4K-GjN" secondAttribute="trailing" constant="5" id="bxE-3S-72K"/>
-                        <constraint firstAttribute="bottom" secondItem="ekt-4K-GjN" secondAttribute="bottom" id="l49-1b-Adg"/>
-                        <constraint firstItem="ekt-4K-GjN" firstAttribute="leading" secondItem="Bng-FC-0Ya" secondAttribute="leading" constant="5" id="ox7-PJ-vvT"/>
-                        <constraint firstItem="ekt-4K-GjN" firstAttribute="top" secondItem="Bng-FC-0Ya" secondAttribute="top" id="uHM-e6-LhC"/>
-                    </constraints>
-                </customView>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="Bng-FC-0Ya" secondAttribute="bottom" constant="26" id="JKP-eI-1Df"/>
-                <constraint firstAttribute="trailing" secondItem="Bng-FC-0Ya" secondAttribute="trailing" id="Obo-a8-U4c"/>
-                <constraint firstItem="Bng-FC-0Ya" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="70" id="Rfk-bD-RlL"/>
-                <constraint firstItem="mxV-pt-2uu" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="S1r-yj-NqA"/>
-                <constraint firstItem="Bng-FC-0Ya" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="bMP-Ll-ICH"/>
-                <constraint firstItem="mxV-pt-2uu" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="d8D-QU-RAB"/>
+                <constraint firstItem="uIm-iS-FNW" firstAttribute="top" secondItem="FZc-LL-v7b" secondAttribute="bottom" constant="5" id="A5o-B2-WHQ"/>
+                <constraint firstItem="FZc-LL-v7b" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="Dyu-N2-3gB"/>
+                <constraint firstAttribute="trailing" secondItem="FZc-LL-v7b" secondAttribute="trailing" id="FNw-MP-Y9u"/>
+                <constraint firstItem="FZc-LL-v7b" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="Nvh-HB-yjR"/>
                 <constraint firstItem="uIm-iS-FNW" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="10" id="iPZ-su-whG"/>
-                <constraint firstItem="Bng-FC-0Ya" firstAttribute="top" secondItem="mxV-pt-2uu" secondAttribute="bottom" id="qcy-kk-sNT"/>
                 <constraint firstAttribute="bottom" secondItem="uIm-iS-FNW" secondAttribute="bottom" constant="5" id="sbd-83-TJc"/>
-                <constraint firstAttribute="trailing" secondItem="mxV-pt-2uu" secondAttribute="trailing" id="zDH-Ua-8Hk"/>
             </constraints>
             <connections>
                 <outlet property="collectionView" destination="52y-nX-aep" id="B50-ae-Mf3"/>
                 <outlet property="colorWheelContainerView" destination="Bng-FC-0Ya" id="nym-d2-Mu1"/>
                 <outlet property="colorWheelView" destination="ekt-4K-GjN" id="b07-Li-ktA"/>
+                <outlet property="resetBtnTop" destination="A5o-B2-WHQ" id="sgG-7Q-xMa"/>
             </connections>
         </customView>
     </objects>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ColorPickerView.xib
@@ -11,14 +11,14 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe" customClass="ColorPickerView" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="220" height="96"/>
+            <rect key="frame" x="0.0" y="0.0" width="220" height="190"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FZc-LL-v7b">
-                    <rect key="frame" x="0.0" y="26" width="220" height="70"/>
+                    <rect key="frame" x="0.0" y="26" width="220" height="164"/>
                     <subviews>
                         <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="mxV-pt-2uu">
-                            <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
+                            <rect key="frame" x="0.0" y="94" width="220" height="70"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xTa-DE-szS">
                                 <rect key="frame" x="0.0" y="0.0" width="220" height="70"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -46,14 +46,11 @@
                                 <autoresizingMask key="autoresizingMask"/>
                             </scroller>
                         </scrollView>
-                        <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
-                            <rect key="frame" x="0.0" y="-24" width="220" height="94"/>
+                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Bng-FC-0Ya">
+                            <rect key="frame" x="0.0" y="0.0" width="220" height="94"/>
                             <subviews>
                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="ekt-4K-GjN" customClass="ColorGraphicsView" customModule="TogglDesktop" customModuleProvider="target">
                                     <rect key="frame" x="5" y="0.0" width="210" height="94"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="210" id="0EG-UJ-IN8"/>
-                                    </constraints>
                                 </customView>
                             </subviews>
                             <constraints>
@@ -65,6 +62,10 @@
                             </constraints>
                         </customView>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="Bng-FC-0Ya" secondAttribute="trailing" id="QVy-v2-r58"/>
+                        <constraint firstItem="Bng-FC-0Ya" firstAttribute="leading" secondItem="FZc-LL-v7b" secondAttribute="leading" id="m7S-N5-HOj"/>
+                    </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
                         <integer value="1000"/>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -60,6 +60,8 @@ final class ProjectCreationView: NSView {
                 selectedClient = nil
                 clientAutoComplete.stringValue = ""
             }
+
+            // Update color picker visible
         }
     }
     private var selectedClient: Client?

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -41,7 +41,6 @@ final class ProjectCreationView: NSView {
     @IBOutlet weak var clientAutoComplete: ClientAutoCompleteTextField!
     @IBOutlet weak var colorBtn: CursorButton!
     @IBOutlet weak var colorPickerContainerBox: NSBox!
-    @IBOutlet weak var colorPickerContainerView: NSView!
     @IBOutlet weak var publicProjectCheckBox: NSButton!
     
     // MARK: Variables
@@ -61,7 +60,9 @@ final class ProjectCreationView: NSView {
                 clientAutoComplete.stringValue = ""
             }
 
-            // Update color picker visible
+            // Update Premium plan
+            let isPremium = selectedWorkspace?.isPremium ?? false
+            updateWorkspacePlan(isPremium: isPremium)
         }
     }
     private var selectedClient: Client?
@@ -187,7 +188,7 @@ extension ProjectCreationView {
 
     fileprivate func initCommon() {
         colorPickerView.isHidden = false
-        colorPickerContainerView.isHidden = true
+        colorPickerContainerBox.isHidden = true
         colorBtn.wantsLayer = true
         colorBtn.layer?.cornerRadius = 12.0
         colorBtn.layer?.borderColor = colorBtnBorderColor.cgColor
@@ -213,19 +214,22 @@ extension ProjectCreationView {
         workspaceAutoComplete.layoutArrowBtn(with: self)
         clientAutoComplete.layoutArrowBtn(with: self)
 
-        colorPickerContainerView.wantsLayer = true
-        colorPickerContainerView.layer?.masksToBounds = true
-        colorPickerContainerView.layer?.cornerRadius = 8
+        colorPickerContainerBox.wantsLayer = true
+        colorPickerContainerBox.layer?.masksToBounds = true
+        colorPickerContainerBox.layer?.cornerRadius = 8
+
+        // Hide color wheel for free workspace by default
+        updateWorkspacePlan(isPremium: false)
     }
 
     fileprivate func updateLayout() {
         let height = displayMode.height
         switch displayMode {
         case .compact:
-            colorPickerContainerView.isHidden = true
+            colorPickerContainerBox.isHidden = true
             self.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: height)
         case .full:
-            colorPickerContainerView.isHidden = false
+            colorPickerContainerBox.isHidden = false
             self.frame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: height)
         }
         delegate?.projectCreationDidUpdateSize()
@@ -291,6 +295,10 @@ extension ProjectCreationView {
     fileprivate func closeAllSuggestions() {
         workspaceAutoComplete.closeSuggestion()
         clientAutoComplete.closeSuggestion()
+    }
+
+    fileprivate func updateWorkspacePlan(isPremium: Bool) {
+        colorPickerView.setColorWheelHidden(!isPremium)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -67,7 +67,6 @@ final class ProjectCreationView: NSView {
             isPremiumWorkspace = selectedWorkspace?.isPremium ?? false
         }
     }
-    private var isPremiumWorkspace = false { didSet { updateWorkspacePlanLayout() }}
     private var selectedClient: Client?
     private var isPublic = false
     private lazy var clientDatasource: ClientDataSource = {
@@ -95,6 +94,16 @@ final class ProjectCreationView: NSView {
     private var displayMode = DisplayMode.normal {
         didSet {
             updateLayout()
+        }
+    }
+    private var isPremiumWorkspace = false {
+        didSet {
+            updateWorkspacePlanLayout()
+
+            // Reset custom color if we switch Premium -> Free
+            if oldValue && !isPremiumWorkspace {
+                colorPickerView.resetBtnOnTap(self)
+            }
         }
     }
     var suitableHeight: CGFloat {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
@@ -130,26 +130,14 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
-                        <customView hidden="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z6i-Vm-FEs">
+                        <box hidden="YES" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="1oc-cY-QWd">
                             <rect key="frame" x="0.0" y="120" width="270" height="190"/>
-                            <subviews>
-                                <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="1oc-cY-QWd">
-                                    <rect key="frame" x="0.0" y="0.0" width="270" height="190"/>
-                                    <view key="contentView" id="Bzo-Ix-voH">
-                                        <rect key="frame" x="0.0" y="0.0" width="270" height="190"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    </view>
-                                    <color key="fillColor" name="color-picker-background"/>
-                                </box>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="1oc-cY-QWd" firstAttribute="top" secondItem="Z6i-Vm-FEs" secondAttribute="top" id="3b3-Ti-mMg"/>
-                                <constraint firstAttribute="trailing" secondItem="1oc-cY-QWd" secondAttribute="trailing" id="HMa-Br-pYx"/>
-                                <constraint firstAttribute="height" constant="190" id="Oee-h7-oLp"/>
-                                <constraint firstItem="1oc-cY-QWd" firstAttribute="leading" secondItem="Z6i-Vm-FEs" secondAttribute="leading" id="V1z-0K-RDn"/>
-                                <constraint firstAttribute="bottom" secondItem="1oc-cY-QWd" secondAttribute="bottom" id="gEN-1b-JnV"/>
-                            </constraints>
-                        </customView>
+                            <view key="contentView" ambiguous="YES" id="Bzo-Ix-voH">
+                                <rect key="frame" x="0.0" y="0.0" width="270" height="190"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            </view>
+                            <color key="fillColor" name="color-picker-background"/>
+                        </box>
                         <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="5Vn-FK-aKk">
                             <rect key="frame" x="0.0" y="40" width="220" height="30"/>
                             <view key="contentView" id="qm3-nV-m4Z">
@@ -223,8 +211,6 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="H6x-LK-MTr" secondAttribute="trailing" id="84y-J7-xaq"/>
-                        <constraint firstAttribute="trailing" secondItem="Z6i-Vm-FEs" secondAttribute="trailing" id="MiO-5j-6aq"/>
-                        <constraint firstItem="Z6i-Vm-FEs" firstAttribute="leading" secondItem="OJp-YS-19d" secondAttribute="leading" id="ro1-uF-IR3"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>
@@ -269,12 +255,11 @@
                 <outlet property="clientAutoComplete" destination="cCQ-e0-gV1" id="sMM-dm-fm9"/>
                 <outlet property="colorBtn" destination="Zz6-Ng-Mjf" id="dah-ED-Ork"/>
                 <outlet property="colorPickerContainerBox" destination="1oc-cY-QWd" id="jyE-Q2-QW5"/>
-                <outlet property="colorPickerContainerView" destination="Z6i-Vm-FEs" id="hac-Fv-cL7"/>
                 <outlet property="projectTextField" destination="eQK-O0-2vn" id="yle-Cg-xGS"/>
                 <outlet property="publicProjectCheckBox" destination="2Vy-Nq-8Ub" id="Ik7-Kv-WnW"/>
                 <outlet property="workspaceAutoComplete" destination="I8L-vz-Mr7" id="CXb-Ky-yPT"/>
             </connections>
-            <point key="canvasLocation" x="-290" y="114"/>
+            <point key="canvasLocation" x="-290" y="9"/>
         </customView>
     </objects>
     <resources>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
@@ -130,7 +130,7 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
-                        <box hidden="YES" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="1oc-cY-QWd">
+                        <box hidden="YES" horizontalHuggingPriority="200" verticalHuggingPriority="200" horizontalCompressionResistancePriority="200" verticalCompressionResistancePriority="200" boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="1oc-cY-QWd">
                             <rect key="frame" x="0.0" y="120" width="270" height="190"/>
                             <view key="contentView" ambiguous="YES" id="Bzo-Ix-voH">
                                 <rect key="frame" x="0.0" y="0.0" width="270" height="190"/>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
@@ -211,6 +211,8 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="H6x-LK-MTr" secondAttribute="trailing" id="84y-J7-xaq"/>
+                        <constraint firstAttribute="trailing" secondItem="1oc-cY-QWd" secondAttribute="trailing" id="piX-EB-QmW"/>
+                        <constraint firstItem="1oc-cY-QWd" firstAttribute="leading" secondItem="OJp-YS-19d" secondAttribute="leading" id="zL2-YD-z6B"/>
                     </constraints>
                     <visibilityPriorities>
                         <integer value="1000"/>

--- a/src/ui/osx/TogglDesktop/test2/ViewItem.h
+++ b/src/ui/osx/TogglDesktop/test2/ViewItem.h
@@ -15,6 +15,7 @@
 @property (copy, nonatomic) NSString *GUID;
 @property (copy, nonatomic) NSString *Name;
 @property (copy, nonatomic) NSString *workspaceName;
+@property (assign, nonatomic) BOOL Premium;
 
 + (NSArray<ViewItem *> *)loadAll:(TogglGenericView *)first;
 - (void)load:(TogglGenericView *)data;

--- a/src/ui/osx/TogglDesktop/test2/ViewItem.m
+++ b/src/ui/osx/TogglDesktop/test2/ViewItem.m
@@ -15,7 +15,7 @@
 	self.WID = data->WID;
 	self.Name = [NSString stringWithUTF8String:data->Name];
 	self.GUID = nil;
-	self.Premium =  data->Premium;
+	self.Premium = data->Premium;
 	if (data->GUID)
 	{
 		self.GUID = [NSString stringWithUTF8String:data->GUID];

--- a/src/ui/osx/TogglDesktop/test2/ViewItem.m
+++ b/src/ui/osx/TogglDesktop/test2/ViewItem.m
@@ -15,6 +15,7 @@
 	self.WID = data->WID;
 	self.Name = [NSString stringWithUTF8String:data->Name];
 	self.GUID = nil;
+	self.Premium =  data->Premium;
 	if (data->GUID)
 	{
 		self.GUID = [NSString stringWithUTF8String:data->GUID];


### PR DESCRIPTION
### 📒 Description
This PR will introduce the fix to hide / present the Custom Color Wheel, which relies on the current worksapce's plan is.

By default, it's no -> The custom color wheel is hide

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Expose the Premium in Library to macOS model
- [x] Observe the workspace's plan in order to show/hide the color wheel
- [x] Update the height of Project Creation properly, depend on 3 DisplayMode: 
- Normal: No Color Picker
- Full Color Picker: Has Color picker and Color wheel
- Compact Color Picker: Only Color Picker and no wheel
- [x] Reset the custom color if we switch from Premium -> Free workspace

### 👫 Relationships
Close #2987 

### 🔎 Review hints
- If the workspace is free -> The color wheel shouldn't present
- if the workspace is Premium -> Color Picker & Wheel should be appear
- Switch workspace should update the color properly.

### GIF
![2019-05-30 20 42 38](https://user-images.githubusercontent.com/5878421/58637229-43b88580-831c-11e9-941b-e67741ef7d28.gif)


