### PR TITLE
Fix for Double-clicking on mini-timer does not open desktop app #3034

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -313,6 +313,11 @@ namespace TogglDesktop
                 return;
 
             this.updateEditPopupLocation(true);
+
+            if (open)
+            {
+                this.Show();
+            }
         }
 
         private void onStoppedTimerState()


### PR DESCRIPTION
### 📒 Description
Fix the issue when double-clicking on mini-timer does not open the desktop app.

The bug was introduced in `0fda7e90d1ed4a288a0a48c258950994c6c2be0a` (#2911 PR) in the library fixes of MacOS focus jump which did not account for double-clicking on Windows Mini-Timer flow.

I've decided to make a simple fix on the Windows side to avoid MacOS focus jump problems. The logic is similar to what was on the library side. It just makes sure that the main window is open when the app tries to open a time entry editor.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3034.

### 🔎 Review hints
All scenarios that can trigger `DisplayTimeEntryEditor()` are affected. This logic was previously present in the lib, so the fix looks pretty safe imho.