### PR TITLE
Stop Timer when Idle or Pomodoro break occurs

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -187,10 +187,6 @@ NSString *kInactiveTimerColor = @"#999999";
 		{
 			return;
 		}
-		if (self.descriptionLabel.stringValue != nil || self.projectTextField.stringValue != nil)
-		{
-			return;
-		}
 		te = [[TimeEntryViewItem alloc] init];
 	}
 	self.time_entry = te;


### PR DESCRIPTION
### 📒 Description
There is two scenarios that the Timer doesn't stop 
1. Discard Idle time
2. Pomodoro break finishes

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Remove invalid code in TimerEditViewController, which prevents the Timer from stopping.

### 👫 Relationships
Close #3037 
Close #3030  

### 🔎 Review hints
#### Idle time
1. Set 1 min for Idle Detection in Preference
2. Start any Time Entry and keep the mouse from moving (idle)
3. After 1 min, the Idle Windows appears -> Press Discard Idle
=> If the Timer stop, and we have new TE in the List => 💯 

#### Pomodoro break
1. Set 1 min for Pomodoro Timer and Pomodoro Break in Preference
2. Start any Time Entry
3. Keep using the app, and after 1 mins => Pomodoro Break Task will start 
4. After 1 min, the Pomodoro Break Task will stop
5. If the timer Stop => 💯 