### PR TITLE
Feature/create private projects win

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -65,6 +65,7 @@
                 <Grid Grid.IsSharedSizeScope="True">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -124,9 +125,11 @@
                                 ConfirmWithoutCompletion="projectAutoComplete_OnConfirmWithoutCompletion"/>
 
                     </Grid>
+
+                    <CheckBox Grid.Row="1" Name="isProjectPublicCheckBox">Public (visible to the whole team)</CheckBox>
             
                     <!-- client -->
-                    <Grid  Grid.Row="1"  Height="50" Visibility="Visible"
+                    <Grid  Grid.Row="2"  Height="50" Visibility="Visible"
                            Name="clientArea" x:FieldModifier="private">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -177,7 +180,7 @@
                     </Grid>
                 
                     <!-- workspace -->
-                    <Grid Grid.Row="2" Height="50" Visibility="Visible"
+                    <Grid Grid.Row="3" Height="50" Visibility="Visible"
                            Name="workspaceArea" x:FieldModifier="private">
 
                         <toggl:ExtendedTextBox x:Name="workspaceTextBox" x:FieldModifier="private"
@@ -194,7 +197,7 @@
                                 ConfirmWithoutCompletion="workspaceAutoComplete_OnConfirmWithoutCompletion"/>
                     </Grid>
 
-                    <StackPanel Grid.Row="3" Height="50" Visibility="Visible"
+                    <StackPanel Grid.Row="4" Height="50" Visibility="Visible"
                                 Name="projectSaveArea" x:FieldModifier="private"
                                 Orientation="Horizontal" HorizontalAlignment="Right">
                         <Button Click="projectSaveButton_Click">SAVE</Button>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -661,7 +661,7 @@ namespace TogglDesktop
             var ret = Toggl.AddProject(
                 this.timeEntry.GUID, this.selectedWorkspaceId,
                 this.selectedClientId, this.selectedClientGUID,
-                text, !isProjectPublicCheckBox.IsChecked.GetValueOrDefault(true), color) != null;
+                text, !isProjectPublicCheckBox.IsChecked.GetValueOrDefault(), color) != null;
 
             this.isCreatingProject = false;
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -565,6 +565,7 @@ namespace TogglDesktop
 
         private void enableNewProjectMode()
         {
+            this.isProjectPublicCheckBox.IsChecked = false;
             this.isProjectPublicCheckBox.Visibility = Visibility.Visible;
             this.showClientArea();
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -565,6 +565,7 @@ namespace TogglDesktop
 
         private void enableNewProjectMode()
         {
+            this.isProjectPublicCheckBox.Visibility = Visibility.Visible;
             this.showClientArea();
 
             this.projectTextBox.SetText("", "");
@@ -587,6 +588,7 @@ namespace TogglDesktop
         private void disableNewProjectMode()
         {
             this.disableNewClientMode();
+            this.isProjectPublicCheckBox.Visibility = Visibility.Collapsed;
             this.hideClientArea();
 
             this.projectTextBox.SetText(this.timeEntry.ProjectLabel, this.timeEntry.TaskLabel);
@@ -658,7 +660,7 @@ namespace TogglDesktop
             var ret = Toggl.AddProject(
                 this.timeEntry.GUID, this.selectedWorkspaceId,
                 this.selectedClientId, this.selectedClientGUID,
-                text, false, color) != null;
+                text, !isProjectPublicCheckBox.IsChecked.GetValueOrDefault(true), color) != null;
 
             this.isCreatingProject = false;
 


### PR DESCRIPTION
### 📒 Description
Adds `Public (visible to the whole team)` checkbox when adding new project.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #2967.

### 🔎 Review hints
Note: this does not fix #2135. We probably have this issue on all platforms, will have to look into it separately.