### PR TITLE
Do not record timeline when PC is locked

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -3780,6 +3780,7 @@ void Context::SetSleep() {
     if (!isHandled) {
         logger().debug("SetSleep");
         idle_.SetSleep();
+		window_change_recorder_->SetIsSleeping(true);
     }
 }
 
@@ -3986,6 +3987,7 @@ void Context::onWake(Poco::Util::TimerTask& task) {  // NOLINT
         }
 
         idle_.SetWake(user_);
+		window_change_recorder_->SetIsSleeping(false);
 
         Sync();
     }
@@ -3998,6 +4000,16 @@ void Context::onWake(Poco::Util::TimerTask& task) {  // NOLINT
     catch (const std::string& ex) {
         logger().error(ex);
     }
+}
+
+void Context::SetLocked() {
+	logger().debug("SetLocked");
+	window_change_recorder_->SetIsLocked(true);
+}
+
+void Context::SetUnlocked() {
+	logger().debug("SetUnlocked");
+	window_change_recorder_->SetIsLocked(false);
 }
 
 void Context::SetOnline() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -3780,7 +3780,7 @@ void Context::SetSleep() {
     if (!isHandled) {
         logger().debug("SetSleep");
         idle_.SetSleep();
-		window_change_recorder_->SetIsSleeping(true);
+        window_change_recorder_->SetIsSleeping(true);
     }
 }
 
@@ -3987,7 +3987,7 @@ void Context::onWake(Poco::Util::TimerTask& task) {  // NOLINT
         }
 
         idle_.SetWake(user_);
-		window_change_recorder_->SetIsSleeping(false);
+        window_change_recorder_->SetIsSleeping(false);
 
         Sync();
     }
