### PR TITLE
[WIP] Explicitly set Application User Model ID on app startup

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -29,6 +29,7 @@ static class Program
     [STAThread]
     static void Main()
     {
+        Win32.SetCurrentProcessExplicitAppUserModelID("Toggl.TogglDesktop." + Version);
         Win32.AttachConsole(Win32.ATTACH_PARENT_PROCESS);
 
         using (Mutex mutex = new Mutex(false, "Global\\" + Environment.UserName + "_" + appGUID))
@@ -66,7 +67,7 @@ static class Program
             Toggl.InitialiseLog();
 
             var configuration = new Bugsnag.Configuration("aa13053a88d5133b688db0f25ec103b7");
-            configuration.AppVersion = Version();
+            configuration.AppVersion = Version;
 
 #if TOGGL_PRODUCTION_BUILD
             configuration.ReleaseStage = "production";
@@ -147,7 +148,7 @@ static class Program
         Environment.Exit(exitCode);
     }
 
-    public static string Version()
+    private static string GetVersionFromAssembly()
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
         FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
@@ -156,5 +157,7 @@ static class Program
                              versionInfo.ProductMinorPart,
                              versionInfo.ProductBuildPart);
     }
+
+    public static string Version { get; } = GetVersionFromAssembly();
 }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -125,8 +125,7 @@
       <HintPath>..\packages\Google.Apis.1.37.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Hardcodet.Wpf.TaskbarNotification, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.5\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
+      <HintPath>..\packages\Hardcodet.NotifyIcon.Wpf.1.0.8\lib\net45\Hardcodet.Wpf.TaskbarNotification.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/packages.config
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/packages.config
@@ -5,7 +5,7 @@
   <package id="Google.Apis.Auth" version="1.37.0" targetFramework="net45" />
   <package id="Google.Apis.Core" version="1.37.0" targetFramework="net45" />
   <package id="Google.Apis.Oauth2.v2" version="1.37.0.1404" targetFramework="net45" />
-  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.5" targetFramework="net45" />
+  <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.8" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Drawing;
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
-using Hardcodet.Wpf.TaskbarNotification;
-using Hardcodet.Wpf.TaskbarNotification.Interop;
 
 namespace TogglDesktop
 {
@@ -47,28 +43,6 @@ static class UIExtensions
     }
 
     #endregion
-
-    public static void ShowBalloonTipWithLargeIcon(this TaskbarIcon icon, string title, string message, Icon customIcon)
-    {
-        if (icon == null)
-            throw new ArgumentNullException("icon");
-
-        var method = typeof (TaskbarIcon)
-                     .GetMethod("ShowBalloonTip", BindingFlags.NonPublic | BindingFlags.Instance);
-
-        lock (icon)
-        {
-            // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
-            // (The enum behaves like flags)
-            method.Invoke(icon, new object[]
-            {
-                title,
-                message,
-                BalloonFlags.User | BalloonFlags.LargeIcon,
-                customIcon.Handle
-            });
-        }
-    }
 
     public static void ShowOnlyIf(this UIElement control, bool condition)
     {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace TogglDesktop
             this.updateText.Text = "";
             this.restartButton.Visibility = Visibility.Collapsed;
 
-            this.versionText.Text = Program.Version();
+            this.versionText.Text = Program.Version;
 
             var isUpdatCheckDisabled = Toggl.IsUpdateCheckDisabled();
             this.releaseChannelComboBox.ShowOnlyIf(!isUpdatCheckDisabled, true);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -245,7 +245,7 @@ namespace TogglDesktop
         {
             Toggl.RegisterMainWindow(this);
 
-            if (!Toggl.StartUI(Program.Version(), this.experimentManager.CurrentExperumentIds))
+            if (!Toggl.StartUI(Program.Version, this.experimentManager.CurrentExperumentIds))
             {
                 MessageBox.Show(null, "Missing callback. See the log file for details");
                 this.shutdown(1);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -359,7 +359,7 @@ namespace TogglDesktop
             if (this.TryBeginInvoke(this.onReminder, title, informativeText))
                 return;
 
-            this.taskbarIcon.ShowBalloonTipWithLargeIcon(title, informativeText, Properties.Resources.toggl);
+            this.taskbarIcon.ShowBalloonTip(title, informativeText, Properties.Resources.toggl, largeIcon: true);
         }
 
         private void onOnlineState(Toggl.OnlineState state)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Win32.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Win32.cs
@@ -121,6 +121,10 @@ static class Win32
         var extendedStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
         SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
     }
+
+    [DllImport("shell32.dll", SetLastError = true)]
+    public static extern void SetCurrentProcessExplicitAppUserModelID([MarshalAs(UnmanagedType.LPWStr)] string AppID);
+
 }
 
 }


### PR DESCRIPTION
### 📒 Description
Related PR in `branding` repo: https://github.com/toggl/toggldesktop-branding/pull/32

In order to make the application notifications work consistently, Application User Model ID should be explicitly set for the application. Some links for more info:
https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/send-local-toast-desktop#classic-win32
https://docs.microsoft.com/en-us/windows/desktop/shell/appids
https://github.com/electron/electron/issues/10864

I wasn't able to pinpoint the steps to reproduce the issue with notifications not being shown, so I'll find some people to test this after we make a dev release.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Set explicit AppUserModelId
- [x] Do not reevaluate version string on every call
- [x] Update Hardcodet.NotifyIcon.Wpf NuGet package (can potentially fix some bugs related to notifications and tray icon)

### 👫 Relationships
#2583
#2133

(will need further testing to verify that the PR actually fixes these bugs)

### 🔎 Review hints
- Check that AppUserModelID `Toggl.TogglDesktop.VERSION` is set (https://docs.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app#to-find-the-aumid-by-using-file-explorer)
- Everything else works in the same way
- Reminder notifications should now appear for all? users (if you can reproduce the bug then this PR should fix it)

If notifications do not appear, check the following settings:
- Notifications & actions settings -> Get notifications from these senders -> TogglDesktop -> On
- Focus assist settings -> Off
- Settings -> Privacy -> Background apps -> Let apps run in the background -> On (reboot if this changed)