### PR TITLE
Disable logging for QtWebEngine

### DIFF
--- a/src/ui/linux/TogglDesktop.sh
+++ b/src/ui/linux/TogglDesktop.sh
@@ -14,6 +14,7 @@ if [ -f "$dirname/QtWebEngineProcess" ]; then
   QTWEBENGINEPROCESS_PATH=$dirname/QtWebEngineProcess
   export QTWEBENGINEPROCESS_PATH
 fi
+export QTWEBENGINE_CHROMIUM_FLAGS="--disable-logging"
 
 # Xubuntu, i3 and Cinnamon tray icon fix
 XDG=$XDG_CURRENT_DESKTOP


### PR DESCRIPTION
### 📒 Description
This should help with log flooding in case of Snapcraft uninstall. I haven't actually tested this yet, personally, as I don't have a working Snapcraft configuration on my computer at this moment (can't download an Ubuntu image using `multipass` while running `snapcraft`)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Logging is now disabled for QtWebEngine

### 👫 Relationships
Closes #2941

### 🔎 Review hints
While TogglDesktop installed using Snap is running, uninstall it. Without this patch, you should notice the process logging huge amounts of error messages in your system log. With this patch, it should not log anything.

