### PR TITLE
Fixed keyboard support for idle popup (mac), #2888

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,10 +16,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" id="OXh-s9-LHB" customClass="NSPanel">
+        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" id="OXh-s9-LHB" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" HUD="YES"/>
             <rect key="contentRect" x="517" y="489" width="291" height="286"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" appearanceType="aqua" id="IAa-lP-ER3">
                 <rect key="frame" x="0.0" y="0.0" width="291" height="286"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -110,6 +110,9 @@
                     </textField>
                 </subviews>
             </view>
+            <connections>
+                <outlet property="initialFirstResponder" destination="fpJ-rI-lKJ" id="QFm-QX-kPF"/>
+            </connections>
             <point key="canvasLocation" x="282.5" y="372"/>
         </window>
     </objects>


### PR DESCRIPTION
### 📒 Description
Sets initial responder to `keep idle time` button

### 🕶️ Types of changes
**Bug fix**

### 👫 Relationships

Closes #2888

### 🔎 Review hints
- Set idle time to 1 minute
- Start timer
- Wait 1 minute
- Press any key on the keyboard
- Try to select an item from idle popup with keyboard