### PR TITLE
Keyboard issue on Tag Input

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
@@ -1,0 +1,36 @@
+//
+//  AddTagButton.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 6/13/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+protocol AddTagButtonDelegate: class {
+    func shouldOpenTagAutoComplete(with text: String)
+}
+
+final class AddTagButton: NSButton {
+
+    // MARK: Variables
+
+    weak var delegate: AddTagButtonDelegate?
+    private let ignoreKeys = ["\t", " "] // Tab and space
+
+    // MARK: Override
+
+    override func keyDown(with event: NSEvent) {
+        super.keyDown(with: event)
+
+        // Open the auto complete if the key isn't ignore key
+        guard let characters = event.characters, !ignoreKeys.contains(characters) else { return }
+
+        // Replace "enter" with empty string if need
+        let text = characters == "\r" ? "" : characters
+
+        // Notify
+        delegate?.shouldOpenTagAutoComplete(with: text)
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -96,8 +96,7 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
     }
 
     func controlTextDidChange(_ obj: Notification) {
-        state = .expand
-        autoCompleteView.filter(with: self.stringValue)
+        handleTextDidChange()
     }
 
     @objc func arrowBtnOnTap() {
@@ -126,6 +125,11 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         let rect = windowFrameRect()
         autoCompleteWindow.layoutFrame(with: self, origin: rect.origin, size: rect.size)
         autoCompleteWindow.makeKey()
+    }
+
+    func handleTextDidChange() {
+        state = .expand
+        autoCompleteView.filter(with: self.stringValue)
     }
 
     private func closeAutoComplete() {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -120,6 +120,11 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         state = .collapse
     }
 
+    func resetText() {
+        stringValue = ""
+        handleTextDidChange()
+    }
+
     func updateWindowContent(with view: NSView, height: CGFloat) {
         autoCompleteWindow.contentView = view
         let rect = windowFrameRect()

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/TagAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/TagAutoCompleteTextField.swift
@@ -54,6 +54,10 @@ final class TagAutoCompleteTextField: AutoCompleteTextField, NSWindowDelegate {
         DispatchQueue.main.async {
             self.autoCompleteWindow.makeKeyAndOrderFront(nil)
             self.autoCompleteWindow.makeFirstResponder(self)
+
+            // We don't select all text
+            // so user can start typying
+            self.currentEditor()?.moveToEndOfDocument(nil)
         }
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -109,6 +109,11 @@ final class EditorViewController: NSViewController {
     }
 
     @IBAction func tagAddButtonOnTap(_ sender: Any) {
+
+        // Reset
+        tagTextField.resetText()
+
+        // Expand the view
         openTagAutoCompleteView()
     }
 
@@ -610,7 +615,7 @@ extension EditorViewController: AddTagButtonDelegate {
 
     func shouldOpenTagAutoComplete(with text: String) {
         // Expand the tag auto-complete
-        tagAddButtonOnTap(self)
+        openTagAutoCompleteView()
 
         // Pass the text
         tagTextField.stringValue = text

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -30,7 +30,7 @@ final class EditorViewController: NSViewController {
     @IBOutlet weak var deleteBtn: NSButton!
     @IBOutlet weak var tagAutoCompleteContainerView: NSBox!
     @IBOutlet weak var tagStackView: NSStackView!
-    @IBOutlet weak var tagAddButton: NSButton!
+    @IBOutlet weak var tagAddButton: AddTagButton!
     @IBOutlet weak var tagInputContainerView: NSBox!
     @IBOutlet weak var datePickerView: KeyboardDatePicker!
     @IBOutlet weak var dayNameButton: CursorButton!
@@ -218,6 +218,9 @@ extension EditorViewController {
             guard let strongSelf = self else { return }
             strongSelf.closeBtnOnTap(strongSelf)
         }
+
+        // Tags
+        tagAddButton.delegate = self
     }
 
     fileprivate func initDatasource() {
@@ -598,5 +601,22 @@ extension EditorViewController {
                                                        selector: #selector(self.updateProjectUndoValue(_:)),
                                                        object: oldValue)
         }
+    }
+}
+
+// MARK: AddTagButtonDelegate
+
+extension EditorViewController: AddTagButtonDelegate {
+
+    func shouldOpenTagAutoComplete(with text: String) {
+        // Expand the tag auto-complete
+        tagAddButtonOnTap(self)
+
+        // Pass the text
+        tagTextField.stringValue = text
+
+        // Notify the change manually
+        // because stringValue doesn't notify the delegate
+        tagTextField.handleTextDidChange()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -482,6 +482,9 @@ extension EditorViewController: AutoCompleteTextFieldDelegate {
             tagDatasource.updateSelectedTags(selectedTags)
             TagStorage.shared.addNewTag(newTag)
             DesktopLibraryBridge.shared().updateTimeEntry(withTags: selectedTags.toNames(), guid: timeEntry.guid)
+
+            // Focus on tag textfield agains, so user can continue typying
+            sender.window?.makeFirstResponder(tagTextField)
         }
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -140,7 +140,7 @@
                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Scx-li-Ewv">
                                             <rect key="frame" x="0.0" y="0.0" width="252" height="28"/>
                                             <subviews>
-                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fzH-q2-m3a">
+                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fzH-q2-m3a" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="252" height="28"/>
                                                     <buttonCell key="cell" type="bevel" title="Add tags" bezelStyle="rounded" alignment="left" imageScaling="proportionallyDown" inset="2" id="FrN-5J-6rF" customClass="VerticallyCenteredButtonCell" customModule="TogglDesktop" customModuleProvider="target">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		BAD858CC228EAE7C00226C71 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = BAD858CB228EAE7C00226C71 /* libz.tbd */; };
 		BAE007DE21FAF00D00404379 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAE007DD21FAF00D00404379 /* Media.xcassets */; };
 		BAE49CAE222FC1C900773814 /* TimerContainerBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE49CAD222FC1C900773814 /* TimerContainerBox.swift */; };
+		BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE6379922B225C70024DD08 /* AddTagButton.swift */; };
 		BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */; };
 		BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
 		BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAF50DE421A29FED0090BA95 /* Images.xcassets */; };
