### PR TITLE
Idle design

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.h
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.h
@@ -11,17 +11,8 @@
 
 @interface IdleNotificationWindowController : NSWindowController
 
-@property IBOutlet NSTextField *idleSinceTextField;
-@property IBOutlet NSTextField *idleAmountTextField;
-@property IBOutlet NSTextField *timeentryDescriptionTextField;
-
-- (IBAction)stopButtonClicked:(id)sender;
-- (IBAction)ignoreButtonClicked:(id)sender;
-- (IBAction)addIdleTimeAsNewTimeEntry:(id)sender;
-- (IBAction)discardIdleAndContinue:(id)sender;
-
 - (void)displayIdleEvent:(IdleEvent *)idleEvent;
 
-@property IdleEvent *idleEvent;
+@property (strong, nonatomic) IdleEvent *idleEvent;
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -12,9 +12,46 @@
 #import "UIEvents.h"
 #import "TogglDesktop-Swift.h"
 
+@interface IdleNotificationWindowController()
+
+@property (weak) IBOutlet NSTextField *idleSinceTextField;
+@property (weak) IBOutlet NSTextField *idleAmountTextField;
+@property (weak) IBOutlet NSTextField *timeentryDescriptionTextField;
+@property (weak) IBOutlet FlatButton *addIdleTimeButton;
+
+- (IBAction)stopButtonClicked:(id)sender;
+- (IBAction)ignoreButtonClicked:(id)sender;
+- (IBAction)addIdleTimeAsNewTimeEntry:(id)sender;
+
+@end
+
 @implementation IdleNotificationWindowController
 
 extern void *ctx;
+
+-(void)awakeFromNib
+{
+    [super awakeFromNib];
+
+    [self initCommon];
+}
+
+- (void) initCommon
+{
+    // Style buttons
+    self.addIdleTimeButton.wantsLayer = YES;
+    self.addIdleTimeButton.layer.borderWidth = 1;
+    if (@available(macOS 10.13, *))
+    {
+        self.addIdleTimeButton.layer.borderColor = [NSColor colorNamed:@"upload-border-color"].CGColor;
+        self.addIdleTimeButton.bgColor = [NSColor colorNamed:@"upload-background-color"];
+    }
+    else
+    {
+        self.addIdleTimeButton.layer.borderColor = [ConvertHexColor hexCodeToNSColor:@"#acacac"].CGColor;
+        self.addIdleTimeButton.bgColor = NSColor.whiteColor;
+    }
+}
 
 - (void)displayIdleEvent:(IdleEvent *)idleEvent
 {
@@ -61,14 +98,6 @@ extern void *ctx;
 	cmd.open = YES;
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayApp
 																object:cmd];
