### PR TITLE
Work around notification issues on systems without org.freedesktop.Notifications

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -91,7 +91,6 @@ MainWindowController::MainWindowController(
 
     setWindowIcon(icon);
     trayIcon = new SystemTray(this, icon);
-    preferencesDialog->setRemindersEnabled(trayIcon->notificationsAvailable());
 
     setShortcuts();
     connectMenuActions();

--- a/src/ui/linux/TogglDesktop/preferencesdialog.cpp
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.cpp
@@ -10,7 +10,6 @@
 PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent),
 ui(new Ui::PreferencesDialog) {
     ui->setupUi(this);
-    ui->reminderWarning->setGeometry(ui->tab_reminder->geometry());
 
     connect(TogglApi::instance, SIGNAL(displaySettings(bool,SettingsView*)),  // NOLINT
             this, SLOT(displaySettings(bool,SettingsView*)));  // NOLINT
@@ -37,17 +36,6 @@ ui(new Ui::PreferencesDialog) {
 
 PreferencesDialog::~PreferencesDialog() {
     delete ui;
-}
-
-void PreferencesDialog::setRemindersEnabled(bool enabled) {
-    if (enabled) {
-        ui->tab_reminder->setEnabled(true);
-        ui->reminderWarning->setVisible(false);
-    }
-    else {
-        ui->tab_reminder->setEnabled(false);
-        ui->reminderWarning->setVisible(true);
-    }
 }
 
 void PreferencesDialog::displaySettings(const bool open,
@@ -305,11 +293,6 @@ bool PreferencesDialog::setProxySettings() {
             ui->proxyPort->text().toULongLong(),
             ui->proxyUsername->text(),
             ui->proxyPassword->text());
-}
-
-void PreferencesDialog::paintEvent(QPaintEvent *event) {
-    QDialog::paintEvent(event);
-    ui->reminderWarning->setGeometry(ui->tab_reminder->geometry());
 }
 
 void PreferencesDialog::on_useProxy_clicked(bool checked) {

--- a/src/ui/linux/TogglDesktop/preferencesdialog.h
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.h
@@ -18,8 +18,6 @@ class PreferencesDialog : public QDialog {
     explicit PreferencesDialog(QWidget *parent = 0);
     ~PreferencesDialog();
 
-    void setRemindersEnabled(bool enabled);
-
  private:
     Ui::PreferencesDialog *ui;
     int keyId;
@@ -27,8 +25,6 @@ class PreferencesDialog : public QDialog {
 
     bool setSettings();
     bool setProxySettings();
-
-    void paintEvent(QPaintEvent *event) override;
 
  private slots:  // NOLINT
     void displaySettings(const bool open,

--- a/src/ui/linux/TogglDesktop/preferencesdialog.ui
+++ b/src/ui/linux/TogglDesktop/preferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>451</width>
-    <height>414</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <attribute name="title">
@@ -466,41 +466,6 @@
         </widget>
        </item>
       </layout>
-      <widget class="QLabel" name="reminderWarning">
-       <property name="geometry">
-        <rect>
-         <x>-1</x>
-         <y>200</y>
-         <width>331</width>
-         <height>101</height>
-        </rect>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">color:white;background-color:#bb888888</string>
-       </property>
-       <property name="text">
-        <string>&lt;b&gt;Notifications are not available on your system&lt;/b&gt;&lt;br&gt;You do not have a notfication daemon running.</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-      <zorder>reminderEndTimeEdit</zorder>
-      <zorder>remindToTrackTime</zorder>
-      <zorder>dayCheckbox_7</zorder>
-      <zorder>reminderEndTimeLabel</zorder>
-      <zorder>dayCheckbox_4</zorder>
-      <zorder>reminderStartTimeLabel</zorder>
-      <zorder>dayCheckbox_3</zorder>
-      <zorder>reminderDaysLabel</zorder>
-      <zorder>dayCheckbox_5</zorder>
-      <zorder>dayCheckbox_6</zorder>
-      <zorder>dayCheckbox_1</zorder>
-      <zorder>reminderMinutes</zorder>
-      <zorder>dayCheckbox_2</zorder>
-      <zorder>reminderStartTimeEdit</zorder>
-      <zorder>reminderMinutesLabel</zorder>
-      <zorder>reminderWarning</zorder>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
### 📒 Description
We're doing notifications manually using the DBus freedesktop API so we can handle icons and buttons ourselves. On some platforms (Elementary seems to be the case) this is not available, so this patch makes use of the built-in Qt notification capabilities to work around this.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Notification support on Linux is broader

### 👫 Relationships
Closes #2916

### 🔎 Review hints
Test if notifications work on Elementary and some other platform (like GNOME in Ubuntu for example), both.

