### PR TITLE
Focus textfields on Editor

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -48,6 +48,7 @@ final class EditorViewController: NSViewController {
         didSet {
             fillData()
             registerUndoForAllFields()
+            setFocusOnTextField()
         }
     }
     private var selectedProjectItem: ProjectContentItem?
@@ -93,8 +94,6 @@ final class EditorViewController: NSViewController {
 
     override func viewDidAppear() {
         super.viewDidAppear()
-
-        view.window?.makeFirstResponder(descriptionTextField)
         updateNextKeyViews()
     }
 
@@ -387,6 +386,21 @@ extension EditorViewController {
         // Update
         let durationText = DesktopLibraryBridge.shared().convertDuraton(inSecond: timeEntry.duration_in_seconds)
         durationTextField.stringValue = durationText
+    }
+
+    fileprivate func setFocusOnTextField() {
+        guard let timeEntry = timeEntry,
+            let focusedFieldName = timeEntry.focusedFieldName else { return }
+
+        // Focus on specific text fields
+        switch focusedFieldName {
+        case String(utf8String: kFocusedFieldNameDuration):
+            view.window?.makeFirstResponder(durationTextField)
+        case String(utf8String: kFocusedFieldNameProject):
+            view.window?.makeFirstResponder(projectTextField)
+        default:
+            view.window?.makeFirstResponder(descriptionTextField)
+        }
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -398,6 +398,13 @@ extension EditorViewController {
             view.window?.makeFirstResponder(durationTextField)
         case String(utf8String: kFocusedFieldNameProject):
             view.window?.makeFirstResponder(projectTextField)
+        case String(utf8String: kFocusedFieldNameTag):
+            if let tags = timeEntry.tags, tags.isEmpty {
+                view.window?.makeFirstResponder(tagAddButton)
+            } else {
+                guard let firstTag = tagStackView.arrangedSubviews.first as? TagTokenView else { return }
+                view.window?.makeFirstResponder(firstTag.actionButton)
+            }
         default:
             view.window?.makeFirstResponder(descriptionTextField)
         }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -48,7 +48,11 @@ final class EditorViewController: NSViewController {
         didSet {
             fillData()
             registerUndoForAllFields()
-            setFocusOnTextField()
+
+            // Check if the Editor has update with new TimeEntry -> Reset focus to Description TextField
+            // If not, just keep focus on current textfield
+            let defaultFocus = checkShouldFocusByDefault(for: oldValue, newValue: timeEntry)
+            setFocusOnTextField(shouldFocusByDefault: defaultFocus)
         }
     }
     private var selectedProjectItem: ProjectContentItem?
@@ -388,7 +392,14 @@ extension EditorViewController {
         durationTextField.stringValue = durationText
     }
 
-    fileprivate func setFocusOnTextField() {
+    fileprivate func checkShouldFocusByDefault(for oldValue: TimeEntryViewItem?, newValue: TimeEntryViewItem?) -> Bool {
+        guard let oldValueGuid = oldValue?.guid, let newValueGuid = timeEntry?.guid else { return false }
+        return oldValueGuid != newValueGuid
+    }
+
+    fileprivate func setFocusOnTextField(shouldFocusByDefault: Bool) {
+
+
         guard let timeEntry = timeEntry,
             let focusedFieldName = timeEntry.focusedFieldName else { return }
 
@@ -406,7 +417,9 @@ extension EditorViewController {
                 view.window?.makeFirstResponder(firstTag.actionButton)
             }
         default:
-            view.window?.makeFirstResponder(descriptionTextField)
+            if shouldFocusByDefault {
+                view.window?.makeFirstResponder(descriptionTextField)
+            }
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -401,7 +401,7 @@
                                     <constraint firstAttribute="height" constant="20" id="bbQ-Pp-Vcw"/>
                                     <constraint firstAttribute="width" constant="20" id="bnN-Hu-0cO"/>
                                 </constraints>
-                                <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="close-button" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="UZy-3R-deK">
+                                <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="close-button" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="UZy-3R-deK">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -58,3 +58,4 @@ extern NSString *const kUserHasBeenSignup;
 const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;
 const char *kFocusedFieldNameProject;
+const char *kFocusedFieldNameTag;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -55,3 +55,4 @@ NSString *const kUserHasBeenSignup = @"kUserHasBeenSignup";
 const char *kFocusedFieldNameDuration = "duration";
 const char *kFocusedFieldNameDescription = "description";
 const char *kFocusedFieldNameProject = "project";
+const char *kFocusedFieldNameTag = "tag";

--- a/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
+++ b/src/ui/osx/TogglDesktop/test2/TimeEntryCell.m
@@ -321,6 +321,13 @@ extern void *ctx;
 		return;
 	}
 
+	NSRect tagFlagFrame = [self.view convertRect:self.tagFlag.frame fromView:self.tagFlag];
+	if (NSPointInRect(mouseLocation, tagFlagFrame))
+	{
+		toggl_edit(ctx, [self.GUID UTF8String], false, kFocusedFieldNameTag);
+		return;
+	}
+
 	toggl_edit(ctx, [self.GUID UTF8String], false, "");
 }
 


### PR DESCRIPTION
### 📒 Description
This PR will introduce the feature to focus on specific textfields, which we select on Time Entry List. It's old behavior of Time Entry Editor, but we forgot to bring it up to new home.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Focus on text fields, depend on current selection on TimeEntryCell
- [x] Support focus on Tag Token views

### 👫 Relationships
#3041 

### 🔎 Review hints
1. Select following labels in Time Entry Cell, and observe the focus ring in TimeEntry Editor
- Click on Title label -> The Description textfield should be focused
- Click on Project label -> The Project textfield should be focused
- Click on Duration -> The duration should be focused
- Click on Tag -> The first tag view should be focused
- Otherwise -> The Description textfield should be focused

### GIF
![2019-06-25 15 08 51](https://user-images.githubusercontent.com/5878421/60081958-11544980-975d-11e9-8039-77aec340fbb7.gif)