@@ -4003,13 +4003,13 @@ void Context::onWake(Poco::Util::TimerTask& task) {  // NOLINT
 }
 
 void Context::SetLocked() {
-	logger().debug("SetLocked");
-	window_change_recorder_->SetIsLocked(true);
+    logger().debug("SetLocked");
+    window_change_recorder_->SetIsLocked(true);
 }
 
 void Context::SetUnlocked() {
-	logger().debug("SetUnlocked");
-	window_change_recorder_->SetIsLocked(false);
+    logger().debug("SetUnlocked");
+    window_change_recorder_->SetIsLocked(false);
 }
 
 void Context::SetOnline() {

--- a/src/context.h
+++ b/src/context.h
@@ -418,6 +418,10 @@ class Context : public TimelineDatasource {
 
     void SetWake();
 
+	void SetLocked();
+
+	void SetUnlocked();
+
     void osShutdown();
 
     void SetOnline();

--- a/src/context.h
+++ b/src/context.h
@@ -418,9 +418,9 @@ class Context : public TimelineDatasource {
 
     void SetWake();
 
-	void SetLocked();
+    void SetLocked();
 
-	void SetUnlocked();
+    void SetUnlocked();
 
     void osShutdown();
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1056,11 +1056,11 @@ void toggl_set_wake(void *context) {
 }
 
 void toggl_set_locked(void* context) {
-	app(context)->SetLocked();
+    app(context)->SetLocked();
 }
 
 void toggl_set_unlocked(void* context) {
-	app(context)->SetUnlocked();
+    app(context)->SetUnlocked();
 }
 
 void toggl_os_shutdown(void *context) {

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1055,6 +1055,14 @@ void toggl_set_wake(void *context) {
     app(context)->SetWake();
 }
 
+void toggl_set_locked(void* context) {
+	app(context)->SetLocked();
+}
+
+void toggl_set_unlocked(void* context) {
+	app(context)->SetUnlocked();
+}
+
 void toggl_os_shutdown(void *context) {
     if (!context) {
         return;

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -911,11 +911,11 @@ extern "C" {
     TOGGL_EXPORT void toggl_set_wake(
         void *context);
 
-	TOGGL_EXPORT void toggl_set_locked(
-		void *context);
+    TOGGL_EXPORT void toggl_set_locked(
+        void *context);
 
-	TOGGL_EXPORT void toggl_set_unlocked(
-		void *context);
+    TOGGL_EXPORT void toggl_set_unlocked(
+        void *context);
 
     TOGGL_EXPORT void toggl_os_shutdown(
         void *context);

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -911,6 +911,12 @@ extern "C" {
     TOGGL_EXPORT void toggl_set_wake(
         void *context);
 
+	TOGGL_EXPORT void toggl_set_locked(
+		void *context);
+
+	TOGGL_EXPORT void toggl_set_unlocked(
+		void *context);
+
     TOGGL_EXPORT void toggl_os_shutdown(
         void *context);
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -582,6 +582,16 @@ public static partial class Toggl
         toggl_set_sleep(ctx);
     }
 
+    public static void SetLocked()
+    {
+        toggl_set_locked(ctx);
+    }
+
+    public static void SetUnlocked()
+    {
+        toggl_set_unlocked(ctx);
+    }
+
     public static void SetOSShutdown()
     {
         toggl_os_shutdown(ctx);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -6,12 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace TogglDesktop
 {
-public static partial class Toggl
-{
-    private const string dll = "TogglDesktopDLL.dll";
-    private const CharSet charset = CharSet.Unicode;
-    private const CallingConvention convention = CallingConvention.Cdecl;
-    private const int structPackingBytes = 8;
+    public static partial class Toggl
+    {
+    		private const string dll = "TogglDesktopDLL.dll";
+    		private const CharSet charset = CharSet.Unicode;
+    		private const CallingConvention convention = CallingConvention.Cdecl;
+    		private const int structPackingBytes = 8;
 
 
 
@@ -21,1396 +21,1405 @@ public static partial class Toggl
 
 // Constants
 
-    private const int kOnlineStateOnline = 0;
-    private const int kOnlineStateNoNetwork = 1;
-    private const int kOnlineStateBackendDown = 2;
+private const int kOnlineStateOnline = 0;
+private const int kOnlineStateNoNetwork = 1;
+private const int kOnlineStateBackendDown = 2;
 
-    private const int kSyncStateIdle = 0;
-    private const int kSyncStateWork = 1;
+private const int kSyncStateIdle = 0;
+private const int kSyncStateWork = 1;
 
-    private const int kDownloadStatusStarted = 0;
-    private const int kDownloadStatusDone = 1;
+private const int kDownloadStatusStarted = 0;
+private const int kDownloadStatusDone = 1;
 
-    private const int kPromotionJoinBetaChannel = 1;
+private const int kPromotionJoinBetaChannel = 1;
 
 // Models
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglTimeEntryView
-    {
-        public         Int64 DurationInSeconds;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Description;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectAndTaskLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string TaskLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ClientLabel;
-        public         UInt64 WID;
-        public         UInt64 PID;
-        public         UInt64 TID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Duration;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Color;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string GUID;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Billable;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Tags;
-        public         UInt64 Started;
-        public         UInt64 Ended;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string StartTimeString;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string EndTimeString;
-        public         UInt64 UpdatedAt;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool DurOnly;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglTimeEntryView
+{
+public         Int64 DurationInSeconds;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Description;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectAndTaskLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string TaskLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ClientLabel;
+public         UInt64 WID;
+public         UInt64 PID;
+public         UInt64 TID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Duration;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Color;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string GUID;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Billable;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Tags;
+public         UInt64 Started;
+public         UInt64 Ended;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string StartTimeString;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string EndTimeString;
+public         UInt64 UpdatedAt;
+[MarshalAs(UnmanagedType.I1)]
+public         bool DurOnly;
         // In case it's a header
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string DateHeader;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string DateDuration;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool IsHeader;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string DateHeader;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string DateDuration;
+[MarshalAs(UnmanagedType.I1)]
+public         bool IsHeader;
         // Additional fields; only when in time entry editor
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool CanAddProjects;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool CanSeeBillable;
-        public         UInt64 DefaultWID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string WorkspaceName;
+[MarshalAs(UnmanagedType.I1)]
+public         bool CanAddProjects;
+[MarshalAs(UnmanagedType.I1)]
+public         bool CanSeeBillable;
+public         UInt64 DefaultWID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string WorkspaceName;
         // If syncing a time entry ended with an error,
         // the error is attached to the time entry
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Error;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Locked;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Error;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Locked;
         // Indicates if time entry is not synced to server
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Unsynced;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Unsynced;
         // Group attributes
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Group;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool GroupOpen;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string GroupName;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string GroupDuration;
-        public         UInt64 GroupItemCount;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Group;
+[MarshalAs(UnmanagedType.I1)]
+public         bool GroupOpen;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string GroupName;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string GroupDuration;
+public         UInt64 GroupItemCount;
         // Next in list
-        public         IntPtr Next;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return GroupDuration;
-        }
+public override string ToString()
+{
+    return GroupDuration;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglAutocompleteView
-    {
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglAutocompleteView
+{
         // This is what is displayed to user, includes project and task.
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Text;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Text;
         // This is copied to "time_entry.description" field if item is selected
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Description;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Description;
         // Project label, if has a project
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectAndTaskLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string TaskLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ClientLabel;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectColor;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectGUID;
-        public         UInt64 TaskID;
-        public         UInt64 ProjectID;
-        public         UInt64 WorkspaceID;
-        public         UInt64 Type;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectAndTaskLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string TaskLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ClientLabel;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectColor;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectGUID;
+public         UInt64 TaskID;
+public         UInt64 ProjectID;
+public         UInt64 WorkspaceID;
+public         UInt64 Type;
         // If its a time entry or project, it can be billable
-        public         bool Billable;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Billable;
         // If its a time entry, it has tags
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Tags;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string WorkspaceName;
-        public         UInt64 ClientID;
-        public         IntPtr Next;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Tags;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string WorkspaceName;
+public         UInt64 ClientID;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return WorkspaceName;
-        }
+public override string ToString()
+{
+    return WorkspaceName;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglGenericView
-    {
-        public         UInt64 ID;
-        public         UInt64 WID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string GUID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Name;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string WorkspaceName;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Premium;
-        public         IntPtr Next;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglGenericView
+{
+public         UInt64 ID;
+public         UInt64 WID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string GUID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Name;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string WorkspaceName;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Premium;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return WorkspaceName;
-        }
+public override string ToString()
+{
+    return WorkspaceName;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglHelpArticleView
-    {
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Category;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Name;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string URL;
-        public         IntPtr Next;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglHelpArticleView
+{
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Category;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Name;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string URL;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return URL;
-        }
+public override string ToString()
+{
+    return URL;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglSettingsView
-    {
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool UseProxy;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProxyHost;
-        public         UInt64 ProxyPort;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProxyUsername;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProxyPassword;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool UseIdleDetection;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool MenubarTimer;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool MenubarProject;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool DockIcon;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool OnTop;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Reminder;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RecordTimeline;
-        public         UInt64 IdleMinutes;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool FocusOnShortcut;
-        public         UInt64 ReminderMinutes;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool ManualMode;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool AutodetectProxy;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindMon;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindTue;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindWed;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindThu;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindFri;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindSat;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool RemindSun;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string RemindStarts;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string RemindEnds;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Autotrack;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool OpenEditorOnShortcut;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Pomodoro;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool PomodoroBreak;
-        public         UInt64 PomodoroMinutes;
-        public         UInt64 PomodoroBreakMinutes;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool StopEntryOnShutdownSleep;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglSettingsView
+{
+[MarshalAs(UnmanagedType.I1)]
+public         bool UseProxy;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProxyHost;
+public         UInt64 ProxyPort;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProxyUsername;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProxyPassword;
+[MarshalAs(UnmanagedType.I1)]
+public         bool UseIdleDetection;
+[MarshalAs(UnmanagedType.I1)]
+public         bool MenubarTimer;
+[MarshalAs(UnmanagedType.I1)]
+public         bool MenubarProject;
+[MarshalAs(UnmanagedType.I1)]
+public         bool DockIcon;
+[MarshalAs(UnmanagedType.I1)]
+public         bool OnTop;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Reminder;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RecordTimeline;
+public         UInt64 IdleMinutes;
+[MarshalAs(UnmanagedType.I1)]
+public         bool FocusOnShortcut;
+public         UInt64 ReminderMinutes;
+[MarshalAs(UnmanagedType.I1)]
+public         bool ManualMode;
+[MarshalAs(UnmanagedType.I1)]
+public         bool AutodetectProxy;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindMon;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindTue;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindWed;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindThu;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindFri;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindSat;
+[MarshalAs(UnmanagedType.I1)]
+public         bool RemindSun;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string RemindStarts;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string RemindEnds;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Autotrack;
+[MarshalAs(UnmanagedType.I1)]
+public         bool OpenEditorOnShortcut;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Pomodoro;
+[MarshalAs(UnmanagedType.I1)]
+public         bool PomodoroBreak;
+public         UInt64 PomodoroMinutes;
+public         UInt64 PomodoroBreakMinutes;
+[MarshalAs(UnmanagedType.I1)]
+public         bool StopEntryOnShutdownSleep;
 
-        public override string ToString()
-        {
-            return RemindEnds;
-        }
+public override string ToString()
+{
+    return RemindEnds;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglAutotrackerRuleView
-    {
-        public         Int64 ID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Term;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string ProjectAndTaskLabel;
-        public         IntPtr Next;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglAutotrackerRuleView
+{
+public         Int64 ID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Term;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string ProjectAndTaskLabel;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return ProjectAndTaskLabel;
-        }
+public override string ToString()
+{
+    return ProjectAndTaskLabel;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglTimelineEventView
-    {
-        public         Int64 ID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Title;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Filename;
-        public         UInt64 StartTime;
-        public         UInt64 EndTime;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool Idle;
-        public         IntPtr Next;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglTimelineEventView
+{
+public         Int64 ID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Title;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Filename;
+public         UInt64 StartTime;
+public         UInt64 EndTime;
+[MarshalAs(UnmanagedType.I1)]
+public         bool Idle;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return Filename;
-        }
+public override string ToString()
+{
+    return Filename;
+}
 
-    }
+}
 
-    [StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
-    public struct    TogglCountryView
-    {
-        public         Int64 ID;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Name;
-        [MarshalAs(UnmanagedType.I1)]
-        public         bool VatApplicable;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string VatRegex;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string VatPercentage;
-        [MarshalAs(UnmanagedType.LPWStr)]
-        public         string Code;
-        public         IntPtr Next;
+[StructLayout(LayoutKind.Sequential, Pack = structPackingBytes, CharSet = CharSet.Unicode)]
+public struct    TogglCountryView
+{
+public         Int64 ID;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Name;
+[MarshalAs(UnmanagedType.I1)]
+public         bool VatApplicable;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string VatRegex;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string VatPercentage;
+[MarshalAs(UnmanagedType.LPWStr)]
+public         string Code;
+public         IntPtr Next;
 
-        public override string ToString()
-        {
-            return Code;
-        }
+public override string ToString()
+{
+    return Code;
+}
 
-    }
+}
 
     // Callbacks that need to be implemented in UI
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayApp(
-        [MarshalAs(UnmanagedType.I1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayApp(
+[MarshalAs(UnmanagedType.I1)]
         bool open);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplaySyncState(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplaySyncState(
         Int64 state);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayUnsyncedItems(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayUnsyncedItems(
         Int64 count);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayError(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayError(
+[MarshalAs(UnmanagedType.LPWStr)]
         string errmsg,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool user_error);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayOverlay(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayOverlay(
         Int64 type);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayOnlineState(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayOnlineState(
         Int64 state);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayURL(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayURL(
+[MarshalAs(UnmanagedType.LPWStr)]
         string url);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayLogin(
-        [MarshalAs(UnmanagedType.I1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayLogin(
+[MarshalAs(UnmanagedType.I1)]
         bool open,
         UInt64 user_id);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayReminder(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayReminder(
+[MarshalAs(UnmanagedType.LPWStr)]
         string title,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string informative_text);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayPomodoro(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayPomodoro(
+[MarshalAs(UnmanagedType.LPWStr)]
         string title,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string informative_text);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayPomodoroBreak(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayPomodoroBreak(
+[MarshalAs(UnmanagedType.LPWStr)]
         string title,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string informative_text);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayAutotrackerNotification(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayAutotrackerNotification(
+[MarshalAs(UnmanagedType.LPWStr)]
         string project_name,
         UInt64 project_id,
         UInt64 task_id);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayPromotion(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayPromotion(
         Int64 promotion_type);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayObmExperiment(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayObmExperiment(
         UInt64 nr,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool included,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool seen);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayTimeEntryList(
-        [MarshalAs(UnmanagedType.I1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayTimeEntryList(
+[MarshalAs(UnmanagedType.I1)]
         bool open,
         IntPtr first,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool show_load_more_button);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayAutocomplete(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayAutocomplete(
         IntPtr first);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayHelpArticles(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayHelpArticles(
         IntPtr first);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayViewItems(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayViewItems(
         IntPtr first);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayTimeEntryEditor(
-        [MarshalAs(UnmanagedType.I1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayTimeEntryEditor(
+[MarshalAs(UnmanagedType.I1)]
         bool open,
-        IntPtr te,
-        [MarshalAs(UnmanagedType.LPWStr)]
+IntPtr te,
+[MarshalAs(UnmanagedType.LPWStr)]
         string focused_field_name);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplaySettings(
-        [MarshalAs(UnmanagedType.I1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplaySettings(
+[MarshalAs(UnmanagedType.I1)]
         bool open,
-        IntPtr settings);
+IntPtr settings);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayTimerState(
-        IntPtr te);
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayTimerState(
+IntPtr te);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayIdleNotification(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayIdleNotification(
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string since,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string duration,
         UInt64 started,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string description);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayUpdate(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayUpdate(
+[MarshalAs(UnmanagedType.LPWStr)]
         string url);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayUpdateDownloadState(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayUpdateDownloadState(
+[MarshalAs(UnmanagedType.LPWStr)]
         string version,
         Int64 download_state);
 
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayAutotrackerRules(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayAutotrackerRules(
         IntPtr first,
         UInt64 title_count,
-        [MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.LPWStr, SizeParamIndex=1)]
+[MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.LPWStr, SizeParamIndex=1)]
         string[] title_list);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayProjectColors(
-        [MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.LPWStr, SizeParamIndex=1)]
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayProjectColors(
+[MarshalAs(UnmanagedType.LPArray, ArraySubType=UnmanagedType.LPWStr, SizeParamIndex=1)]
         string[] color_list,
         UInt64 color_count);
 
-    [UnmanagedFunctionPointer(convention)]
-    private delegate void     TogglDisplayCountries(
+[UnmanagedFunctionPointer(convention)]
+private delegate void     TogglDisplayCountries(
         IntPtr first);
 
     // Initialize/destroy an instance of the app
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern IntPtr toggl_context_init(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern IntPtr toggl_context_init(
+[MarshalAs(UnmanagedType.LPWStr)]
         string app_name,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string app_version);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_context_clear(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_context_clear(
         IntPtr context);
 
     // Set environment. By default, production is assumed. Optional.
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_environment(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_environment(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string environment);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_environment(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_environment(
         IntPtr context);
 
     // Optionally, disable update check
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_disable_update_check(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_disable_update_check(
         IntPtr context);
 
     // CA cert bundle must be configured from UI
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_cacert_path(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_cacert_path(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string path);
 
     // DB path must be configured from UI
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_db_path(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_db_path(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string path);
 
     // Configure update download path for silent updates
     // Need to configure only if you have
     // enabled update check and have not set the
     // display update callback
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_update_path(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_update_path(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string path);
 
     // you must free the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_update_path(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_update_path(
         IntPtr context);
 
     // Log path must be configured from UI
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_log_path(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_log_path(
+[MarshalAs(UnmanagedType.LPWStr)]
         string path);
 
     // Log level is optional
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_log_level(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_log_level(
+[MarshalAs(UnmanagedType.LPWStr)]
         string level);
 
     // Various parts of UI can tell the app to show itself.
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_show_app(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_show_app(
         IntPtr context);
 
     // Configure the UI callbacks. Required.
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_show_app(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_show_app(
         IntPtr context,
         TogglDisplayApp cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_sync_state(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_sync_state(
         IntPtr context,
         TogglDisplaySyncState cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_unsynced_items(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_unsynced_items(
         IntPtr context,
         TogglDisplayUnsyncedItems cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_error(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_error(
         IntPtr context,
         TogglDisplayError cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_overlay(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_overlay(
         IntPtr context,
         TogglDisplayOverlay cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_update(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_update(
         IntPtr context,
         TogglDisplayUpdate cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_update_download_state(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_update_download_state(
         IntPtr context,
         TogglDisplayUpdateDownloadState cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_online_state(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_online_state(
         IntPtr context,
         TogglDisplayOnlineState cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_url(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_url(
         IntPtr context,
         TogglDisplayURL cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_login(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_login(
         IntPtr context,
         TogglDisplayLogin cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_reminder(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_reminder(
         IntPtr context,
         TogglDisplayReminder cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_pomodoro(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_pomodoro(
         IntPtr context,
         TogglDisplayPomodoro cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_pomodoro_break(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_pomodoro_break(
         IntPtr context,
         TogglDisplayPomodoroBreak cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_autotracker_notification(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_autotracker_notification(
         IntPtr context,
         TogglDisplayAutotrackerNotification cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_time_entry_list(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_time_entry_list(
         IntPtr context,
         TogglDisplayTimeEntryList cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_toggle_entries_group(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_toggle_entries_group(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string name);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_mini_timer_autocomplete(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_mini_timer_autocomplete(
         IntPtr context,
         TogglDisplayAutocomplete cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_help_articles(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_help_articles(
         IntPtr context,
         TogglDisplayHelpArticles cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_time_entry_autocomplete(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_time_entry_autocomplete(
         IntPtr context,
         TogglDisplayAutocomplete cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_project_autocomplete(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_project_autocomplete(
         IntPtr context,
         TogglDisplayAutocomplete cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_workspace_select(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_workspace_select(
         IntPtr context,
         TogglDisplayViewItems cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_client_select(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_client_select(
         IntPtr context,
         TogglDisplayViewItems cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_tags(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_tags(
         IntPtr context,
         TogglDisplayViewItems cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_time_entry_editor(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_time_entry_editor(
         IntPtr context,
         TogglDisplayTimeEntryEditor cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_settings(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_settings(
         IntPtr context,
         TogglDisplaySettings cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_timer_state(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_timer_state(
         IntPtr context,
         TogglDisplayTimerState cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_idle_notification(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_idle_notification(
         IntPtr context,
         TogglDisplayIdleNotification cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_autotracker_rules(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_autotracker_rules(
         IntPtr context,
         TogglDisplayAutotrackerRules cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_project_colors(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_project_colors(
         IntPtr context,
         TogglDisplayProjectColors cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_countries(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_countries(
         IntPtr context,
         TogglDisplayCountries cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_promotion(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_promotion(
         IntPtr context,
         TogglDisplayPromotion cb);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_on_obm_experiment(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_on_obm_experiment(
         IntPtr context,
         TogglDisplayObmExperiment cb);
 
     // After UI callbacks are configured, start pumping UI events
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_ui_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_ui_start(
         IntPtr context);
 
     // User interaction with the app
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_login(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_login(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string email,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string password);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_login_async(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_login_async(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string email,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string password);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_signup(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_signup(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string email,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string password,
         UInt64 country_id);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_signup_async(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_signup_async(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string email,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string password,
         UInt64 country_id);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_google_login(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_google_login(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string access_token);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_google_login_async(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_google_login_async(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string access_token);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_password_forgot(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_password_forgot(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_tos(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_tos(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_privacy_policy(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_privacy_policy(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_open_in_browser(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_open_in_browser(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_accept_tos(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_accept_tos(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_get_support(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_get_support(
         IntPtr context,
         int type);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_feedback_send(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_feedback_send(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string topic,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string details,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string filename);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_search_help_articles(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_search_help_articles(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string keywords);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_view_time_entry_list(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_view_time_entry_list(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_edit(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_edit(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool edit_running_time_entry,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string focused_field_name);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_edit_preferences(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_edit_preferences(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_continue(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_continue(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_continue_latest(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_continue_latest(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool prevent_on_app);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_delete_time_entry(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_delete_time_entry(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_duration(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_duration(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_project(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_project(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
         UInt64 task_id,
         UInt64 project_id,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string project_guid);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_date(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_date(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
         Int64 unix_timestamp);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_start(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_end(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_end(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
     // value is '\t' separated tag list
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_tags(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_tags(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_billable(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_billable(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_time_entry_description(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_time_entry_description(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_stop(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_stop(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool prevent_on_app);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_discard_time_at(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_discard_time_at(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
         UInt64 at,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool split_into_new_entry);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_discard_time_and_continue(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_discard_time_and_continue(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string guid,
         UInt64 at);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_remind_days(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_remind_days(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_mon,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_tue,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_wed,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_thu,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_fri,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_sat,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool remind_sun);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_remind_times(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_remind_times(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string remind_starts,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string remind_ends);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_use_idle_detection(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_use_idle_detection(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool use_idle_detection);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_autotrack(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_autotrack(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_open_editor_on_shortcut(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_open_editor_on_shortcut(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_autodetect_proxy(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_autodetect_proxy(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool autodetect_proxy);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_menubar_timer(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_menubar_timer(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool menubar_timer);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_menubar_project(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_menubar_project(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool menubar_project);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_dock_icon(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_dock_icon(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool dock_icon);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_on_top(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_on_top(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool on_top);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_reminder(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_reminder(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool reminder);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_pomodoro(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_pomodoro(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool pomodoro);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_pomodoro_break(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_pomodoro_break(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool pomodoro_break);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_stop_entry_on_shutdown_sleep(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_stop_entry_on_shutdown_sleep(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool stop_entry);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_idle_minutes(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_idle_minutes(
         IntPtr context,
         UInt64 idle_minutes);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_focus_on_shortcut(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_focus_on_shortcut(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool focus_on_shortcut);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_reminder_minutes(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_reminder_minutes(
         IntPtr context,
         UInt64 reminder_minutes);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_pomodoro_minutes(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_pomodoro_minutes(
         IntPtr context,
         UInt64 pomodoro_minutes);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_pomodoro_break_minutes(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_pomodoro_break_minutes(
         IntPtr context,
         UInt64 pomodoro_break_minutes);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_settings_manual_mode(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_settings_manual_mode(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool manual_mode);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_proxy_settings(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_proxy_settings(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool use_proxy,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string proxy_host,
         UInt64 proxy_port,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string proxy_username,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string proxy_password);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_window_settings(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_window_settings(
         IntPtr context,
         Int64 window_x,
         Int64 window_y,
         Int64 window_height,
         Int64 window_width);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_window_settings(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_window_settings(
         IntPtr context,
         ref Int64 window_x,
         ref Int64 window_y,
         ref Int64 window_height,
         ref Int64 window_width);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_window_maximized(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_window_maximized(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_window_maximized(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_get_window_maximized(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_window_minimized(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_window_minimized(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_window_minimized(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_get_window_minimized(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_window_edit_size_height(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_window_edit_size_height(
         IntPtr context,
         Int64 value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_get_window_edit_size_height(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_get_window_edit_size_height(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_window_edit_size_width(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_window_edit_size_width(
         IntPtr context,
         Int64 value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_get_window_edit_size_width(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_get_window_edit_size_width(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_key_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_key_start(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_key_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_key_start(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_key_show(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_key_show(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_key_show(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_key_show(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_key_modifier_show(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_key_modifier_show(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_key_modifier_show(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_key_modifier_show(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_key_modifier_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_key_modifier_start(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_key_modifier_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_key_modifier_start(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_logout(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_logout(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_clear_cache(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_clear_cache(
         IntPtr context);
 
     // returns GUID of the started time entry. you must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_start(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_start(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string description,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string duration,
         UInt64 task_id,
         UInt64 project_id,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string project_guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string tags,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool prevent_on_app);
 
     // returns GUID of the new project. you must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_add_project(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_add_project(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string time_entry_guid,
         UInt64 workspace_id,
         UInt64 client_id,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string client_guid,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string project_name,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool is_private,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string project_color);
 
     // returns GUID of the new client. you must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_create_client(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_create_client(
         IntPtr context,
         UInt64 workspace_id,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string client_name);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_add_obm_action(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_add_obm_action(
         IntPtr context,
         UInt64 experiment_id,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string key,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_add_obm_experiment_nr(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_add_obm_experiment_nr(
         UInt64 nr);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_default_project(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_default_project(
         IntPtr context,
         UInt64 pid,
         UInt64 tid);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_get_project_colors(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_get_project_colors(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_get_countries(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_get_countries(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_get_countries_async(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_get_countries_async(
         IntPtr context);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_default_project_name(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_default_project_name(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern UInt64 toggl_get_default_project_id(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern UInt64 toggl_get_default_project_id(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern UInt64 toggl_get_default_task_id(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern UInt64 toggl_get_default_task_id(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_update_channel(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_update_channel(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string update_channel);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_update_channel(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_update_channel(
         IntPtr context);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_user_fullname(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_user_fullname(
         IntPtr context);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_get_user_email(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_get_user_email(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_sync(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_sync(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_fullsync(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_fullsync(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_timeline_toggle_recording(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_timeline_toggle_recording(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool record_timeline);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_timeline_is_recording_enabled(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_timeline_is_recording_enabled(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_sleep(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_sleep(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_wake(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_wake(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_os_shutdown(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_locked(
+		IntPtr context);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_unlocked(
+		IntPtr context);
+
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_os_shutdown(
         IntPtr context);
 
     // Notify lib that client is online again.
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_online(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_online(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_idle_seconds(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_idle_seconds(
         IntPtr context,
         UInt64 idle_seconds);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_set_promotion_response(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_set_promotion_response(
         IntPtr context,
         Int64 promotion_type,
         Int64 promotion_response);
@@ -1418,31 +1427,31 @@ public static partial class Toggl
     // Shared helpers
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_format_tracking_time_duration(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_format_tracking_time_duration(
         Int64 duration_in_seconds);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_format_tracked_time_duration(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_format_tracked_time_duration(
         Int64 duration_in_seconds);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_parse_duration_string_into_seconds(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_parse_duration_string_into_seconds(
+[MarshalAs(UnmanagedType.LPWStr)]
         string duration_string);
 
     // Write to the lib logger
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_debug(
-        [MarshalAs(UnmanagedType.LPWStr)]
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_debug(
+[MarshalAs(UnmanagedType.LPWStr)]
         string text);
 
     // Check if sizeof view struct matches those in UI
     // Will return error string if size is invalid,
     // you must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_check_view_struct_size(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_check_view_struct_size(
         int time_entry_view_item_size,
         int autocomplete_view_item_size,
         int view_item_size,
@@ -1450,107 +1459,107 @@ public static partial class Toggl
         int autotracker_view_item_size);
 
     // You must free() the result
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern string toggl_run_script(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern string toggl_run_script(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string script,
         ref Int64 err);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_autotracker_add_rule(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_autotracker_add_rule(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPWStr)]
+[MarshalAs(UnmanagedType.LPWStr)]
         string term,
         UInt64 project_id,
         UInt64 task_id);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_autotracker_delete_rule(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_autotracker_delete_rule(
         IntPtr context,
         Int64 id);
 
     // Testing helpers. May change any time
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void testing_sleep(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void testing_sleep(
         int seconds);
 
     // For testing only
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool testing_set_logged_in_user(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool testing_set_logged_in_user(
         IntPtr context,
-        [MarshalAs(UnmanagedType.LPStr)]
+[MarshalAs(UnmanagedType.LPStr)]
         string json);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_compact_mode(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_compact_mode(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_compact_mode(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_get_compact_mode(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_keep_end_time_fixed(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_keep_end_time_fixed(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_keep_end_time_fixed(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_get_keep_end_time_fixed(
         IntPtr context);
 
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_mini_timer_x(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_mini_timer_x(
         IntPtr context,
         Int64 value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_get_mini_timer_x(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_get_mini_timer_x(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_mini_timer_y(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_mini_timer_y(
         IntPtr context,
         Int64 value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_get_mini_timer_y(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_get_mini_timer_y(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_mini_timer_w(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_mini_timer_w(
         IntPtr context,
         Int64 value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern Int64 toggl_get_mini_timer_w(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern Int64 toggl_get_mini_timer_w(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_mini_timer_visible(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_set_mini_timer_visible(
         IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
+[MarshalAs(UnmanagedType.I1)]
         bool value);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_mini_timer_visible(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+[return:MarshalAs(UnmanagedType.I1)]
+private static extern bool toggl_get_mini_timer_visible(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_load_more(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void toggl_load_more(
         IntPtr context);
 
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void track_window_size(
+[DllImport(dll, CharSet = charset, CallingConvention = convention)]
+private static extern void track_window_size(
         IntPtr context,
         UInt64 width,
         UInt64 height);
@@ -1558,6 +1567,6 @@ public static partial class Toggl
 
 
 
-}
+    }
 
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -157,11 +157,11 @@ namespace TogglDesktop
         {
             if (e.Reason == SessionSwitchReason.SessionLock)
             {
-                Toggl.SetSleep();
+                Toggl.SetLocked();
             }
             else if (e.Reason == SessionSwitchReason.SessionUnlock)
             {
-                Toggl.SetWake();
+                Toggl.SetUnlocked();
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -136,8 +136,21 @@ namespace TogglDesktop
 
         private void initializeSessionNotification()
         {
-            SystemEvents.SessionSwitch += new SessionSwitchEventHandler(SystemEvents_SessionSwitch);
-            SystemEvents.SessionEnded += new SessionEndedEventHandler(SystemEventsSessionEndOnChanged);
+            SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
+            SystemEvents.SessionEnded += SystemEventsSessionEndOnChanged;
+            SystemEvents.PowerModeChanged += SystemEventsOnPowerModeChanged;
+        }
+
+        private void SystemEventsOnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+        {
+            if (e.Mode == PowerModes.Suspend)
+            {
+                Toggl.SetSleep();
+            }
+            else if (e.Mode == PowerModes.Resume)
+            {
+                Toggl.SetWake();
+            }
         }
 
         private void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e)

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -79,7 +79,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
             timeline_datasource_->StartAutotrackerEvent(event);
         }
     }
-
+	idle = idle || getIsLocked() || getIsSleeping();
     bool idleChanged = hasIdlenessChanged(idle);
 
     if (idleChanged) {

--- a/src/window_change_recorder.h
+++ b/src/window_change_recorder.h
@@ -28,6 +28,8 @@ class WindowChangeRecorder {
     , recording_(this, &WindowChangeRecorder::recordLoop)
     , last_autotracker_title_("")
     , shutdown_(false)
+	, isLocked_(false)
+	, isSleeping_(false)
     , timeline_errors_() {
         recording_.start();
     }
@@ -35,6 +37,16 @@ class WindowChangeRecorder {
     ~WindowChangeRecorder() {
         Shutdown();
     }
+
+	void SetIsLocked(bool isLocked) {
+		Poco::Mutex::ScopedLock lock(isLocked_m_);
+		isLocked_ = isLocked;
+    }
+
+	void SetIsSleeping(bool isSleeping) {
+		Poco::Mutex::ScopedLock lock(isSleeping_m_);
+		isSleeping_ = isSleeping;
+	}
 
     error Shutdown();
 
@@ -52,6 +64,16 @@ class WindowChangeRecorder {
 
     Poco::Logger &logger();
 
+	bool getIsLocked() {
+		Poco::Mutex::ScopedLock lock(isLocked_m_);
+		return isLocked_;
+	}
+
+	bool getIsSleeping() {
+		Poco::Mutex::ScopedLock lock(isSleeping_m_);
+		return isSleeping_;
+	}
+
     // Last window focus event data
     std::string last_title_;
     std::string last_filename_;
@@ -66,6 +88,12 @@ class WindowChangeRecorder {
 
     Poco::Mutex shutdown_m_;
     bool shutdown_;
+
+	Poco::Mutex isLocked_m_;
+	bool isLocked_;
+
+	Poco::Mutex isSleeping_m_;
+	bool isSleeping_;
 
     std::map<const int, int> timeline_errors_;
 };


### PR DESCRIPTION
### 📒 Description
Timeline data should not be recorded when the PC is locked or in sleep mode

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] add toggl_set_locked() and toggl_set_unlocked() to the API (lib)
- [x] extend WindowChangeRecorder to not record while locked or sleeping (lib)
- [x] trigger SetSleep(), SetWake(), SetLocked() and SetUnlocked() correctly (win)

### 👫 Relationships
Closes #1965
Closes #2914
Closes #1554

### 🔎 Review hints
Check that:
- Timeline recording still works on Windows, MacOS, and Linux

On Windows:
- During the time when PC is locked/asleep the timeline data is not being recorded
- When "Stop running entry on computer sleep/shutdown" is checked - entry should not be stopped if PC is just locked