### PR TITLE
Fix compilation warnings coming from the library

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -21,6 +21,7 @@
 
 namespace toggl {
 
+
 void Analytics::Track(const std::string client_id,
                       const std::string category,
                       const std::string action) {

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -96,9 +96,9 @@ class GoogleAnalyticsSettingsEvent : public Poco::Task {
         : Poco::Task("GoogleAnalyticsSettingsEvent")
     , client_id_(client_id)
     , category_(category)
+    , uses_proxy(uses_proxy)
     , record_timeline(record_timeline)
     , settings(settings)
-    , uses_proxy(uses_proxy)
     , proxy(proxy) {}
     void runTask();
 

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -120,7 +120,7 @@ error BaseModel::LoadFromDataString(const std::string data_string) {
 }
 
 void BaseModel::Delete() {
-    SetDeletedAt(time(0));
+    SetDeletedAt(time(nullptr));
     SetUIModified();
 }
 

--- a/src/base_model.cc
+++ b/src/base_model.cc
@@ -63,14 +63,14 @@ void BaseModel::SetValidationError(const std::string value) {
     }
 }
 
-void BaseModel::SetDeletedAt(const Poco::UInt64 value) {
+void BaseModel::SetDeletedAt(const Poco::Int64 value) {
     if (deleted_at_ != value) {
         deleted_at_ = value;
         SetDirty();
     }
 }
 
-void BaseModel::SetUpdatedAt(const Poco::UInt64 value) {
+void BaseModel::SetUpdatedAt(const Poco::Int64 value) {
     if (updated_at_ != value) {
         updated_at_ = value;
         SetDirty();
@@ -84,7 +84,7 @@ void BaseModel::SetGUID(const std::string value) {
     }
 }
 
-void BaseModel::SetUIModifiedAt(const Poco::UInt64 value) {
+void BaseModel::SetUIModifiedAt(const Poco::Int64 value) {
     if (ui_modified_at_ != value) {
         ui_modified_at_ = value;
         SetDirty();

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -57,7 +57,7 @@ class BaseModel {
     }
     void SetUIModifiedAt(const Poco::Int64 value);
     void SetUIModified() {
-        SetUIModifiedAt(time(0));
+        SetUIModifiedAt(time(nullptr));
     }
 
     const std::string &GUID() const {

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -52,10 +52,10 @@ class BaseModel {
     }
     void SetID(const Poco::UInt64 value);
 
-    const Poco::UInt64 &UIModifiedAt() const {
+    const Poco::Int64 &UIModifiedAt() const {
         return ui_modified_at_;
     }
-    void SetUIModifiedAt(const Poco::UInt64 value);
+    void SetUIModifiedAt(const Poco::Int64 value);
     void SetUIModified() {
         SetUIModifiedAt(time(0));
     }
@@ -88,15 +88,15 @@ class BaseModel {
 
     // Deleting a time entry hides it from
     // UI and flags it for removal from server:
-    const Poco::UInt64 &DeletedAt() const {
+    const Poco::Int64 &DeletedAt() const {
         return deleted_at_;
     }
-    void SetDeletedAt(const Poco::UInt64 value);
+    void SetDeletedAt(const Poco::Int64 value);
 
-    const Poco::UInt64 &UpdatedAt() const {
+    const Poco::Int64 &UpdatedAt() const {
         return updated_at_;
     }
-    void SetUpdatedAt(const Poco::UInt64 value);
+    void SetUpdatedAt(const Poco::Int64 value);
 
     std::string UpdatedAtString() const;
     void SetUpdatedAtString(const std::string value);

--- a/src/base_model.h
+++ b/src/base_model.h
@@ -167,12 +167,12 @@ class BaseModel {
     Poco::Int64 local_id_;
     Poco::UInt64 id_;
     guid guid_;
-    Poco::UInt64 ui_modified_at_;
+    Poco::Int64 ui_modified_at_;
     Poco::UInt64 uid_;
     bool dirty_;
-    Poco::UInt64 deleted_at_;
+    Poco::Int64 deleted_at_;
     bool is_marked_as_deleted_on_server_;
-    Poco::UInt64 updated_at_;
+    Poco::Int64 updated_at_;
 
     // If model push to backend results in an error,
     // the error is attached to the model for later inspection.

--- a/src/context.cc
+++ b/src/context.cc
@@ -2246,7 +2246,6 @@ error Context::Login(
     } catch(const std::string& ex) {
         return displayError(ex);
     }
-    return noError;
 }
 
 error Context::AsyncSignup(const std::string email,
@@ -2483,7 +2482,6 @@ error Context::ClearCache() {
     } catch(const std::string& ex) {
         return displayError(ex);
     }
-    return noError;
 }
 
 TimeEntry *Context::Start(
@@ -3407,7 +3405,6 @@ error Context::SetDefaultProject(
     } catch(const std::string& ex) {
         return displayError(ex);
     }
-    return noError;
 }
 
 error Context::DefaultProjectName(std::string *name) {
@@ -5060,7 +5057,6 @@ error Context::pullObmExperiments() {
     } catch(const std::string& ex) {
         return ex;
     }
-    return noError;
 }
 
 error Context::pushObmAction() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1007,7 +1007,7 @@ int Context::nextSyncIntervalSeconds() const {
 }
 
 void Context::scheduleSync() {
-    Poco::Int64 elapsed_seconds = Poco::Int64(time(0)) - last_sync_started_;
+    Poco::Int64 elapsed_seconds = Poco::Int64(time(nullptr)) - last_sync_started_;
 
     {
         std::stringstream ss;
@@ -1040,14 +1040,14 @@ void Context::Sync() {
 
     overlay_visible_ = false;
 
-    Poco::Int64 elapsed_seconds = Poco::Int64(time(0)) - last_sync_started_;
+    Poco::Int64 elapsed_seconds = Poco::Int64(time(nullptr)) - last_sync_started_;
 
     // 2 seconds backoff to avoid too many sync requests
     if (elapsed_seconds < kRequestThrottleSeconds) {
         return;
     }
 
-    last_sync_started_ = time(0);
+    last_sync_started_ = time(nullptr);
 
     // Always sync asyncronously with syncerActivity
     trigger_sync_ = true;
@@ -1655,7 +1655,7 @@ void Context::onSendFeedback(Poco::Util::TimerTask& task) {  // NOLINT
     form.set("toggl_version", HTTPSClient::Config.AppVersion);
     form.set("details", Formatter::EscapeJSONString(feedback_.Details()));
     form.set("subject", Formatter::EscapeJSONString(feedback_.Subject()));
-    form.set("date", Formatter::Format8601(time(0)));
+    form.set("date", Formatter::Format8601(time(nullptr)));
     form.set("update_channel", Formatter::EscapeJSONString(update_channel));
 
     if (!feedback_.AttachmentPath().empty()) {
@@ -3269,7 +3269,7 @@ TimeEntry *Context::DiscardTimeAndContinue(
     const Poco::Int64 at) {
 
     // Reset reminder count when doing idle actions
-    last_tracking_reminder_time_ = time(0);
+    last_tracking_reminder_time_ = time(nullptr);
 
     // Tracking action
     if ("production" == environment_) {
@@ -4035,7 +4035,7 @@ void Context::displayReminder() {
             return;
         }
 
-        if (time(0) - last_tracking_reminder_time_
+        if (time(nullptr) - last_tracking_reminder_time_
                 < settings_.reminder_minutes * 60) {
             return;
         }
@@ -4094,7 +4094,7 @@ void Context::displayReminder() {
 }
 
 void Context::resetLastTrackingReminderTime() {
-    last_tracking_reminder_time_ = time(0);
+    last_tracking_reminder_time_ = time(nullptr);
 }
 
 void Context::displayPomodoro() {
@@ -4122,12 +4122,12 @@ void Context::displayPomodoro() {
         }
 
         if (current_te->DurOnly() && current_te->LastStartAt() != 0) {
-            if (time(0) - current_te->LastStartAt()
+            if (time(nullptr) - current_te->LastStartAt()
                     < settings_.pomodoro_minutes * 60) {
                 return;
             }
         } else {
-            if (time(0) - current_te->Start()
+            if (time(nullptr) - current_te->Start()
                     < settings_.pomodoro_minutes * 60) {
                 return;
             }
@@ -4177,7 +4177,7 @@ void Context::displayPomodoroBreak() {
             return;
         }
 
-        if (time(0) - current_te->Start()
+        if (time(nullptr) - current_te->Start()
                 < settings_.pomodoro_break_minutes * 60) {
             return;
         }

--- a/src/context.cc
+++ b/src/context.cc
@@ -658,8 +658,8 @@ void Context::updateUI(const UIElements &what) {
 
             // Group data maps
             std::map<std::string, Poco::Int64> group_durations;
-            std::map<std::string, Poco::Int64> group_header_id;
-            std::map<std::string, std::vector<Poco::Int64> > group_items;
+            std::map<std::string, Poco::UInt64> group_header_id;
+            std::map<std::string, std::vector<Poco::UInt64> > group_items;
 
             for (unsigned int i = 0; i < time_entries.size(); i++) {
                 TimeEntry *te = time_entries[i];
@@ -999,7 +999,7 @@ error Context::displayError(const error err) {
 int Context::nextSyncIntervalSeconds() const {
     Poco::Random random;
     random.seed();
-    int n = random.next(kSyncIntervalRangeSeconds) + kSyncIntervalRangeSeconds;
+    int n = static_cast<int>(random.next(kSyncIntervalRangeSeconds)) + kSyncIntervalRangeSeconds;
     std::stringstream ss;
     ss << "Next autosync in " << n << " seconds";
     logger().trace(ss.str());
@@ -1300,8 +1300,8 @@ void Context::startPeriodicUpdateCheck() {
         new Poco::Util::TimerTaskAdapter<Context>
     (*this, &Context::onPeriodicUpdateCheck);
 
-    Poco::UInt64 micros = kCheckUpdateIntervalSeconds *
-                          Poco::UInt64(kOneSecondInMicros);
+    Poco::Int64 micros = kCheckUpdateIntervalSeconds *
+                          Poco::Int64(kOneSecondInMicros);
     Poco::Timestamp next_periodic_check_at = Poco::Timestamp() + micros;
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_periodic_check_at);
@@ -4577,7 +4577,7 @@ error Context::pullAllUserData(
     TogglClient *toggl_client) {
 
     std::string api_token("");
-    Poco::UInt64 since(0);
+    Poco::Int64 since(0);
     {
         Poco::Mutex::ScopedLock lock(user_m_);
         if (!user_) {
@@ -5138,7 +5138,7 @@ error Context::me(
     const std::string email,
     const std::string password,
     std::string *user_data_json,
-    const Poco::UInt64 since) {
+    const Poco::Int64 since) {
 
     if (email.empty()) {
         return "Empty email or API token";
@@ -5524,8 +5524,8 @@ error Context::PullCountries() {
 
         std::vector<TogglCountryView> countries;
 
-        for (int i = root.size() - 1; i >= 0; i--) {
-            TogglCountryView *item = country_view_item_init(root[i]);
+        for (unsigned int i = root.size(); i > 0; i--) {
+            TogglCountryView *item = country_view_item_init(root[i - 1]);
             countries.push_back(*item);
         }
 
@@ -5582,8 +5582,8 @@ void on_websocket_message(
     ctx->LoadUpdateFromJSONString(json);
 }
 
-void Context::TrackWindowSize(const Poco::Int64 width,
-                              const Poco::Int64 height) {
+void Context::TrackWindowSize(const Poco::UInt64 width,
+                              const Poco::UInt64 height) {
     if ("production" == environment_) {
         analytics_.TrackWindowSize(db_->AnalyticsClientID(),
                                    shortOSName(),

--- a/src/context.cc
+++ b/src/context.cc
@@ -1056,7 +1056,7 @@ void Context::Sync() {
     }
 }
 
-void Context::onTimeEntryAutocompletes(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onTimeEntryAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> time_entry_autocompletes;
     if (user_) {
         user_->related.TimeEntryAutocompleteItems(&time_entry_autocompletes);
@@ -1064,7 +1064,7 @@ void Context::onTimeEntryAutocompletes(Poco::Util::TimerTask& task) {  // NOLINT
     UI()->DisplayTimeEntryAutocomplete(&time_entry_autocompletes);
 }
 
-void Context::onMiniTimerAutocompletes(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onMiniTimerAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> minitimer_autocompletes;
     if (user_) {
         user_->related.MinitimerAutocompleteItems(&minitimer_autocompletes);
@@ -1072,7 +1072,7 @@ void Context::onMiniTimerAutocompletes(Poco::Util::TimerTask& task) {  // NOLINT
     UI()->DisplayMinitimerAutocomplete(&minitimer_autocompletes);
 }
 
-void Context::onProjectAutocompletes(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onProjectAutocompletes(Poco::Util::TimerTask&) {  // NOLINT
     std::vector<view::Autocomplete> project_autocompletes;
     if (user_) {
         user_->related.ProjectAutocompleteItems(&project_autocompletes);
@@ -1105,7 +1105,7 @@ void Context::switchWebSocketOff() {
     timer_.schedule(ptask, Poco::Timestamp());
 }
 
-void Context::onSwitchWebSocketOff(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onSwitchWebSocketOff(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onSwitchWebSocketOff");
 
     Poco::Mutex::ScopedLock lock(ws_client_m_);
@@ -1151,7 +1151,7 @@ void Context::switchWebSocketOn() {
     timer_.schedule(ptask, Poco::Timestamp());
 }
 
-void Context::onSwitchWebSocketOn(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onSwitchWebSocketOn(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onSwitchWebSocketOn");
 
     std::string apitoken("");
@@ -1186,7 +1186,7 @@ void Context::switchTimelineOff() {
     timer_.schedule(ptask, Poco::Timestamp());
 }
 
-void Context::onSwitchTimelineOff(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onSwitchTimelineOff(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onSwitchTimelineOff");
 
     {
@@ -1213,7 +1213,7 @@ void Context::switchTimelineOn() {
     timer_.schedule(ptask, Poco::Timestamp());
 }
 
-void Context::onSwitchTimelineOn(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onSwitchTimelineOn(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onSwitchTimelineOn");
 
     if (quit_) {
@@ -1255,7 +1255,7 @@ void Context::fetchUpdates() {
     logger().debug(ss.str());
 }
 
-void Context::onFetchUpdates(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onFetchUpdates(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_fetch_updates_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
         logger().debug("onFetchUpdates postponed");
@@ -1285,7 +1285,7 @@ void Context::startPeriodicSync() {
     logger().debug(ss.str());
 }
 
-void Context::onPeriodicSync(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onPeriodicSync(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onPeriodicSync");
 
     scheduleSync();
@@ -1312,7 +1312,7 @@ void Context::startPeriodicUpdateCheck() {
     logger().debug(ss.str());
 }
 
-void Context::onPeriodicUpdateCheck(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onPeriodicUpdateCheck(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onPeriodicUpdateCheck");
 
     executeUpdateCheck();
@@ -1564,7 +1564,7 @@ void Context::TimelineUpdateServerSettings() {
 const std::string kRecordTimelineEnabledJSON = "{\"record_timeline\": true}";
 const std::string kRecordTimelineDisabledJSON = "{\"record_timeline\": false}";
 
-void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onTimelineUpdateServerSettings(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_update_timeline_settings_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
         logger().debug("onTimelineUpdateServerSettings postponed");
@@ -1629,7 +1629,7 @@ error Context::SendFeedback(Feedback fb) {
     return noError;
 }
 
-void Context::onSendFeedback(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onSendFeedback(Poco::Util::TimerTask&) {  // NOLINT
     logger().debug("onSendFeedback");
 
     std::string api_token_value("");
@@ -3967,7 +3967,7 @@ void Context::SetWake() {
     logger().debug(ss.str());
 }
 
-void Context::onWake(Poco::Util::TimerTask& task) {  // NOLINT
+void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
     if (isPostponed(next_wake_at_,
                     kRequestThrottleSeconds * kOneSecondInMicros)) {
         logger().debug("onWake postponed");
@@ -4472,7 +4472,7 @@ void Context::LoadMore() {
     }
 }
 
-void Context::onLoadMore(Poco::Util::TimerTask& task) {
+void Context::onLoadMore(Poco::Util::TimerTask&) {
     bool needs_render = !user_->HasLoadedMore();
     std::string api_token;
     {
@@ -4912,7 +4912,7 @@ error Context::updateEntryProjects(
 }
 
 error Context::pushEntries(
-    std::map<std::string, BaseModel *> models,
+    std::map<std::string, BaseModel *>,
     std::vector<TimeEntry *> time_entries,
     std::string api_token,
     TogglClient toggl_client) {

--- a/src/context.h
+++ b/src/context.h
@@ -469,8 +469,8 @@ class Context : public TimelineDatasource {
     error AsyncPullCountries();
     error PullCountries();
 
-    void TrackWindowSize(const Poco::Int64 width,
-                         const Poco::Int64 height);
+    void TrackWindowSize(const Poco::UInt64 width,
+                         const Poco::UInt64 height);
 
  protected:
     void uiUpdaterActivity();
@@ -598,12 +598,11 @@ class Context : public TimelineDatasource {
         const std::string password,
         std::string *user_data_json,
         const uint64_t country_id);
-    static error me(
-        TogglClient *https_client,
+    static error me(TogglClient *https_client,
         const std::string email,
         const std::string password,
         std::string *user_data,
-        const Poco::UInt64 since);
+        const Poco::Int64 since);
 
     bool isTimeEntryLocked(TimeEntry* te);
     bool isTimeLockedInWorkspace(time_t t, Workspace* ws);

--- a/src/context.h
+++ b/src/context.h
@@ -666,11 +666,11 @@ class Context : public TimelineDatasource {
 
     Idle idle_;
 
-    Poco::UInt64 last_sync_started_;
+    Poco::Int64 last_sync_started_;
     Poco::Int64 sync_interval_seconds_;
-    Poco::UInt64 last_tracking_reminder_time_;
-    Poco::UInt64 last_pomodoro_reminder_time_;
-    Poco::UInt64 last_pomodoro_break_reminder_time_;
+    Poco::Int64 last_tracking_reminder_time_;
+    Poco::Int64 last_pomodoro_reminder_time_;
+    Poco::Int64 last_pomodoro_break_reminder_time_;
 
     bool update_check_disabled_;
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -3756,7 +3756,6 @@ error Database::EnsureTimelineGUIDS() {
     } catch(const std::string& ex) {
         return ex;
     }
-    return noError;
 }
 
 error Database::EnsureAnalyticsClientID() {

--- a/src/database.cc
+++ b/src/database.cc
@@ -209,7 +209,7 @@ error Database::DeleteUser(
 
 error Database::deleteAllFromTableByUID(
     const std::string table_name,
-    const Poco::Int64 &UID) {
+    const Poco::UInt64 &UID) {
 
 
     if (!UID) {
@@ -1183,7 +1183,7 @@ error Database::LoadUserByID(
         Poco::Int64 local_id(0);
         Poco::UInt64 id(0);
         Poco::UInt64 default_wid(0);
-        Poco::UInt64 since(0);
+        Poco::Int64 since(0);
         std::string fullname("");
         std::string email("");
         bool record_timeline(false);
@@ -1930,13 +1930,13 @@ error Database::loadTimeEntriesFromSQLStatement(
                 if (rs[10].isEmpty()) {
                     model->SetUIModifiedAt(0);
                 } else {
-                    model->SetUIModifiedAt(rs[10].convert<Poco::UInt64>());
+                    model->SetUIModifiedAt(rs[10].convert<Poco::Int64>());
                 }
-                model->SetStart(rs[11].convert<Poco::UInt64>());
+                model->SetStart(rs[11].convert<Poco::Int64>());
                 if (rs[12].isEmpty()) {
                     model->SetStop(0);
                 } else {
-                    model->SetStop(rs[12].convert<Poco::UInt64>());
+                    model->SetStop(rs[12].convert<Poco::Int64>());
                 }
                 model->SetDurationInSeconds(rs[13].convert<Poco::Int64>());
                 if (rs[14].isEmpty()) {
@@ -1952,12 +1952,12 @@ error Database::loadTimeEntriesFromSQLStatement(
                 if (rs[16].isEmpty()) {
                     model->SetDeletedAt(0);
                 } else {
-                    model->SetDeletedAt(rs[16].convert<Poco::UInt64>());
+                    model->SetDeletedAt(rs[16].convert<Poco::Int64>());
                 }
                 if (rs[17].isEmpty()) {
                     model->SetUpdatedAt(0);
                 } else {
-                    model->SetUpdatedAt(rs[17].convert<Poco::UInt64>());
+                    model->SetUpdatedAt(rs[17].convert<Poco::Int64>());
                 }
                 if (rs[18].isEmpty()) {
                     model->SetProjectGUID("");

--- a/src/database.h
+++ b/src/database.h
@@ -344,7 +344,7 @@ class Database {
 
     error deleteAllFromTableByUID(
         const std::string table_name,
-        const Poco::Int64 &UID);
+        const Poco::UInt64 &UID);
 
     error saveModel(
         ObmAction *model,

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -396,7 +396,7 @@ Poco::Int64 Formatter::AbsDuration(const Poco::Int64 value) {
 
     // Duration is negative when time is tracking
     if (duration < 0) {
-        duration += time(0);
+        duration += time(nullptr);
     }
     // If after calculation time is still negative,
     // either computer clock is wrong or user

--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -313,7 +313,10 @@ int Formatter::parseDurationStringHoursMinutesSeconds(
     take("sec", &seconds, whatsleft);
     take("s", &seconds, whatsleft);
 
-    return Poco::Timespan(hours*3600 + minutes*60 + seconds, 0).totalSeconds();
+    long period = static_cast<long>(hours) * 3600 +
+                  static_cast<long>(minutes) * 60 +
+                  static_cast<long>(seconds);
+    return Poco::Timespan(period, 0).totalSeconds();
 }
 
 bool Formatter::parseDurationStringMMSS(const std::string value,
@@ -388,7 +391,7 @@ int Formatter::ParseDurationString(const std::string value) {
     return seconds;
 }
 
-Poco::UInt64 Formatter::AbsDuration(const Poco::Int64 value) {
+Poco::Int64 Formatter::AbsDuration(const Poco::Int64 value) {
     Poco::Int64 duration = value;
 
     // Duration is negative when time is tracking
@@ -403,7 +406,7 @@ Poco::UInt64 Formatter::AbsDuration(const Poco::Int64 value) {
         duration *= -1;
     }
 
-    return static_cast<Poco::UInt64>(duration);
+    return duration;
 }
 
 std::string Formatter::FormatDurationForDateHeader(
@@ -435,7 +438,7 @@ std::string Formatter::FormatDuration(
         // Following rounding up is needed
         // to be compatible with Toggl web site.
         double a = hours * 100.0;
-        int b = hours * 100;
+        int b = static_cast<int>(hours) * 100;
         double d = a - std::floor(a);
         if (d > 0.5) {
             b++;

--- a/src/formatter.h
+++ b/src/formatter.h
@@ -34,7 +34,7 @@ class TimedEvent {
     TimedEvent() {}
     virtual ~TimedEvent() {}
 
-    virtual const Poco::UInt64 &Start() const = 0;
+    virtual const Poco::Int64 &Start() const = 0;
     virtual Poco::Int64 Duration() const = 0;
 };
 
@@ -74,7 +74,7 @@ class Formatter {
 
     // Time
 
-    static Poco::UInt64 AbsDuration(const Poco::Int64 value);
+    static Poco::Int64 AbsDuration(const Poco::Int64 value);
 
     // Parse
 

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -95,7 +95,7 @@ int getFocusedWindowInfo(
 
     // get active window
     unsigned long size = 0; // NOLINT
-    Window active_window = (Window)0;
+    Window active_window = 0;
     char *prop = get_property(
         display,
         DefaultRootWindow(display),
@@ -131,8 +131,8 @@ int getFocusedWindowInfo(
     // get pid of active window
     unsigned long *pid = nullptr;
     if (active_window) {
-        pid = (unsigned long *)get_property(display, active_window, // NOLINT
-                                            XA_CARDINAL, "_NET_WM_PID", nullptr);
+        pid = reinterpret_cast<unsigned long*>(get_property(display, active_window,
+                                                            XA_CARDINAL, "_NET_WM_PID", nullptr));
         if (pid) {
             // get process name by pid
             char buf[256];

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -151,8 +151,8 @@ int getFocusedWindowInfo(
                     if (sscanf(buf, "%u (%m[^)]) %*c %u", // NOLINT
                                &tmp_pid, &process_name, &tmp_ppid) == 3) {
                         *filename = std::string(process_name);
+                        free(process_name);
                     }
-                    free(process_name);
                 }
             }
         }

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -148,7 +148,7 @@ int getFocusedWindowInfo(
                     //   <pid> (<name>) R <parent pid>
                     unsigned tmp_pid, tmp_ppid;
                     char *process_name = nullptr;
-                    if (sscanf(buf, "%u (%a[^)]) %*c %u", // NOLINT
+                    if (sscanf(buf, "%u (%m[^)]) %*c %u", // NOLINT
                                &tmp_pid, &process_name, &tmp_ppid) == 3) {
                         *filename = std::string(process_name);
                     }

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -1,5 +1,11 @@
 // Copyright 2014 Toggl Desktop developers.
 
+// HANDLE_EITNR and scanf("%m") won't work without declaring it a GNU source file
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#pragma GCC diagnostic ignored "-Wgnu"
+
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -63,7 +63,7 @@ static char *get_property(Display *disp, Window win, Atom xa_prop_type,
     }
 
     // null terminate the result to make string handling easier
-    tmp_size = (ret_format / (32 / sizeof(long))) * ret_nitems; // NOLINT
+    tmp_size = (static_cast<unsigned>(ret_format) / (32 / sizeof(long))) * ret_nitems;
     ret = reinterpret_cast<char *>(malloc(tmp_size + 1));
     if (!ret) {
         XFree(ret_prop);

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -54,12 +54,12 @@ static char *get_property(Display *disp, Window win, Atom xa_prop_type,
                            &ret_nitems,
                            &ret_bytes_after,
                            &ret_prop) != Success) {
-        return NULL;
+        return nullptr;
     }
 
     if (xa_ret_type != xa_prop_type) {
         XFree(ret_prop);
-        return NULL;
+        return nullptr;
     }
 
     // null terminate the result to make string handling easier
@@ -67,7 +67,7 @@ static char *get_property(Display *disp, Window win, Atom xa_prop_type,
     ret = reinterpret_cast<char *>(malloc(tmp_size + 1));
     if (!ret) {
         XFree(ret_prop);
-        return NULL;
+        return nullptr;
     }
     memcpy(ret, ret_prop, tmp_size);
     ret[tmp_size] = '\0';
@@ -88,7 +88,7 @@ int getFocusedWindowInfo(
     *filename = "";
     *idle = false;
 
-    Display *display = XOpenDisplay(NULL);
+    Display *display = XOpenDisplay(nullptr);
     if (!display) {
         return 1;
     }
@@ -114,12 +114,12 @@ int getFocusedWindowInfo(
             active_window,
             XInternAtom(display, "UTF8_STRING", false),
             "_NET_WM_NAME",
-            NULL);
+            nullptr);
         if (net_wm_name) {
             *title = std::string(net_wm_name);
         } else {
             char *wm_name = get_property(display, active_window,
-                                         XA_STRING, "WM_NAME", NULL);
+                                         XA_STRING, "WM_NAME", nullptr);
             if (wm_name) {
                 *title = std::string(wm_name);
             }
@@ -129,10 +129,10 @@ int getFocusedWindowInfo(
     }
 
     // get pid of active window
-    unsigned long *pid = 0; // NOLINT
+    unsigned long *pid = nullptr;
     if (active_window) {
         pid = (unsigned long *)get_property(display, active_window, // NOLINT
-                                            XA_CARDINAL, "_NET_WM_PID", NULL);
+                                            XA_CARDINAL, "_NET_WM_PID", nullptr);
         if (pid) {
             // get process name by pid
             char buf[256];
@@ -147,7 +147,7 @@ int getFocusedWindowInfo(
                     // The start of the file looks like:
                     //   <pid> (<name>) R <parent pid>
                     unsigned tmp_pid, tmp_ppid;
-                    char *process_name = 0;
+                    char *process_name = nullptr;
                     if (sscanf(buf, "%u (%a[^)]) %*c %u", // NOLINT
                                &tmp_pid, &process_name, &tmp_ppid) == 3) {
                         *filename = std::string(process_name);

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -24,7 +24,7 @@ namespace toggl {
 
 namespace view {
 
-bool TimeEntry::operator == (const TimeEntry& a) const {
+bool TimeEntry::operator == (const TimeEntry&) const {
     return false;
 }
 
@@ -59,19 +59,19 @@ void TimeEntry::Fill(toggl::TimeEntry * const model) {
     GroupName = ss.str();
 }
 
-bool Autocomplete::operator == (const Autocomplete& a) const {
+bool Autocomplete::operator == (const Autocomplete&) const {
     return false;
 }
 
-bool Generic::operator == (const Generic& a) const {
+bool Generic::operator == (const Generic&) const {
     return false;
 }
 
-bool AutotrackerRule::operator == (const AutotrackerRule& a) const {
+bool AutotrackerRule::operator == (const AutotrackerRule&) const {
     return false;
 }
 
-bool TimelineEvent::operator == (const TimelineEvent& a) const {
+bool TimelineEvent::operator == (const TimelineEvent&) const {
     return false;
 }
 

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -419,7 +419,7 @@ void GUI::DisplayTimeEntryList(const bool open,
             this->isFirstLaunch = false;
 
             // Get render list from last 9 days at the first launch
-            time_t last9Days = time(0) - 9 * 86400;
+            time_t last9Days = time(nullptr) - 9 * 86400;
             for (auto it = list.begin(); it != list.end(); it++) {
                 auto timeEntry = *it;
                 if (timeEntry.Started >= last9Days) {

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -269,7 +269,7 @@ void GUI::DisplayReminder() {
     free(s2);
 }
 
-void GUI::DisplayPomodoro(const Poco::UInt64 minutes) {
+void GUI::DisplayPomodoro(const Poco::Int64 minutes) {
     logger().debug("DisplayPomodoro");
     char_t *s1 = copy_string("Pomodoro Timer");
 
@@ -282,7 +282,7 @@ void GUI::DisplayPomodoro(const Poco::UInt64 minutes) {
     free(s2);
 }
 
-void GUI::DisplayPomodoroBreak(const Poco::UInt64 minutes) {
+void GUI::DisplayPomodoroBreak(const Poco::Int64 minutes) {
     logger().debug("DisplayPomodoroBreak");
     char_t *s1 = copy_string("Pomodoro Break Timer");
 
@@ -612,7 +612,7 @@ void GUI::DisplayEmptyTimerState() {
 void GUI::DisplayIdleNotification(const std::string guid,
                                   const std::string since,
                                   const std::string duration,
-                                  const uint64_t started,
+                                  const int64_t started,
                                   const std::string description) {
     char_t *guid_s = copy_string(guid);
     char_t *since_s = copy_string(since);

--- a/src/gui.h
+++ b/src/gui.h
@@ -236,8 +236,8 @@ class Settings {
     , Autotrack(false)
     , OpenEditorOnShortcut(false)
     , Pomodoro(false)
-    , PomodoroMinutes(0)
     , PomodoroBreak(false)
+    , PomodoroMinutes(0)
     , PomodoroBreakMinutes(0)
     , StopEntryOnShutdownSleep(false) {}
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -75,11 +75,11 @@ class TimeEntry {
     std::string GUID;
     bool Billable;
     std::string Tags;
-    uint64_t Started;
-    uint64_t Ended;
+    int64_t Started;
+    int64_t Ended;
     std::string StartTimeString;
     std::string EndTimeString;
-    uint64_t UpdatedAt;
+    int64_t UpdatedAt;
     bool DurOnly;
     // In case it's a header
     std::string DateHeader;
@@ -401,9 +401,9 @@ class GUI : public SyncStateMonitor {
 
     void DisplayReminder();
 
-    void DisplayPomodoro(const Poco::UInt64 minutes);
+    void DisplayPomodoro(const Poco::Int64 minutes);
 
-    void DisplayPomodoroBreak(const Poco::UInt64 minutes);
+    void DisplayPomodoroBreak(const Poco::Int64 minutes);
 
     void DisplayAutotrackerNotification(
         toggl::Project *const p,
@@ -462,7 +462,7 @@ class GUI : public SyncStateMonitor {
     void DisplayIdleNotification(const std::string guid,
                                  const std::string since,
                                  const std::string duration,
-                                 const uint64_t started,
+                                 const int64_t started,
                                  const std::string description);
 
     void DisplayUpdate(const std::string URL);

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -109,7 +109,7 @@ void ServerStatus::runActivity() {
         if (noError != resp.err) {
             logger().error(resp.err);
 
-            srand(static_cast<unsigned>(time(0)));
+            srand(static_cast<unsigned>(time(nullptr)));
             float low(1.0), high(1.5);
             if (!fast_retry_) {
                 low = 1.5;
@@ -338,7 +338,7 @@ HTTPSResponse HTTPSClient::makeHttpRequest(
             verification_mode, 9, true, "ALL");
 
         Poco::Net::SSLManager::instance().initializeClient(
-            0, acceptCertHandler, context);
+            nullptr, acceptCertHandler, context);
 
         Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort(),
                                               context);

--- a/src/https_client.cc
+++ b/src/https_client.cc
@@ -115,9 +115,9 @@ void ServerStatus::runActivity() {
                 low = 1.5;
                 high = 2.0;
             }
-            float r = low + static_cast<float>(rand()) /  // NOLINT
+            float r = low + static_cast<float>(rand()) /
                       (static_cast<float>(RAND_MAX / (high - low)));
-            delay_seconds = delay_seconds * r;
+            delay_seconds = static_cast<int>(delay_seconds * r);
 
             {
                 std::stringstream ss;

--- a/src/idle.cc
+++ b/src/idle.cc
@@ -24,7 +24,7 @@ Idle::Idle(GUI *ui)
 }
 
 void Idle::SetIdleSeconds(
-    const Poco::UInt64 idle_seconds,
+    const Poco::Int64 idle_seconds,
     User *current_user) {
     /*
     {
@@ -51,7 +51,7 @@ void Idle::SetIdleSeconds(
 }
 
 void Idle::computeIdleState(
-    const Poco::UInt64 idle_seconds,
+    const Poco::Int64 idle_seconds,
     User *current_user) {
     if (settings_.idle_minutes &&
             (idle_seconds >= (settings_.idle_minutes*60)) &&

--- a/src/idle.cc
+++ b/src/idle.cc
@@ -56,7 +56,7 @@ void Idle::computeIdleState(
     if (settings_.idle_minutes &&
             (idle_seconds >= (settings_.idle_minutes*60)) &&
             !last_idle_started_) {
-        last_idle_started_ = time(0) - idle_seconds;
+        last_idle_started_ = time(nullptr) - idle_seconds;
 
         std::stringstream ss;
         ss << "User is idle since " << last_idle_started_;
@@ -67,7 +67,7 @@ void Idle::computeIdleState(
 
     if (last_idle_started_ &&
             idle_seconds < last_idle_seconds_reading_) {
-        time_t now = time(0);
+        time_t now = time(nullptr);
 
         TimeEntry *te = current_user->RunningTimeEntry();
         if (!te) {

--- a/src/idle.h
+++ b/src/idle.h
@@ -20,7 +20,7 @@ class Idle {
     virtual ~Idle() {}
 
     void SetIdleSeconds(
-        const Poco::UInt64 idle_seconds,
+        const Poco::Int64 idle_seconds,
         User *current_user);
 
     void SetSettings(const Settings settings) {
@@ -43,8 +43,7 @@ class Idle {
     }
 
  private:
-    void computeIdleState(
-        const Poco::UInt64 idle_seconds,
+    void computeIdleState(const Poco::Int64 idle_seconds,
         User *current_user);
 
     Poco::Logger &logger() const;

--- a/src/idle.h
+++ b/src/idle.h
@@ -50,8 +50,8 @@ class Idle {
     Poco::Logger &logger() const;
 
     // Idle detection related values
-    Poco::UInt64 last_idle_seconds_reading_;
-    Poco::UInt64 last_idle_started_;
+    Poco::Int64 last_idle_seconds_reading_;
+    Poco::Int64 last_idle_started_;
     time_t last_sleep_started_;
 
     Settings settings_;

--- a/src/idle.h
+++ b/src/idle.h
@@ -28,12 +28,12 @@ class Idle {
     }
 
     void SetSleep() {
-        last_sleep_started_ = time(0);
+        last_sleep_started_ = time(nullptr);
     }
 
     void SetWake(User *current_user) {
         if (last_sleep_started_) {
-            Poco::Int64 slept_seconds = time(0) - last_sleep_started_;
+            Poco::Int64 slept_seconds = time(nullptr) - last_sleep_started_;
             if (slept_seconds > 0) {
                 SetIdleSeconds(slept_seconds, current_user);
             }

--- a/src/project.cc
+++ b/src/project.cc
@@ -92,8 +92,8 @@ void Project::SetColor(const std::string value) {
 }
 
 std::string Project::ColorCode() const {
-    int index(0);
-    if (!Poco::NumberParser::tryParse(Color(), index)) {
+    unsigned index(0);
+    if (!Poco::NumberParser::tryParseUnsigned(Color(), index)) {
         return Color();
     }
     return ColorCodes[index % ColorCodes.size()];

--- a/src/project.cc
+++ b/src/project.cc
@@ -13,7 +13,7 @@
 
 namespace toggl {
 
-const char *known_colors[] = {
+static const char *known_colors[] = {
     "#06aaf5", "#c56bff", "#ea468d", "#fb8b14", "#c7741c",
     "#4bc800", "#04bb9b", "#e19a86", "#3750b5", "#a01aa5",
     "#f1c33f", "#205500", "#890000", "#e20505", "#000000"

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -502,9 +502,9 @@ void RelatedData::ProjectAutocompleteItems(
 }
 
 void RelatedData::workspaceAutocompleteItems(
-    std::set<std::string> *unique_names,
+    std::set<std::string> *,
     std::map<Poco::UInt64, std::string> *ws_names,
-    std::vector<view::Autocomplete> *list) const {
+    std::vector<view::Autocomplete> *) const {
 
     // remember workspaces that have projects
     std::set<Poco::UInt64> ws_ids_with_projects;

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -296,7 +296,7 @@ void RelatedData::taskAutocompleteItems(
     std::set<std::string> *unique_names,
     std::map<Poco::UInt64, std::string> *ws_names,
     std::vector<toggl::view::Autocomplete> *list,
-    std::map<Poco::Int64, std::vector<view::Autocomplete> > *items) const {
+    std::map<Poco::UInt64, std::vector<view::Autocomplete> > *items) const {
 
     poco_check_ptr(list);
 
@@ -374,7 +374,7 @@ void RelatedData::projectAutocompleteItems(
     std::map<Poco::UInt64, std::string> *ws_names,
     std::vector<view::Autocomplete> *list,
     std::map<std::string, std::vector<view::Autocomplete> > *items,
-    std::map<Poco::Int64, std::vector<view::Autocomplete> > *task_items) const {
+    std::map<Poco::UInt64, std::vector<view::Autocomplete> > *task_items) const {
 
     poco_check_ptr(list);
 
@@ -460,7 +460,7 @@ void RelatedData::MinitimerAutocompleteItems(
     std::set<std::string> unique_names;
     std::map<Poco::UInt64, std::string> ws_names;
     std::map<std::string, std::vector<view::Autocomplete> > items;
-    std::map<Poco::Int64, std::vector<view::Autocomplete> > task_items;
+    std::map<Poco::UInt64, std::vector<view::Autocomplete> > task_items;
 
     workspaceAutocompleteItems(&unique_names, &ws_names, result);
     timeEntryAutocompleteItems(&unique_names, &ws_names, result, &items);
@@ -495,7 +495,7 @@ void RelatedData::ProjectAutocompleteItems(
     std::vector<view::Autocomplete> *result) const {
     std::set<std::string> unique_names;
     std::map<Poco::UInt64, std::string> ws_names;
-    std::map<Poco::Int64, std::vector<view::Autocomplete> > task_items;
+    std::map<Poco::UInt64, std::vector<view::Autocomplete> > task_items;
     workspaceAutocompleteItems(&unique_names, &ws_names, result);
     taskAutocompleteItems(&unique_names, &ws_names, result, &task_items);
     projectAutocompleteItems(&unique_names, &ws_names, result, nullptr, &task_items);

--- a/src/related_data.cc
+++ b/src/related_data.cc
@@ -305,7 +305,7 @@ void RelatedData::taskAutocompleteItems(
             it != Tasks.end(); it++) {
         Task *t = *it;
 
-        if (t == NULL) {
+        if (t == nullptr) {
             continue;
         }
 
@@ -389,7 +389,7 @@ void RelatedData::projectAutocompleteItems(
 
         Client *c = clientByProject(p);
 
-        std::string text = Formatter::JoinTaskName(0, p);
+        std::string text = Formatter::JoinTaskName(nullptr, p);
         if (text.empty()) {
             continue;
         }

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -114,18 +114,17 @@ class RelatedData {
         std::vector<view::Autocomplete> *list,
         std::map<std::string, std::vector<view::Autocomplete> > *items) const;
 
-    void taskAutocompleteItems(
-        std::set<std::string> *unique_names,
+    void taskAutocompleteItems(std::set<std::string> *unique_names,
         std::map<Poco::UInt64, std::string> *ws_names,
         std::vector<view::Autocomplete> *list,
-        std::map<Poco::Int64, std::vector<view::Autocomplete> > *items) const;
+        std::map<Poco::UInt64, std::vector<view::Autocomplete> > *items) const;
 
     void projectAutocompleteItems(
         std::set<std::string> *unique_names,
         std::map<Poco::UInt64, std::string> *ws_names,
         std::vector<view::Autocomplete> *list,
         std::map<std::string, std::vector<view::Autocomplete> > *items,
-        std::map<Poco::Int64, std::vector<view::Autocomplete> > *task_items) const;
+        std::map<Poco::UInt64, std::vector<view::Autocomplete> > *task_items) const;
 
     void workspaceAutocompleteItems(
         std::set<std::string> *unique_names,

--- a/src/settings.h
+++ b/src/settings.h
@@ -54,9 +54,9 @@ class Settings : public BaseModel {
     bool dock_icon;
     bool on_top;
     bool reminder;
-    Poco::UInt64 idle_minutes;
+    Poco::Int64 idle_minutes;
     bool focus_on_shortcut;
-    Poco::UInt64 reminder_minutes;
+    Poco::Int64 reminder_minutes;
     bool manual_mode;
     bool autodetect_proxy;
     bool remind_mon;
@@ -73,8 +73,8 @@ class Settings : public BaseModel {
     bool has_seen_beta_offering;
     bool pomodoro;
     bool pomodoro_break;
-    Poco::UInt64 pomodoro_minutes;
-    Poco::UInt64 pomodoro_break_minutes;
+    Poco::Int64 pomodoro_minutes;
+    Poco::Int64 pomodoro_break_minutes;
     bool stop_entry_on_shutdown_sleep;
 
     bool IsSame(const Settings &other) const;

--- a/src/settings.h
+++ b/src/settings.h
@@ -41,8 +41,8 @@ class Settings : public BaseModel {
     , open_editor_on_shortcut(false)
     , has_seen_beta_offering(false)
     , pomodoro(false)
-    , pomodoro_minutes(0)
     , pomodoro_break(false)
+    , pomodoro_minutes(0)
     , pomodoro_break_minutes(0)
     , stop_entry_on_shutdown_sleep(false) {}
 

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -143,7 +143,7 @@ void TimeEntry::DiscardAt(const Poco::Int64 at) {
 }
 
 void TimeEntry::StopTracking() {
-    DiscardAt(time(0));
+    DiscardAt(time(nullptr));
 }
 
 std::string TimeEntry::String() const {
@@ -322,7 +322,7 @@ void TimeEntry::SetStartString(const std::string value) {
 void TimeEntry::SetDurationUserInput(const std::string value) {
     int seconds = Formatter::ParseDurationString(value);
     if (IsTracking()) {
-        time_t now = time(0);
+        time_t now = time(nullptr);
         time_t start = now - seconds;
         SetStart(start);
         SetDurationInSeconds(-start);
@@ -497,7 +497,7 @@ Json::Value TimeEntry::SaveToJSON() const {
 }
 
 Poco::Int64 TimeEntry::RealDurationInSeconds() const {
-    auto now = time(0);
+    auto now = time(nullptr);
 
     return now + DurationInSeconds();
 }

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -29,16 +29,16 @@ namespace toggl {
 
 bool TimeEntry::ResolveError(const error err) {
     if (durationTooLarge(err) && Stop() && Start()) {
-        Poco::UInt64 seconds =
+        Poco::Int64 seconds =
             (std::min)(Stop() - Start(),
-                       Poco::UInt64(kMaxTimeEntryDurationSeconds));
+                       Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
         return true;
     }
     if (startTimeWrongYear(err) && Stop() && Start()) {
-        Poco::UInt64 seconds =
+        Poco::Int64 seconds =
             (std::min)(Stop() - Start(),
-                       Poco::UInt64(kMaxTimeEntryDurationSeconds));
+                       Poco::Int64(kMaxTimeEntryDurationSeconds));
         SetDurationInSeconds(seconds);
         SetStart(Stop() - Duration());
         return true;
@@ -114,7 +114,7 @@ bool TimeEntry::billableIsAPremiumFeature(const error err) const {
         "Billable is a premium feature"));
 }
 
-void TimeEntry::DiscardAt(const Poco::UInt64 at) {
+void TimeEntry::DiscardAt(const Poco::Int64 at) {
     if (!IsTracking()) {
         logger().error("Cannot discard time entry that is not tracking");
         return;
@@ -170,7 +170,7 @@ std::string TimeEntry::String() const {
     return ss.str();
 }
 
-void TimeEntry::SetLastStartAt(const Poco::UInt64 value) {
+void TimeEntry::SetLastStartAt(const Poco::Int64 value) {
     if (last_start_at_ != value) {
         last_start_at_ = value;
     }
@@ -183,14 +183,14 @@ void TimeEntry::SetDurOnly(const bool value) {
     }
 }
 
-void TimeEntry::SetStart(const Poco::UInt64 value) {
+void TimeEntry::SetStart(const Poco::Int64 value) {
     if (start_ != value) {
         start_ = value;
         SetDirty();
     }
 }
 
-void TimeEntry::SetStop(const Poco::UInt64 value) {
+void TimeEntry::SetStop(const Poco::Int64 value) {
     if (stop_ != value) {
         stop_ = value;
         SetDirty();
@@ -379,11 +379,11 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
     // No ui_modified_at in server responses.
     // Compare updated_at with ui_modified_at to see if ui has been changed
     Json::Value at = data["at"];
-    Poco::UInt64 updated_at(0);
+    Poco::Int64 updated_at(0);
     if (at.isString()) {
         updated_at = Formatter::Parse8601(at.asString());
     } else {
-        updated_at = at.asUInt64();
+        updated_at = at.asInt64();
     }
 
     if (data.isMember("id")) {

--- a/src/time_entry.h
+++ b/src/time_entry.h
@@ -144,15 +144,15 @@ class TimeEntry : public BaseModel, public TimedEvent {
     Poco::UInt64 pid_;
     Poco::UInt64 tid_;
     bool billable_;
-    Poco::UInt64 start_;
-    Poco::UInt64 stop_;
+    Poco::Int64 start_;
+    Poco::Int64 stop_;
     Poco::Int64 duration_in_seconds_;
     std::string description_;
     bool duronly_;
     std::string created_with_;
     std::string project_guid_;
     bool unsynced_;
-    Poco::UInt64 last_start_at_;
+    Poco::Int64 last_start_at_;
 
     bool setDurationStringHHMMSS(const std::string value);
     bool setDurationStringHHMM(const std::string value);

--- a/src/time_entry.h
+++ b/src/time_entry.h
@@ -34,10 +34,10 @@ class TimeEntry : public BaseModel, public TimedEvent {
 
     virtual ~TimeEntry() {}
 
-    const Poco::UInt64 &LastStartAt() const {
+    const Poco::Int64 &LastStartAt() const {
         return last_start_at_;
     }
-    void SetLastStartAt(const Poco::UInt64 value);
+    void SetLastStartAt(const Poco::Int64 value);
 
     std::vector<std::string> TagNames;
 
@@ -82,25 +82,25 @@ class TimeEntry : public BaseModel, public TimedEvent {
     std::string StartString() const;
     void SetStartString(const std::string value);
 
-    const Poco::UInt64 &Start() const {
+    const Poco::Int64 &Start() const {
         return start_;
     }
-    void SetStart(const Poco::UInt64 value);
+    void SetStart(const Poco::Int64 value);
 
     std::string StopString() const;
     void SetStopString(const std::string value);
 
-    const Poco::UInt64 &Stop() const {
+    const Poco::Int64 &Stop() const {
         return stop_;
     }
-    void SetStop(const Poco::UInt64 value);
+    void SetStop(const Poco::Int64 value);
 
     const std::string &CreatedWith() const {
         return created_with_;
     }
     void SetCreatedWith(const std::string value);
 
-    void DiscardAt(const Poco::UInt64);
+    void DiscardAt(const Poco::Int64);
 
     bool IsToday() const;
 

--- a/src/timeline_event.cc
+++ b/src/timeline_event.cc
@@ -35,14 +35,14 @@ void TimelineEvent::SetTitle(const std::string value) {
     }
 }
 
-void TimelineEvent::SetStart(const Poco::UInt64 value) {
+void TimelineEvent::SetStart(const Poco::Int64 value) {
     if (start_time_ != value) {
         start_time_ = value;
         SetDirty();
     }
 }
 
-void TimelineEvent::SetEndTime(const Poco::UInt64 value) {
+void TimelineEvent::SetEndTime(const Poco::Int64 value) {
     if (end_time_ != value) {
         end_time_ = value;
         SetDirty();

--- a/src/timeline_event.h
+++ b/src/timeline_event.h
@@ -82,8 +82,8 @@ class TimelineEvent : public BaseModel, public TimedEvent {
  private:
     std::string title_;
     std::string filename_;
-    Poco::UInt64 start_time_;
-    Poco::UInt64 end_time_;
+    Poco::Int64 start_time_;
+    Poco::Int64 end_time_;
     bool idle_;
     bool chunked_;
     bool uploaded_;

--- a/src/timeline_event.h
+++ b/src/timeline_event.h
@@ -32,15 +32,15 @@ class TimelineEvent : public BaseModel, public TimedEvent {
     }
     void SetTitle(const std::string value);
 
-    const Poco::UInt64 &Start() const {
+    const Poco::Int64 &Start() const {
         return start_time_;
     }
-    void SetStart(const Poco::UInt64 value);
+    void SetStart(const Poco::Int64 value);
 
-    const Poco::UInt64 &EndTime() const {
+    const Poco::Int64 &EndTime() const {
         return end_time_;
     }
-    void SetEndTime(const Poco::UInt64 value);
+    void SetEndTime(const Poco::Int64 value);
 
     const bool &Idle() const {
         return idle_;

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -833,7 +833,7 @@ bool_t toggl_feedback_send(
     feedback.SetSubject(to_string(topic));
     feedback.SetDetails(to_string(details));
 
-    if (filename != NULL) {
+    if (filename != nullptr) {
         // Check image size (max 5mb)
         std::ifstream file(filename, std::ifstream::ate | std::ifstream::binary);
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -347,7 +347,7 @@ bool_t toggl_set_proxy_settings(void *context,
 }
 
 void toggl_set_cacert_path(
-    void *context,
+    void *,
     const char_t *path) {
 
     toggl::HTTPSClient::Config.CACertPath = to_string(path);

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -769,7 +769,7 @@ bool_t toggl_stop(
 bool_t toggl_discard_time_at(
     void *context,
     const char_t *guid,
-    const uint64_t at,
+    const int64_t at,
     const bool_t split_into_new_entry) {
 
     if (!guid) {
@@ -793,7 +793,7 @@ bool_t toggl_discard_time_at(
 bool_t toggl_discard_time_and_continue(
     void *context,
     const char_t *guid,
-    const uint64_t at) {
+    const int64_t at) {
 
     if (!at) {
         logger().error("Cannot discard time without a timestamp");

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -142,9 +142,9 @@ extern "C" {
         bool_t OnTop;
         bool_t Reminder;
         bool_t RecordTimeline;
-        uint64_t IdleMinutes;
+        int64_t IdleMinutes;
         bool_t FocusOnShortcut;
-        uint64_t ReminderMinutes;
+        int64_t ReminderMinutes;
         bool_t ManualMode;
         bool_t AutodetectProxy;
         bool_t RemindMon;
@@ -160,8 +160,8 @@ extern "C" {
         bool_t OpenEditorOnShortcut;
         bool_t Pomodoro;
         bool_t PomodoroBreak;
-        uint64_t PomodoroMinutes;
-        uint64_t PomodoroBreakMinutes;
+        int64_t PomodoroMinutes;
+        int64_t PomodoroBreakMinutes;
         bool_t StopEntryOnShutdownSleep;
     } TogglSettingsView;
 
@@ -176,8 +176,8 @@ extern "C" {
         int64_t ID;
         char_t *Title;
         char_t *Filename;
-        uint64_t StartTime;
-        uint64_t EndTime;
+        int64_t StartTime;
+        int64_t EndTime;
         bool_t Idle;
         void *Next;
     } TogglTimelineEventView;
@@ -275,7 +275,7 @@ extern "C" {
         const char_t *guid,
         const char_t *since,
         const char_t *duration,
-        const uint64_t started,
+        const int64_t started,
         const char_t *description);
 
     typedef void (*TogglDisplayUpdate)(
@@ -632,13 +632,13 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_discard_time_at(
         void *context,
         const char_t *guid,
-        const uint64_t at,
+        const int64_t at,
         const bool_t split_into_new_entry);
 
     TOGGL_EXPORT bool_t toggl_discard_time_and_continue(
         void *context,
         const char_t *guid,
-        const uint64_t at);
+        const int64_t at);
 
     TOGGL_EXPORT bool_t toggl_set_settings_remind_days(
         void *context,

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -267,7 +267,7 @@ TogglCountryView *country_view_item_init(
     TogglCountryView *item = new TogglCountryView();
     poco_check_ptr(item);
 
-    item->ID = v["id"].asUInt64();
+    item->ID = v["id"].asInt64();
     item->Name = copy_string(v["name"].asString());
     item->VatApplicable = v["vat_applicable"].asBool();
     item->VatRegex = copy_string(v["vat_regex"].asString());

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -177,7 +177,7 @@ void on_display_idle_notification(
     const char *guid,
     const char *since,
     const char *duration,
-    const uint64_t started,
+    const int64_t started,
     const char *description) {
     TogglApi::instance->displayIdleNotification(
         QString(guid),

--- a/src/ui/linux/TogglDesktop/toggl.h
+++ b/src/ui/linux/TogglDesktop/toggl.h
@@ -280,7 +280,7 @@ class TogglApi : public QObject {
         const QString guid,
         const QString since,
         const QString duration,
-        const uint64_t started,
+        const int64_t started,
         const QString description);
 
     void displayClientSelect(
@@ -374,7 +374,7 @@ void on_display_idle_notification(
     const char *guid,
     const char *since,
     const char *duration,
-    const uint64_t started);
+    const int64_t started);
 void on_project_colors(
     const char_t *list[],
     const uint64_t count);

--- a/src/urls.cc
+++ b/src/urls.cc
@@ -7,8 +7,13 @@ namespace toggl {
 namespace urls {
 
 // Whether requests are sent to staging backend
+static bool use_staging_as_backend = false;
 
-bool use_staging_as_backend = false;
+// Whether requests are allowed to Toggl backend
+static bool im_a_teapot_ = false;
+
+// Whether requests are allowed at all (like in tests)
+static bool requests_allowed_ = true;
 
 void SetUseStagingAsBackend(const bool value) {
     use_staging_as_backend = value;
@@ -35,9 +40,13 @@ std::string WebSocket() {
     return "https://stream.toggl.com";
 }
 
-// Whether requests are allowed at all (like in tests)
+bool ImATeapot() {
+    return im_a_teapot_;
+}
 
-bool requests_allowed_ = true;
+void SetImATeapot(const bool value) {
+    im_a_teapot_ = value;
+}
 
 bool RequestsAllowed() {
     return requests_allowed_;
@@ -47,17 +56,6 @@ void SetRequestsAllowed(const bool value) {
     requests_allowed_ = value;
 }
 
-// Whether requests are allowed to Toggl backend
-
-bool im_a_teapot_ = false;
-
-bool ImATeapot() {
-    return im_a_teapot_;
-}
-
-void SetImATeapot(const bool value) {
-    im_a_teapot_ = value;
-}
 
 }  // namespace urls
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -363,7 +363,7 @@ void User::SetAPIToken(const std::string value) {
     api_token_ = value;
 }
 
-void User::SetSince(const Poco::UInt64 value) {
+void User::SetSince(const Poco::Int64 value) {
     if (since_ != value) {
         since_ = value;
         SetDirty();
@@ -467,7 +467,7 @@ bool User::HasValidSinceDate() const {
     // too old
     Poco::Timestamp ts = Poco::Timestamp::fromEpochTime(time(0))
                          - (60 * Poco::Timespan::DAYS);
-    Poco::UInt64 min_allowed = ts.epochTime();
+    Poco::Int64 min_allowed = ts.epochTime();
     if (Since() < min_allowed) {
         return false;
     }
@@ -687,7 +687,7 @@ error User::LoadUserAndRelatedDataFromJSONString(
         return error("Failed to LoadUserAndRelatedDataFromJSONString");
     }
 
-    SetSince(root["since"].asUInt64());
+    SetSince(root["since"].asInt64());
 
     Poco::Logger &logger = Poco::Logger::get("json");
     std::stringstream s;
@@ -1306,12 +1306,12 @@ void User::CompressTimeline() {
     std::map<std::string, TimelineEvent *> compressed;
 
     // Older events will be deleted
-    Poco::UInt64 minimum_time = time(0) - kTimelineSecondsToKeep;
+    Poco::Int64 minimum_time = time(0) - kTimelineSecondsToKeep;
 
     // Find the chunk start time of current time.
     // then process only events that are older that this chunk start time.
     // Else we will have no full chunks to compress.
-    Poco::UInt64 chunk_up_to =
+    Poco::Int64 chunk_up_to =
         (time(0) / kTimelineChunkSeconds) * kTimelineChunkSeconds;
 
 

--- a/src/user.cc
+++ b/src/user.cc
@@ -166,7 +166,7 @@ TimeEntry *User::Start(
 
     Stop();
 
-    time_t now = time(0);
+    time_t now = time(nullptr);
 
     std::stringstream ss;
     ss << "User::Start now=" << now;
@@ -237,7 +237,7 @@ TimeEntry *User::Continue(
 
     Stop();
 
-    time_t now = time(0);
+    time_t now = time(nullptr);
 
     TimeEntry *result = new TimeEntry();
     result->SetCreatedWith(HTTPSClient::Config.UserAgent());
@@ -465,7 +465,7 @@ bool User::HasValidSinceDate() const {
     }
 
     // too old
-    Poco::Timestamp ts = Poco::Timestamp::fromEpochTime(time(0))
+    Poco::Timestamp ts = Poco::Timestamp::fromEpochTime(time(nullptr))
                          - (60 * Poco::Timespan::DAYS);
     Poco::Int64 min_allowed = ts.epochTime();
     if (Since() < min_allowed) {
@@ -1306,16 +1306,16 @@ void User::CompressTimeline() {
     std::map<std::string, TimelineEvent *> compressed;
 
     // Older events will be deleted
-    Poco::Int64 minimum_time = time(0) - kTimelineSecondsToKeep;
+    Poco::Int64 minimum_time = time(nullptr) - kTimelineSecondsToKeep;
 
     // Find the chunk start time of current time.
     // then process only events that are older that this chunk start time.
     // Else we will have no full chunks to compress.
     Poco::Int64 chunk_up_to =
-        (time(0) / kTimelineChunkSeconds) * kTimelineChunkSeconds;
+        (time(nullptr) / kTimelineChunkSeconds) * kTimelineChunkSeconds;
 
 
-    time_t start = time(0);
+    time_t start = time(nullptr);
 
     {
         std::stringstream ss;
@@ -1400,7 +1400,7 @@ void User::CompressTimeline() {
 
     {
         std::stringstream ss;
-        ss << "CompressTimeline done in " << (time(0) - start)
+        ss << "CompressTimeline done in " << (time(nullptr) - start)
            << " seconds, "
            << related.TimelineEvents.size()
            << " compressed into "

--- a/src/user.h
+++ b/src/user.h
@@ -108,10 +108,10 @@ class User : public BaseModel {
     void SetDefaultWID(Poco::UInt64 value);
 
     // Unix timestamp of the user data; returned from API
-    const Poco::UInt64 &Since() const {
+    const Poco::Int64 &Since() const {
         return since_;
     }
-    void SetSince(const Poco::UInt64 value);
+    void SetSince(const Poco::Int64 value);
 
     bool HasValidSinceDate() const;
 

--- a/src/user.h
+++ b/src/user.h
@@ -312,7 +312,7 @@ class User : public BaseModel {
     std::string api_token_;
     Poco::UInt64 default_wid_;
     // Unix timestamp of the user data; returned from API
-    Poco::UInt64 since_;
+    Poco::Int64 since_;
     std::string fullname_;
     std::string email_;
     bool record_timeline_;

--- a/src/websocket_client.cc
+++ b/src/websocket_client.cc
@@ -189,7 +189,7 @@ error WebSocketClient::receiveWebSocketMessage(std::string *message) {
         char buf[kWebsocketBufSize];
         int n = ws_->receiveFrame(buf, kWebsocketBufSize, flags);
         if (n > 0) {
-            json.append(buf, n);
+            json.append(buf, static_cast<unsigned>(n));
         }
     } catch(const Poco::Exception& exc) {
         return error(exc.displayText());
@@ -324,7 +324,7 @@ Poco::Logger &WebSocketClient::logger() const {
 int WebSocketClient::nextWebsocketRestartInterval() {
     Poco::Random random;
     random.seed();
-    int res = random.next(kWebsocketRestartRangeSeconds) + 1;
+    int res = static_cast<int>(random.next(kWebsocketRestartRangeSeconds)) + 1;
     std::stringstream ss;
     ss << "Next websocket restart in " << res << " seconds";
     logger().trace(ss.str());

--- a/src/websocket_client.cc
+++ b/src/websocket_client.cc
@@ -84,7 +84,7 @@ error WebSocketClient::createSession() {
 
     deleteSession();
 
-    last_connection_at_ = time(0);
+    last_connection_at_ = time(nullptr);
 
     error err = TogglClient::TogglStatus.Status();
     if (err != noError) {
@@ -113,7 +113,7 @@ error WebSocketClient::createSession() {
             verification_mode, 9, true, "ALL");
 
         Poco::Net::SSLManager::instance().initializeClient(
-            0, acceptCertHandler, context);
+            nullptr, acceptCertHandler, context);
 
         session_ = new Poco::Net::HTTPSClientSession(
             uri.getHost(),
@@ -223,7 +223,7 @@ error WebSocketClient::poll() {
         ss << "WebSocket message: " << json;
         logger().trace(ss.str());
 
-        last_connection_at_ = time(0);
+        last_connection_at_ = time(nullptr);
 
         std::string type = parseWebSocketMessageType(json);
 
@@ -271,7 +271,7 @@ void WebSocketClient::runActivity() {
             }
         }
 
-        if (time(0) - last_connection_at_ > restart_interval) {
+        if (time(nullptr) - last_connection_at_ > restart_interval) {
             restart_interval = nextWebsocketRestartInterval();
             logger().debug("restarting");
             error err = createSession();


### PR DESCRIPTION
### 📒 Description
Fix most of the warnings coming from the library when building in gcc and clang.

### 🕶️ Types of changes
- Slight enhancement

### 👫 Relationships
Closes #2701 

### 🔎 Review hints
Since the tests are very limited, maybe postpone reviewing this PR for when there is more of them.
There should be no to very little issues but considering the signed/unsigned integer change, we should think of testing stuff thoroughly.
I'm going for a vacation next week, so expect movement in the test department from my side when I return.

