### PR TITLE
UX improvements: Double click to select word, triple click to select entire field

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ExtendedTextBox.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ExtendedTextBox.cs
@@ -28,6 +28,11 @@ namespace TogglDesktop
                 this.SelectionLength = 0;
             }
 
+            if (e.ClickCount == 3)
+            {
+                this.SelectAll();
+            }
+
             base.OnMouseDown(e);
         }
 
@@ -62,12 +67,6 @@ namespace TogglDesktop
             }
 
             base.OnLostKeyboardFocus(e);
-        }
-
-        protected override void OnMouseDoubleClick(MouseButtonEventArgs e)
-        {
-            this.SelectAll();
-            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
### 📒 Description
Double click should select a single word, triple click should select the entire field.
Currently, double click selects the entire field and, what's annoying, there's no quick way to select a single word.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #1826