### PR TITLE
Resizable Editor Popover and Tool tip

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -69,6 +69,17 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         }
     }
 
+    override var stringValue: String {
+        didSet {
+            toolTip = stringValue
+        }
+    }
+    override var attributedStringValue: NSAttributedString {
+        didSet {
+            toolTip = attributedStringValue.string
+        }
+    }
+
     // MARK: Init
 
     override init(frame frameRect: NSRect) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
@@ -14,6 +14,16 @@ final class EditorPopover: NoVibrantPopoverView {
         static let FocusTimerNotification = NSNotification.Name(kFocusTimer)
     }
 
+    override init() {
+        let size = CGSize(width: 274, height: 381)
+        let maxSize = CGSize(width: size.width * 2, height: size.height * 2)
+        super.init(min: size, max: maxSize)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
     @objc func prepareViewController() {
         let editor = EditorViewController(nibName: NSNib.Name("EditorViewController"), bundle: nil)
         contentViewController = editor

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
@@ -16,7 +16,7 @@ final class EditorPopover: NoVibrantPopoverView {
 
     override init() {
         let size = CGSize(width: 274, height: 381)
-        let maxSize = CGSize(width: size.width * 2, height: size.height * 2)
+        let maxSize = CGSize(width: size.width * 3, height: size.height)
         super.init(min: size, max: maxSize)
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -527,7 +527,7 @@
                             <constraint firstItem="Zk0-BK-EiX" firstAttribute="leading" secondItem="RzB-ad-pEO" secondAttribute="leading" constant="10" id="uKE-Oe-S4J"/>
                             <constraint firstItem="FXR-Ha-kYg" firstAttribute="top" secondItem="RzB-ad-pEO" secondAttribute="top" constant="5" id="uSd-7e-ckx"/>
                             <constraint firstAttribute="trailing" secondItem="fPF-go-RPE" secondAttribute="trailing" constant="10" id="utZ-T7-DxC"/>
-                            <constraint firstItem="Wyt-sv-sZR" firstAttribute="leading" secondItem="Qo9-rw-PRz" secondAttribute="trailing" constant="8" id="vUQ-3b-rmy"/>
+                            <constraint firstItem="Wyt-sv-sZR" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Qo9-rw-PRz" secondAttribute="trailing" constant="8" id="vUQ-3b-rmy"/>
                             <constraint firstItem="Qo9-rw-PRz" firstAttribute="top" secondItem="flL-k2-TC8" secondAttribute="bottom" constant="10" id="vlX-v9-R8U"/>
                             <constraint firstItem="sts-eu-78s" firstAttribute="leading" secondItem="RzB-ad-pEO" secondAttribute="leading" constant="10" id="xot-d9-UOv"/>
                         </constraints>
@@ -541,7 +541,7 @@
                 <constraint firstItem="fZO-4l-jo1" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="nno-xe-fYT"/>
                 <constraint firstAttribute="bottom" secondItem="fZO-4l-jo1" secondAttribute="bottom" id="yr2-gk-PkQ"/>
             </constraints>
-            <point key="canvasLocation" x="-586" y="-285.5"/>
+            <point key="canvasLocation" x="-545.5" y="-226"/>
         </customView>
     </objects>
     <resources>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/NoVibrantPopoverView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/NoVibrantPopoverView.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class NoVibrantPopoverView: NSPopover {
+class NoVibrantPopoverView: ResizablePopover {
 
     override var appearance: NSAppearance? {
         get {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
@@ -1,0 +1,231 @@
+//
+//  ResizablePopover.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 6/25/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+class ResizablePopover: NSPopover {
+
+    let BOTTOM_HIT = CGFloat(4)
+    let CORNER_HIT = CGFloat(10)
+
+    private enum Region {
+        case None
+        case Left
+        case LeftBottom
+        case Right
+        case RightBottom
+    }
+
+    // MARK: Variables
+
+    private var min: NSSize
+    private var max: NSSize
+    private var region: Region = .None
+    private var down: NSPoint?
+    private var size: NSSize?
+    private var trackLeft: NSView.TrackingRectTag?
+    private var trackRight: NSView.TrackingRectTag?
+    private var trackLeftBottom: NSView.TrackingRectTag?
+    private var trackRightBottom: NSView.TrackingRectTag?
+    private var trackBottom: NSView.TrackingRectTag?
+    private var sizeChanged: ((_ size: NSSize) -> Void)? = nil
+
+    private let cursorLeftBottom = NSCursor.resizeLeftRight
+    private let cursorRightBottom = NSCursor.resizeUpDown
+
+    override var contentViewController: NSViewController? {
+        didSet {
+            prepareTracker()
+        }
+    }
+    // min: the mimimum size the popover is allowed to be
+    // max: the maximum size the popover is allowed to be
+    // heightFromBottom: Set this to limit the draggable handle region
+    //                   to a height starting from the bottom of the popover
+    //                   If 0, then it uses the entire height of popover
+    public init(min: NSSize, max: NSSize) {
+        self.min = min
+        self.max = max
+
+        // If not defined, use the screen height
+        if let screen = NSScreen.main,
+            self.max.height == 0 {
+            self.max.height = CGFloat(screen.frame.height)
+        }
+        super.init()
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        clearTrackers()
+    }
+
+    // Call this to get notified anytime the popover is resized
+    func resized(_ sizeChanged: @escaping (_ size: NSSize) -> Void) {
+        self.sizeChanged = sizeChanged
+    }
+
+    private func prepareTracker() {
+        guard let controller = contentViewController else { return }
+
+        // Set default content size
+        contentSize = NSSize(width: controller.view.bounds.width, height: controller.view.bounds.height)
+
+        // Setup the tracker
+        setTrackers()
+    }
+
+    override public func mouseEntered(with event: NSEvent) {
+        if region == .None {
+            if event.trackingNumber == trackLeft {
+                region = .Left
+            } else if event.trackingNumber == trackRight {
+                region = .Right
+            } else if event.trackingNumber == trackLeftBottom {
+                region = .LeftBottom
+            } else if event.trackingNumber == trackRightBottom {
+                region = .RightBottom
+            } else {
+                region = .None
+            }
+
+            setCursor()
+        }
+    }
+
+    override public func mouseExited(with event: NSEvent) {
+        if down == nil {
+            region = .None
+            setCursor()
+        }
+    }
+
+    override public func mouseDown(with event: NSEvent) {
+        self.size = contentSize
+        self.down = NSEvent.mouseLocation
+    }
+
+    override public func mouseDragged(with event: NSEvent) {
+        if region == .None {
+            return
+        }
+
+        guard let size = size else { return }
+        guard let down = down else { return }
+
+        let location = NSEvent.mouseLocation
+
+        var movedX = (location.x - down.x) * 2
+        let movedY = location.y - down.y
+        //        print("MOVE x: \(movedX), y: \(movedY)")
+
+        if region == .Left || region == .LeftBottom {
+            movedX = -movedX
+        }
+
+        var newWidth = size.width + movedX
+        if newWidth < min.width {
+            newWidth = min.width
+        } else if newWidth > max.width {
+            newWidth = max.width
+        }
+
+        var newHeight = size.height - movedY
+        if newHeight < min.height {
+            newHeight = min.height
+        } else if newHeight > max.height {
+            newHeight = max.height
+        }
+
+        switch region {
+        case .Left: fallthrough
+        case .Right:
+            contentSize = NSSize(width: newWidth, height: contentSize.height)
+        case .LeftBottom: fallthrough
+        case .RightBottom:
+            contentSize = NSSize(width: newWidth, height: newHeight)
+        default:
+            break
+        }
+
+        setCursor()
+    }
+
+    override public func mouseUp(with event: NSEvent) {
+        if region != .None {
+            region = .None
+            setCursor()
+            setTrackers()
+            down = nil
+
+            if let onChanged = sizeChanged {
+                onChanged(NSSize(width: contentSize.width, height: contentSize.height))
+            }
+        }
+    }
+
+    private func setCursor() {
+        switch region {
+        case .Left:
+            NSCursor.resizeLeft.set()
+        case .Right:
+            NSCursor.resizeRight.set()
+        case .LeftBottom:
+            cursorLeftBottom.set()
+        case .RightBottom:
+            cursorRightBottom.set()
+        default:
+            NSCursor.arrow.set()
+        }
+    }
+
+    private func setTrackers() {
+        clearTrackers()
+
+        if let view = contentViewController?.view {
+            var bounds = NSRect(x: 0, y: CORNER_HIT, width: SIDES_HIT, height: CORNER_HIT)
+            trackLeft = view.addTrackingRect(bounds, owner: self, userData: nil, assumeInside: false)
+
+            bounds = NSRect(x: contentSize.width - SIDES_HIT, y: CORNER_HIT, width: SIDES_HIT, height: CORNER_HIT)
+            trackRight = view.addTrackingRect(bounds, owner: self, userData: nil, assumeInside: false)
+
+            bounds = NSRect(x: 0, y: 0, width: CORNER_HIT, height: CORNER_HIT)
+            trackLeftBottom = view.addTrackingRect(bounds, owner: self, userData: nil, assumeInside: false)
+
+            bounds = NSRect(x: contentSize.width - CORNER_HIT, y: 0, width: CORNER_HIT, height: CORNER_HIT)
+            trackRightBottom = view.addTrackingRect(bounds, owner: self, userData: nil, assumeInside: false)
+
+            bounds = NSRect(x: CORNER_HIT, y: 0, width: contentSize.width - CORNER_HIT * 2, height: BOTTOM_HIT)
+            trackBottom = view.addTrackingRect(bounds, owner: self, userData: nil, assumeInside: false)
+        }
+    }
+
+    private func clearTrackers() {
+        if let view = contentViewController?.view, let left = trackLeft, let right = trackRight, let leftBottom = trackLeftBottom, let rightBottom = trackRightBottom, let bottom = trackBottom {
+            view.removeTrackingRect(left)
+            view.removeTrackingRect(right)
+            view.removeTrackingRect(rightBottom)
+            view.removeTrackingRect(leftBottom)
+            view.removeTrackingRect(bottom)
+        }
+    }
+
+    private static func getCursor(_ name: String) -> NSCursor {
+        return NSCursor.openHand
+        let path = Bundle(for: self).bundlePath
+
+        let image = NSImage(byReferencingFile: path + "/Resources/resources/\(name)_cursor.pdf")
+        let info = NSDictionary(contentsOfFile: path + "/Resources/resources/\(name)_info.plist")
+        let cursor = NSCursor(image: image!, hotSpot: NSPoint(x: (info!.value(forKey: "hotx")! as AnyObject).doubleValue!, y: (info!.value(forKey: "hoty")! as AnyObject).doubleValue!))
+
+        return cursor
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
@@ -129,9 +129,7 @@ class ResizablePopover: NSPopover {
         guard let down = down else { return }
 
         let location = NSEvent.mouseLocation
-
-        var movedX = (location.x - down.x) * 2
-
+        var movedX = location.x - down.x
         if region == .Left {
             movedX = -movedX
         }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Tag/TagCellView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Tag/TagCellView.swift
@@ -75,7 +75,7 @@ final class TagCellView: NSTableCellView {
         } else {
             checkButton.title = tag.name
         }
-
+        checkButton.toolTip = tag.name
     }
 
     func selectCheckBox() {

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		BA412C27224E195C003CA17A /* NoClientCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA412C26224E195C003CA17A /* NoClientCellView.swift */; };
 		BA412C29224E196D003CA17A /* NoClientCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA412C28224E196D003CA17A /* NoClientCellView.xib */; };
 		BA46E09F2226707F00C25763 /* Collection+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46E09E2226707F00C25763 /* Collection+Safe.swift */; };
+		BA4AEB9C22C217A4001A898D /* ResizablePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */; };
 		BA50ED8522705F9E008323FA /* CalendarFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */; };
 		BA6572A6224DFA6F00BA4C60 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A0224DFA6E00BA4C60 /* RGB.swift */; };
 		BA6572A7224DFA6F00BA4C60 /* HSBGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A1224DFA6E00BA4C60 /* HSBGen.swift */; };
@@ -829,6 +830,7 @@
 		BA412C26224E195C003CA17A /* NoClientCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoClientCellView.swift; sourceTree = "<group>"; };
 		BA412C28224E196D003CA17A /* NoClientCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoClientCellView.xib; sourceTree = "<group>"; };
 		BA46E09E2226707F00C25763 /* Collection+Safe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Safe.swift"; sourceTree = "<group>"; };
+		BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizablePopover.swift; sourceTree = "<group>"; };
 		BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarFlowLayout.swift; sourceTree = "<group>"; };
 		BA6572A0224DFA6E00BA4C60 /* RGB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RGB.swift; sourceTree = "<group>"; };
 		BA6572A1224DFA6E00BA4C60 /* HSBGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HSBGen.swift; sourceTree = "<group>"; };
@@ -1432,6 +1434,7 @@
 				BA412C1B224E0D3E003CA17A /* Client */,
 				BA9C2DD8224C7E2E002AD2A1 /* Project */,
 				BA7D332B2248940800B953A8 /* AutoComplete */,
+				BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */,
 				BA13D2162269DE3400EB3833 /* NoVibrantPopoverView.swift */,
 				BA2E5FB0223787C300EB866E /* EditorPopover.swift */,
 				BA34F0FE22439C3000C27A15 /* EditorViewController.swift */,
@@ -2308,6 +2311,7 @@
 				BA7D335A22489C8000B953A8 /* ProjectDataSource.swift in Sources */,
 				BAC4D399225470DA00254DAD /* AutoCompleteRowView.swift in Sources */,
 				BAA260D1222D1DC70094F4E4 /* NSView+Shadow+Border.swift in Sources */,
+				BA4AEB9C22C217A4001A898D /* ResizablePopover.swift in Sources */,
 				BA712EC221BF907200A2D8DD /* UndoManager.swift in Sources */,
 				BAA11AC12251F49E007F31D2 /* WorkspaceStorage.swift in Sources */,
 				3C3AF64E20ACC6280088A3A6 /* CountryViewItem.m in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -42,6 +42,11 @@
 	}
 }
 
+- (void)setAttributedStringValue:(NSAttributedString *)attributedStringValue {
+	[super setAttributedStringValue:attributedStringValue];
+	self.toolTip = self.attributedStringValue.string;
+}
+
 - (void)setTitleWithTimeEntry:(TimeEntryViewItem *)item
 {
 	self.textColor = [ConvertHexColor hexCodeToNSColor:item.ProjectColor];


### PR DESCRIPTION
### 📒 Description
Some users complain that the default size of Editor Popover and AutoComplete is so tiny, and they're unable to read the long title.

This PR will introduce: 
- Resizable Editor Popover (Resize width, same behavior with old design)
- Add tool tips to Project AutoCompleteItem and few controls in Editor
- Add ellipsis if the string is long

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality) 

### 🤯 List of changes
- Introduce Resizable Popover class, which supports to resize the width of the content (Min and Max size)
- EditorPopover is now subclassed from Resizable Popover
- Has flag to enable/disable 
- Add tooltip to project AutoCompleteItem and few controls in Editor
- Check ellipsis

### 👫 Relationships
Close #3040 

### 🔎 Review hints
- Able to resize the width of Editor Popover 
=> The mouse update, and the width changes
- After resizing, the Popover's size still remains (Quit app will reset the size)
- Try creating long Project then observing the following criteria
=> Able to see entire title when we resized the Editor
=> Project in Editor and AutoComplete should has ellipsis
=> Project in Editor and AutoComplete should has tooltip when hovering the mouse

### Screenshots
<img width="1022" alt="Screen Shot 2019-06-25 at 17 18 05" src="https://user-images.githubusercontent.com/5878421/60091453-d1965d80-976e-11e9-8e09-5b80b4296c6c.png">
<img width="450" alt="Screen Shot 2019-06-25 at 17 17 53" src="https://user-images.githubusercontent.com/5878421/60091454-d1965d80-976e-11e9-95b3-d4b43bcafc39.png">
<img width="427" alt="Screen Shot 2019-06-25 at 17 17 47" src="https://user-images.githubusercontent.com/5878421/60091455-d22ef400-976e-11e9-81e5-53b81c3dce55.png">

![2019-06-25 17 20 06](https://user-images.githubusercontent.com/5878421/60091469-d9ee9880-976e-11e9-9bf0-dbd2965405a2.gif)