@@ -909,6 +910,7 @@
 		BAD858CB228EAE7C00226C71 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		BAE007DD21FAF00D00404379 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		BAE49CAD222FC1C900773814 /* TimerContainerBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerContainerBox.swift; sourceTree = "<group>"; };
+		BAE6379922B225C70024DD08 /* AddTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagButton.swift; sourceTree = "<group>"; };
 		BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BAF50DE421A29FED0090BA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TogglDesktop/Images.xcassets; sourceTree = "<group>"; };
 		BAF50DF621A2A18D0090BA95 /* AppIconFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIconFactory.h; sourceTree = "<group>"; };
@@ -1439,6 +1441,7 @@
 				BA84363A22533A6600EF5830 /* DesktopLibraryBridge.m */,
 				BA053658225DDDBB00C26E1F /* CustomFocusRingButton.swift */,
 				BAD307D2229C1BD000C727DB /* KeyboardDatePicker.swift */,
+				BAE6379922B225C70024DD08 /* AddTagButton.swift */,
 			);
 			path = TimeEntryEditor;
 			sourceTree = "<group>";
@@ -2200,6 +2203,7 @@
 				C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */,
 				74762BA118A139D4004433A9 /* NSUnstripedTableView.m in Sources */,
 				C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */,
+				BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */,
 				BA2DA0C621A542E30027B7A5 /* NSTextField+Ext.m in Sources */,
 				747B74871A0AD28200BB3791 /* ConsoleViewController.m in Sources */,
 				BA9D90D4222D155900D5EC0E /* NSView+Ext.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR introduces the fix for keyboard issue in Tag input

### Problem
It's all about the design. The "Add tags" isn't the TextField, it's the NSButton, so we're unable to type any text during focusing here.

![Screen_Shot_2019-06-13_at_14_09_53](https://user-images.githubusercontent.com/5878421/59411295-19b79680-8de5-11e9-8f8b-ea97b8257bca.jpg)

### Solution
I introduce the AddTagButton as a subclass of NSButton, then it will pass all characters (exclude some ignore characters) from `-keyDown` to their `delegate`.

It means that user can start typing without any disruption.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Introduce the AddTAgButton
- [x] Receive the characters from AddTAgButton and present on Tag Input
- [x] Minor cursor improvements 

### 👫 Relationships
Closes #3028 

### 🔎 Review hints
- Able to navigate throughly by pressing Tab
- Able to start typing when focusing on Tag Button
- When typing text on Tag Button -> The Tag AutoComplete view will appear and filter properly
- Click on Tag Button -> Open the view as normal

### GIF
![2019-06-13 14 15 28](https://user-images.githubusercontent.com/5878421/59411698-0822be80-8de6-11e9-98c0-186f896bfc40.gif)