-}
-
-- (IBAction)discardIdleAndContinue:(id)sender
-{
-	toggl_discard_time_and_continue(ctx,
-									[self.idleEvent.guid UTF8String],
-									self.idleEvent.started);
-	[self.window orderOut:nil];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -12,12 +12,13 @@
 #import "UIEvents.h"
 #import "TogglDesktop-Swift.h"
 
-@interface IdleNotificationWindowController()
+@interface IdleNotificationWindowController ()
 
 @property (weak) IBOutlet NSTextField *idleSinceTextField;
 @property (weak) IBOutlet NSTextField *idleAmountTextField;
 @property (weak) IBOutlet NSTextField *timeentryDescriptionTextField;
 @property (weak) IBOutlet FlatButton *addIdleTimeButton;
+@property (weak) IBOutlet NSButton *cancelButton;
 
 - (IBAction)stopButtonClicked:(id)sender;
 - (IBAction)ignoreButtonClicked:(id)sender;
@@ -29,28 +30,58 @@
 
 extern void *ctx;
 
--(void)awakeFromNib
+- (void)awakeFromNib
 {
-    [super awakeFromNib];
+	[super awakeFromNib];
 
-    [self initCommon];
+	[self initCommon];
 }
 
-- (void) initCommon
+- (void)initCommon
 {
-    // Style buttons
-    self.addIdleTimeButton.wantsLayer = YES;
-    self.addIdleTimeButton.layer.borderWidth = 1;
-    if (@available(macOS 10.13, *))
-    {
-        self.addIdleTimeButton.layer.borderColor = [NSColor colorNamed:@"upload-border-color"].CGColor;
-        self.addIdleTimeButton.bgColor = [NSColor colorNamed:@"upload-background-color"];
-    }
-    else
-    {
-        self.addIdleTimeButton.layer.borderColor = [ConvertHexColor hexCodeToNSColor:@"#acacac"].CGColor;
-        self.addIdleTimeButton.bgColor = NSColor.whiteColor;
-    }
+	// Style buttons
+	[self styleAddIdleButton];
+	[self applyUnderlineStyle];
+}
+
+- (void)styleAddIdleButton
+{
+	self.addIdleTimeButton.wantsLayer = YES;
+	self.addIdleTimeButton.layer.borderWidth = 1;
+	if (@available(macOS 10.13, *))
+	{
+		self.addIdleTimeButton.layer.borderColor = [NSColor colorNamed:@"upload-border-color"].CGColor;
+		self.addIdleTimeButton.bgColor = [NSColor colorNamed:@"upload-background-color"];
+	}
+	else
+	{
+		self.addIdleTimeButton.layer.borderColor = [ConvertHexColor hexCodeToNSColor:@"#acacac"].CGColor;
+		self.addIdleTimeButton.bgColor = NSColor.whiteColor;
+	}
+}
+
+- (void)applyUnderlineStyle
+{
+	// Font
+	NSFont *font = self.cancelButton.font;
+
+	if (font == nil)
+	{
+		font = [NSFont systemFontOfSize:12 weight:NSFontWeightMedium];
+	}
+
+	// Color
+	NSColor *color = [ConvertHexColor hexCodeToNSColor:@"#555555"];
+	if (@available(macOS 10.13, *))
+	{
+		color = [NSColor colorNamed:@"grey-text-color"];
+	}
+
+	NSDictionary<NSAttributedStringKey, id> *attributes = @{ NSFontAttributeName: font,
+															 NSForegroundColorAttributeName: color,
+															 NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle), };
+	NSAttributedString *underlineString = [[NSAttributedString alloc] initWithString:@"Cancel" attributes:attributes];
+	self.cancelButton.attributedTitle = underlineString;
 }
 
 - (void)displayIdleEvent:(IdleEvent *)idleEvent

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -41,7 +41,7 @@ extern void *ctx;
 {
 	// Style buttons
 	[self styleAddIdleButton];
-	[self applyUnderlineStyle];
+	[self styleCancelButton];
 }
 
 - (void)styleAddIdleButton
@@ -60,7 +60,7 @@ extern void *ctx;
 	}
 }
 
