### PR TITLE
Fix Tasks handling in the Time Entry Editor

### DIFF
--- a/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
@@ -52,6 +52,9 @@ QVariant AutocompleteListModel::data(const QModelIndex &index, int role) const {
                 return view->Description;
             }
         }
+        else if (view->Type == 1 && displayItem == 2){
+            return QString("%1. %2").arg(view->TaskLabel).arg(view->ProjectLabel);
+        }
         else {
             return QString();
         }

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -101,7 +101,8 @@ void TimerWidget::descriptionProjectSelected(const QString &projectName, uint64_
     if (projectId && !projectName.isEmpty()) {
         ui->projectFrame->setVisible(true);
         ui->project->setText(QString("<font color=\"%1\">%2</font>").arg(color).arg(projectName));
-        clearTask();
+        if (!taskId)
+            clearTask();
         if (taskId && !taskName.isEmpty()) {
             ui->taskFrame->setVisible(true);
             ui->task->setText(QString("<font color=\"gray\">%1</font>").arg(taskName));
@@ -241,6 +242,9 @@ void TimerWidget::displayRunningTimerState(
 }
 
 void TimerWidget::displayStoppedTimerState() {
+    if (ui->description->hasFocus())
+        return;
+
     guid = QString();
     selectedTaskId = 0;
     selectedProjectId = 0;


### PR DESCRIPTION
### 📒 Description
This is a small patch for the Autocomplete widget for Linux. It fixes task and project handling in the Timer and Time Entry Editor widgets.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Tasks are now handled correctly in Linux

### 👫 Relationships
Fixes #3051

### 🔎 Review hints
See the reproduction steps in #3051 - Projects and Tasks should be handled and displayed right in all scenarios.