-- (void)applyUnderlineStyle
+- (void)styleCancelButton
 {
 	// Font
 	NSFont *font = self.cancelButton.font;

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -32,6 +32,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="300" height="323"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         </view>
+                        <color key="fillColor" name="feedback-background-color"/>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sqC-ri-2J8">
                         <rect key="frame" x="36" y="265" width="229" height="18"/>
@@ -144,12 +145,18 @@
                     <constraint firstItem="LfR-bu-tys" firstAttribute="top" secondItem="sqC-ri-2J8" secondAttribute="bottom" constant="5" id="ycY-wp-cGX"/>
                 </constraints>
             </view>
+            <connections>
+                <outlet property="initialFirstResponder" destination="gae-h6-aWA" id="MWd-1C-OCJ"/>
+            </connections>
             <point key="canvasLocation" x="282" y="371.5"/>
         </window>
     </objects>
     <resources>
         <namedColor name="black-text-color">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="feedback-background-color">
+            <color red="0.98039215686274506" green="0.98431372549019602" blue="0.9882352941176471" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="green-color">
             <color red="0.15686274509803921" green="0.80392156862745101" blue="0.25490196078431371" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -76,6 +76,7 @@
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <action selector="stopButtonClicked:" target="-2" id="U8b-ud-zy9"/>
+                            <outlet property="nextKeyView" destination="3DH-9w-EQH" id="UYF-TD-Jdn"/>
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="upW-Uw-TwE">
@@ -111,6 +112,7 @@
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <action selector="addIdleTimeAsNewTimeEntry:" target="-2" id="tDh-N4-FxP"/>
+                            <outlet property="nextKeyView" destination="B6d-ef-DQm" id="m5K-Pj-a0h"/>
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QuW-zx-5VW">
@@ -129,6 +131,7 @@
                         </buttonCell>
                         <connections>
                             <action selector="ignoreButtonClicked:" target="-2" id="q5X-MT-BaQ"/>
+                            <outlet property="nextKeyView" destination="gae-h6-aWA" id="rE5-Za-aBm"/>
                         </connections>
                     </button>
                 </subviews>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -9,6 +9,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="IdleNotificationWindowController">
             <connections>
+                <outlet property="addIdleTimeButton" destination="3DH-9w-EQH" id="aPb-tD-mWD"/>
                 <outlet property="idleAmountTextField" destination="LfR-bu-tys" id="Y6v-ka-ovg"/>
                 <outlet property="idleSinceTextField" destination="sqC-ri-2J8" id="wsN-vw-dVh"/>
                 <outlet property="timeentryDescriptionTextField" destination="QuW-zx-5VW" id="d9n-7m-tBh"/>
@@ -69,6 +70,9 @@
                                 <real key="value" value="8"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
+                        <connections>
+                            <action selector="stopButtonClicked:" target="-2" id="U8b-ud-zy9"/>
+                        </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="upW-Uw-TwE">
                         <rect key="frame" x="83" y="198" width="134" height="14"/>
@@ -96,6 +100,9 @@
                                 <real key="value" value="8"/>
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
+                        <connections>
+                            <action selector="addIdleTimeAsNewTimeEntry:" target="-2" id="tDh-N4-FxP"/>
+                        </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QuW-zx-5VW">
                         <rect key="frame" x="103" y="177" width="95" height="16"/>
@@ -111,6 +118,9 @@
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="systemMedium" size="12"/>
                         </buttonCell>
+                        <connections>
+                            <action selector="ignoreButtonClicked:" target="-2" id="q5X-MT-BaQ"/>
+                        </connections>
                     </button>
                 </subviews>
                 <constraints>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -10,6 +10,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="IdleNotificationWindowController">
             <connections>
                 <outlet property="addIdleTimeButton" destination="3DH-9w-EQH" id="aPb-tD-mWD"/>
+                <outlet property="cancelButton" destination="B6d-ef-DQm" id="BKq-yb-bcR"/>
                 <outlet property="idleAmountTextField" destination="LfR-bu-tys" id="Y6v-ka-ovg"/>
                 <outlet property="idleSinceTextField" destination="sqC-ri-2J8" id="wsN-vw-dVh"/>
                 <outlet property="timeentryDescriptionTextField" destination="QuW-zx-5VW" id="d9n-7m-tBh"/>
@@ -64,9 +65,6 @@
                             <userDefinedRuntimeAttribute type="color" keyPath="bgColor">
                                 <color key="value" name="green-color"/>
                             </userDefinedRuntimeAttribute>
-                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                <color key="value" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </userDefinedRuntimeAttribute>
                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                 <real key="value" value="8"/>
                             </userDefinedRuntimeAttribute>
@@ -79,7 +77,7 @@
                         <rect key="frame" x="83" y="198" width="134" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="RUNNING TIME ENTRY:" id="roh-tK-cQL">
                             <font key="font" metaFont="systemMedium" size="11"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="grey-text-color"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
@@ -160,6 +158,9 @@
         </namedColor>
         <namedColor name="green-color">
             <color red="0.15686274509803921" green="0.80392156862745101" blue="0.25490196078431371" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="grey-text-color">
+            <color red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -3,6 +3,7 @@
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -47,6 +48,28 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gae-h6-aWA" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
+                        <rect key="frame" x="20" y="117" width="260" height="30"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="260" id="WVR-29-5dM"/>
+                            <constraint firstAttribute="height" constant="30" id="u8q-1m-Hpd"/>
+                        </constraints>
+                        <buttonCell key="cell" type="bevel" title="Discard idle time" bezelStyle="regularSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="SPr-5Y-gLE">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="bgColor">
+                                <color key="value" name="green-color"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                <color key="value" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="upW-Uw-TwE">
                         <rect key="frame" x="83" y="198" width="134" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="RUNNING TIME ENTRY:" id="roh-tK-cQL">
@@ -55,6 +78,25 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3DH-9w-EQH" customClass="FlatButton" customModule="TogglDesktop" customModuleProvider="target">
+                        <rect key="frame" x="20" y="77" width="260" height="30"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="260" id="56T-8y-5cD"/>
+                            <constraint firstAttribute="height" constant="30" id="ONB-DD-jbd"/>
+                        </constraints>
+                        <buttonCell key="cell" type="squareTextured" title="Add idle time as new time entry" bezelStyle="texturedSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="DjU-En-tIH">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                <color key="value" name="black-text-color"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="8"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QuW-zx-5VW">
                         <rect key="frame" x="103" y="177" width="95" height="16"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Doing the thing" id="nx5-lP-3u0">
@@ -63,34 +105,6 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button toolTip="Stops timer with the same time when the idle was triggered" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nGW-lp-Mrf">
-                        <rect key="frame" x="19" y="115" width="262" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="260" id="CO0-rV-0UT"/>
-                            <constraint firstAttribute="height" constant="30" id="vSW-2s-Z1y"/>
-                        </constraints>
-                        <buttonCell key="cell" type="squareTextured" title="Discard idle time" bezelStyle="texturedSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="qPv-hn-mbG">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="stopButtonClicked:" target="-2" id="YUn-hV-7AD"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="71P-8X-s86">
-                        <rect key="frame" x="19" y="75" width="262" height="33"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="30" id="fEs-pf-W1r"/>
-                            <constraint firstAttribute="width" constant="260" id="iXJ-je-2QU"/>
-                        </constraints>
-                        <buttonCell key="cell" type="squareTextured" title="Add idle time as a new time entry" bezelStyle="texturedSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="neF-QU-h5e">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="addIdleTimeAsNewTimeEntry:" target="-2" id="GW3-ad-oMu"/>
-                        </connections>
-                    </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B6d-ef-DQm">
                         <rect key="frame" x="236" y="20" width="44" height="16"/>
                         <buttonCell key="cell" type="bevel" title="Cancel" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="0Qu-8p-peH">
@@ -100,12 +114,12 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="nGW-lp-Mrf" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="4Q1-6l-iML"/>
                     <constraint firstItem="QuW-zx-5VW" firstAttribute="top" secondItem="upW-Uw-TwE" secondAttribute="bottom" constant="5" id="C1n-iA-xRY"/>
+                    <constraint firstItem="3DH-9w-EQH" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="HpV-0U-O5Y"/>
                     <constraint firstItem="upW-Uw-TwE" firstAttribute="top" secondItem="LfR-bu-tys" secondAttribute="bottom" constant="30" id="JTR-sF-zof"/>
                     <constraint firstItem="LfR-bu-tys" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="JTU-LE-9YD"/>
                     <constraint firstAttribute="bottom" secondItem="B6d-ef-DQm" secondAttribute="bottom" constant="20" id="MpJ-aO-IoC"/>
-                    <constraint firstItem="71P-8X-s86" firstAttribute="top" secondItem="nGW-lp-Mrf" secondAttribute="bottom" constant="10" id="WUs-ag-XAe"/>
+                    <constraint firstItem="3DH-9w-EQH" firstAttribute="top" secondItem="gae-h6-aWA" secondAttribute="bottom" constant="10" id="Vki-vT-rfn"/>
                     <constraint firstItem="upW-Uw-TwE" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="Yau-29-g0u"/>
                     <constraint firstAttribute="trailing" secondItem="31J-mN-zmo" secondAttribute="trailing" id="b1L-Ng-Oak"/>
                     <constraint firstAttribute="bottom" secondItem="31J-mN-zmo" secondAttribute="bottom" id="b62-TI-aXl"/>
@@ -113,14 +127,22 @@
                     <constraint firstItem="sqC-ri-2J8" firstAttribute="top" secondItem="IAa-lP-ER3" secondAttribute="top" constant="40" id="dXk-ty-x12"/>
                     <constraint firstItem="QuW-zx-5VW" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="eQW-qe-RjN"/>
                     <constraint firstItem="31J-mN-zmo" firstAttribute="top" secondItem="IAa-lP-ER3" secondAttribute="top" id="iPz-wC-Ums"/>
-                    <constraint firstItem="71P-8X-s86" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="jYj-zc-nbe"/>
+                    <constraint firstItem="gae-h6-aWA" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="p34-TA-wmM"/>
                     <constraint firstItem="31J-mN-zmo" firstAttribute="leading" secondItem="IAa-lP-ER3" secondAttribute="leading" id="p6f-ue-RuO"/>
                     <constraint firstAttribute="trailing" secondItem="B6d-ef-DQm" secondAttribute="trailing" constant="20" id="q00-hb-age"/>
-                    <constraint firstItem="nGW-lp-Mrf" firstAttribute="top" secondItem="QuW-zx-5VW" secondAttribute="bottom" constant="30" id="q8V-6X-6jB"/>
+                    <constraint firstItem="gae-h6-aWA" firstAttribute="top" secondItem="QuW-zx-5VW" secondAttribute="bottom" constant="30" id="vkM-Ij-h0S"/>
                     <constraint firstItem="LfR-bu-tys" firstAttribute="top" secondItem="sqC-ri-2J8" secondAttribute="bottom" constant="5" id="ycY-wp-cGX"/>
                 </constraints>
             </view>
             <point key="canvasLocation" x="282" y="371.5"/>
         </window>
     </objects>
+    <resources>
+        <namedColor name="black-text-color">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="green-color">
+            <color red="0.15686274509803921" green="0.80392156862745101" blue="0.25490196078431371" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -16,104 +16,111 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" id="OXh-s9-LHB" customClass="NSPanel">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" utility="YES" HUD="YES"/>
-            <rect key="contentRect" x="517" y="489" width="291" height="286"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <view key="contentView" appearanceType="aqua" id="IAa-lP-ER3">
-                <rect key="frame" x="0.0" y="0.0" width="291" height="286"/>
+        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" tabbingMode="disallowed" id="OXh-s9-LHB" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" texturedBackground="YES"/>
+            <rect key="contentRect" x="517" y="489" width="300" height="323"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <view key="contentView" id="IAa-lP-ER3">
+                <rect key="frame" x="0.0" y="0.0" width="300" height="323"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="251" translatesAutoresizingMaskIntoConstraints="NO" id="sqC-ri-2J8">
-                        <rect key="frame" x="18" y="249" width="255" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="31J-mN-zmo">
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="323"/>
+                        <view key="contentView" id="peO-4A-XP2">
+                            <rect key="frame" x="0.0" y="0.0" width="300" height="323"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        </view>
+                    </box>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sqC-ri-2J8">
+                        <rect key="frame" x="36" y="265" width="229" height="18"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="You have been idle since 12:34:50" id="M7R-YX-LRb">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <font key="font" metaFont="system" size="14"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="250" translatesAutoresizingMaskIntoConstraints="NO" id="LfR-bu-tys">
-                        <rect key="frame" x="19" y="224" width="254" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LfR-bu-tys">
+                        <rect key="frame" x="109" y="242" width="82" height="18"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="(5 minutes)" id="xfZ-e6-g8a">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                            <font key="font" metaFont="system" size="14"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button toolTip="Stops timer with the same time when the idle was triggered" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nGW-lp-Mrf">
-                        <rect key="frame" x="15" y="79" width="262" height="32"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Discard idle time" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="qPv-hn-mbG">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="upW-Uw-TwE">
+                        <rect key="frame" x="83" y="198" width="134" height="14"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="RUNNING TIME ENTRY:" id="roh-tK-cQL">
+                            <font key="font" metaFont="systemMedium" size="11"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QuW-zx-5VW">
+                        <rect key="frame" x="103" y="177" width="95" height="16"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Doing the thing" id="nx5-lP-3u0">
+                            <font key="font" metaFont="cellTitle"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button toolTip="Stops timer with the same time when the idle was triggered" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nGW-lp-Mrf">
+                        <rect key="frame" x="19" y="115" width="262" height="33"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="260" id="CO0-rV-0UT"/>
+                            <constraint firstAttribute="height" constant="30" id="vSW-2s-Z1y"/>
+                        </constraints>
+                        <buttonCell key="cell" type="squareTextured" title="Discard idle time" bezelStyle="texturedSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="qPv-hn-mbG">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
                             <action selector="stopButtonClicked:" target="-2" id="YUn-hV-7AD"/>
-                            <outlet property="nextKeyView" destination="Hfh-FR-her" id="Mc6-Gs-hy5"/>
                         </connections>
                     </button>
-                    <button toolTip="Keeps timer running" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fpJ-rI-lKJ">
-                        <rect key="frame" x="14" y="112" width="263" height="32"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Keep idle time" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="x6P-HU-yW4">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                        </buttonCell>
-                        <connections>
-                            <action selector="ignoreButtonClicked:" target="-2" id="01H-Ma-Ieq"/>
-                            <outlet property="nextKeyView" destination="nGW-lp-Mrf" id="ZsK-62-YQR"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="71P-8X-s86">
-                        <rect key="frame" x="15" y="13" width="262" height="32"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Add idle time as a new time entry" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="neF-QU-h5e">
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="71P-8X-s86">
+                        <rect key="frame" x="19" y="75" width="262" height="33"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="30" id="fEs-pf-W1r"/>
+                            <constraint firstAttribute="width" constant="260" id="iXJ-je-2QU"/>
+                        </constraints>
+                        <buttonCell key="cell" type="squareTextured" title="Add idle time as a new time entry" bezelStyle="texturedSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="neF-QU-h5e">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
                             <action selector="addIdleTimeAsNewTimeEntry:" target="-2" id="GW3-ad-oMu"/>
-                            <outlet property="nextKeyView" destination="fpJ-rI-lKJ" id="vkc-8c-5iR"/>
                         </connections>
                     </button>
-                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hfh-FR-her">
-                        <rect key="frame" x="15" y="46" width="262" height="32"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="push" title="Discard idle and continue" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jp9-g4-Obx">
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B6d-ef-DQm">
+                        <rect key="frame" x="236" y="20" width="44" height="16"/>
+                        <buttonCell key="cell" type="bevel" title="Cancel" bezelStyle="rounded" alignment="center" imageScaling="proportionallyDown" inset="2" id="0Qu-8p-peH">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
+                            <font key="font" metaFont="systemMedium" size="12"/>
                         </buttonCell>
-                        <connections>
-                            <action selector="discardIdleAndContinue:" target="-2" id="sxN-W1-g0Q"/>
-                            <outlet property="nextKeyView" destination="71P-8X-s86" id="f6j-ou-88x"/>
-                        </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="251" translatesAutoresizingMaskIntoConstraints="NO" id="upW-Uw-TwE">
-                        <rect key="frame" x="18" y="185" width="255" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Running time entry:" id="roh-tK-cQL">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="250" translatesAutoresizingMaskIntoConstraints="NO" id="QuW-zx-5VW">
-                        <rect key="frame" x="19" y="160" width="254" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="Doing the thing" id="nx5-lP-3u0">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="nGW-lp-Mrf" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="4Q1-6l-iML"/>
+                    <constraint firstItem="QuW-zx-5VW" firstAttribute="top" secondItem="upW-Uw-TwE" secondAttribute="bottom" constant="5" id="C1n-iA-xRY"/>
+                    <constraint firstItem="upW-Uw-TwE" firstAttribute="top" secondItem="LfR-bu-tys" secondAttribute="bottom" constant="30" id="JTR-sF-zof"/>
+                    <constraint firstItem="LfR-bu-tys" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="JTU-LE-9YD"/>
+                    <constraint firstAttribute="bottom" secondItem="B6d-ef-DQm" secondAttribute="bottom" constant="20" id="MpJ-aO-IoC"/>
+                    <constraint firstItem="71P-8X-s86" firstAttribute="top" secondItem="nGW-lp-Mrf" secondAttribute="bottom" constant="10" id="WUs-ag-XAe"/>
+                    <constraint firstItem="upW-Uw-TwE" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="Yau-29-g0u"/>
+                    <constraint firstAttribute="trailing" secondItem="31J-mN-zmo" secondAttribute="trailing" id="b1L-Ng-Oak"/>
+                    <constraint firstAttribute="bottom" secondItem="31J-mN-zmo" secondAttribute="bottom" id="b62-TI-aXl"/>
+                    <constraint firstItem="sqC-ri-2J8" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="bki-td-YVU"/>
+                    <constraint firstItem="sqC-ri-2J8" firstAttribute="top" secondItem="IAa-lP-ER3" secondAttribute="top" constant="40" id="dXk-ty-x12"/>
+                    <constraint firstItem="QuW-zx-5VW" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="eQW-qe-RjN"/>
+                    <constraint firstItem="31J-mN-zmo" firstAttribute="top" secondItem="IAa-lP-ER3" secondAttribute="top" id="iPz-wC-Ums"/>
+                    <constraint firstItem="71P-8X-s86" firstAttribute="centerX" secondItem="IAa-lP-ER3" secondAttribute="centerX" id="jYj-zc-nbe"/>
+                    <constraint firstItem="31J-mN-zmo" firstAttribute="leading" secondItem="IAa-lP-ER3" secondAttribute="leading" id="p6f-ue-RuO"/>
+                    <constraint firstAttribute="trailing" secondItem="B6d-ef-DQm" secondAttribute="trailing" constant="20" id="q00-hb-age"/>
+                    <constraint firstItem="nGW-lp-Mrf" firstAttribute="top" secondItem="QuW-zx-5VW" secondAttribute="bottom" constant="30" id="q8V-6X-6jB"/>
+                    <constraint firstItem="LfR-bu-tys" firstAttribute="top" secondItem="sqC-ri-2J8" secondAttribute="bottom" constant="5" id="ycY-wp-cGX"/>
+                </constraints>
             </view>
-            <connections>
-                <outlet property="initialFirstResponder" destination="fpJ-rI-lKJ" id="QFm-QX-kPF"/>
-            </connections>
-            <point key="canvasLocation" x="282.5" y="372"/>
+            <point key="canvasLocation" x="282" y="371.5"/>
         </window>
     </objects>
 </document>

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -57,9 +57,14 @@
                             <constraint firstAttribute="width" constant="260" id="WVR-29-5dM"/>
                             <constraint firstAttribute="height" constant="30" id="u8q-1m-Hpd"/>
                         </constraints>
-                        <buttonCell key="cell" type="bevel" title="Discard idle time" bezelStyle="regularSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="SPr-5Y-gLE">
+                        <buttonCell key="cell" type="bevel" title="Discard idle time" bezelStyle="regularSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="SPr-5Y-gLE" customClass="VerticallyCenteredButtonCell" customModule="TogglDesktop" customModuleProvider="target">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="focusRingCornerRadius">
+                                    <real key="value" value="8"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
                         </buttonCell>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="color" keyPath="bgColor">
@@ -87,9 +92,14 @@
                             <constraint firstAttribute="width" constant="260" id="56T-8y-5cD"/>
                             <constraint firstAttribute="height" constant="30" id="ONB-DD-jbd"/>
                         </constraints>
-                        <buttonCell key="cell" type="squareTextured" title="Add idle time as new time entry" bezelStyle="texturedSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="DjU-En-tIH">
+                        <buttonCell key="cell" type="squareTextured" title="Add idle time as new time entry" bezelStyle="texturedSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="DjU-En-tIH" customClass="VerticallyCenteredButtonCell" customModule="TogglDesktop" customModuleProvider="target">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="focusRingCornerRadius">
+                                    <real key="value" value="8"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
                         </buttonCell>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="color" keyPath="textColor">

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,8 +19,8 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" tabbingMode="disallowed" id="OXh-s9-LHB" customClass="NSPanel">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" texturedBackground="YES"/>
+        <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="idleNotificationWindow" animationBehavior="default" tabbingMode="disallowed" titlebarAppearsTransparent="YES" id="OXh-s9-LHB" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="517" y="489" width="300" height="323"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" id="IAa-lP-ER3">


### PR DESCRIPTION
### 📒 Description
This PR will introduce the design for Idle Window

### 🕶️ Types of changes
**New design with minor changes in codebase**

### 🤯 List of changes
- [x] Adopt new design for Idle
- [x] Reuse buttons from Feedback form (Green and white border buttons)
- [x] Navigate by keyboard and become first responder (Inspired from https://github.com/toggl/toggldesktop/pull/3010)
- [x] Corner on focus ring

### 👫 Relationships
Close #3011 

### 🔎 Review hints (Updated)
- Same design and the functionalities are remained 
- UI of Idle windows are changed when switching between light/dark mode (🍏 -> System Preferences -> General -> Light / Dark theme)
- Able to navigate through the buttons by "Tab"
- When the Idle is presented -> The "discard this time button" should be focus
- The main logic remains: Idle Time matches with waiting time.

### Screenshots 🖼 
<img width="412" alt="Screen Shot 2019-06-11 at 15 48 04" src="https://user-images.githubusercontent.com/5878421/59258790-d33a2e80-8c62-11e9-8d48-7d597e1ea58f.png">
<img width="412" alt="Screen Shot 2019-06-12 at 14 14 41" src="https://user-images.githubusercontent.com/5878421/59330879-ddb8fe80-8d1c-11e9-9731-87b077ffa3f9.png">

