### PR TITLE
Preferences pomodoro break timer visibilty bug fix

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -228,6 +228,7 @@
       <DependentUpon>TimeEntryCellDayHeader.xaml</DependentUpon>
     </Compile>
     <Compile Include="ui\controls\TimeEntryCellDragImposter.cs" />
+    <Compile Include="ui\Converters\AndConverter.cs" />
     <Compile Include="ui\Converters\StringToBrushConverter.cs" />
     <Compile Include="ui\Experiments\implementations\Experiment98.cs" />
     <Compile Include="ui\Experiments\implementations\Experiment98Screen2.xaml.cs">

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj.user
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj.user
@@ -9,7 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj.user
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj.user
@@ -9,7 +9,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
-    <ProjectView>ProjectFiles</ProjectView>
+    <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/AndConverter.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/Converters/AndConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace TogglDesktop.Converters
+{
+    public class AndConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return values.All(x => (bool)x);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:converters="clr-namespace:TogglDesktop.Converters"
         xmlns:toggl="clr-namespace:TogglDesktop"
         mc:Ignorable="d" 
         Height="528" Width="500"
@@ -11,7 +12,9 @@
         Title="Preferences"
         Style="{StaticResource Preferences}"
         >
-
+    <toggl:TogglWindow.Resources>
+        <converters:AndConverter x:Key="AndConverter" />
+    </toggl:TogglWindow.Resources>
     <!-- content -->
     <Grid Background="{StaticResource ViewBackgroundLight}" Height="482">
         <Grid.RowDefinitions>
@@ -74,10 +77,22 @@
                         <StackPanel Margin="5" Grid.Column="1" Grid.Row="2"
                                     Orientation="Horizontal">
                             <TextBox Name="pomodoroBreakTimerDuration" x:FieldModifier="private"
-                                    Width="30"  HorizontalContentAlignment="Right" 
-                                  IsEnabled="{Binding ElementName=enablePomodoroBreakCheckBox, Path=IsChecked}">5</TextBox>
-                            <TextBlock Margin="4 0 0 0"
-                                  IsEnabled="{Binding ElementName=enablePomodoroBreakCheckBox, Path=IsChecked}">minutes</TextBlock>
+                                     Width="30"  HorizontalContentAlignment="Right" Text="5">
+                                <TextBox.IsEnabled>
+                                    <MultiBinding Converter="{StaticResource AndConverter}">
+                                        <Binding ElementName="enablePomodoroBreakCheckBox" Path="IsChecked"/>
+                                        <Binding ElementName="enablePomodoroCheckBox" Path="IsChecked"/>
+                                    </MultiBinding>
+                                </TextBox.IsEnabled>
+                            </TextBox>
+                            <TextBlock Margin="4 0 0 0" Text="minutes">
+                                <TextBlock.IsEnabled>
+                                    <MultiBinding Converter="{StaticResource AndConverter}">
+                                        <Binding ElementName="enablePomodoroBreakCheckBox" Path="IsChecked"/>
+                                        <Binding ElementName="enablePomodoroCheckBox" Path="IsChecked"/>
+                                    </MultiBinding>
+                                </TextBlock.IsEnabled>
+                            </TextBlock>
                         </StackPanel>
 
                         <CheckBox Grid.Column="0" Grid.Row="3"

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -58,7 +58,7 @@
 
                         <CheckBox Grid.Column="0" Grid.Row="1"
                             Name="enablePomodoroCheckBox" x:FieldModifier="private"
-                            HorizontalContentAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch" 
                             Margin="5">Pomodoro Timer</CheckBox>
                         <StackPanel Margin="5" Grid.Column="1" Grid.Row="1"
                                     Orientation="Horizontal">
@@ -72,26 +72,20 @@
                         <CheckBox Grid.Column="0" Grid.Row="2"
                             Name="enablePomodoroBreakCheckBox" x:FieldModifier="private"
                             HorizontalContentAlignment="Stretch"
-                            Margin="5"
+                            Margin="5" 
                             IsEnabled="{Binding ElementName=enablePomodoroCheckBox, Path=IsChecked}">Pomodoro Break Timer</CheckBox>
                         <StackPanel Margin="5" Grid.Column="1" Grid.Row="2"
                                     Orientation="Horizontal">
+                            <StackPanel.IsEnabled>
+                                <MultiBinding Converter="{StaticResource AndConverter}">
+                                    <Binding ElementName="enablePomodoroBreakCheckBox" Path="IsChecked"/>
+                                    <Binding ElementName="enablePomodoroCheckBox" Path="IsChecked"/>
+                                </MultiBinding>
+                            </StackPanel.IsEnabled>
                             <TextBox Name="pomodoroBreakTimerDuration" x:FieldModifier="private"
                                      Width="30"  HorizontalContentAlignment="Right" Text="5">
-                                <TextBox.IsEnabled>
-                                    <MultiBinding Converter="{StaticResource AndConverter}">
-                                        <Binding ElementName="enablePomodoroBreakCheckBox" Path="IsChecked"/>
-                                        <Binding ElementName="enablePomodoroCheckBox" Path="IsChecked"/>
-                                    </MultiBinding>
-                                </TextBox.IsEnabled>
                             </TextBox>
                             <TextBlock Margin="4 0 0 0" Text="minutes">
-                                <TextBlock.IsEnabled>
-                                    <MultiBinding Converter="{StaticResource AndConverter}">
-                                        <Binding ElementName="enablePomodoroBreakCheckBox" Path="IsChecked"/>
-                                        <Binding ElementName="enablePomodoroCheckBox" Path="IsChecked"/>
-                                    </MultiBinding>
-                                </TextBlock.IsEnabled>
                             </TextBlock>
                         </StackPanel>
 


### PR DESCRIPTION
### 📒 Description
This PR fixes the visibility behavior of Pomodoro break timer controls

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
Change the visibility of Pomodoro break timer minutes' input Textbox from depending on Pomodoro break timer only to depend on  both pomodoro timer and Pomodoro break timer

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->
Closes #3068 

### 🔎 Review hints
    Open the Preferences window and select the General tab.
    Check Pomodoro Break Timer CheckBox.
    Uncheck Pomodoro Timer CheckBox.
    Now you should not be able to Edit Pomodoro Break Timers minutes.

and it should be like this
![BugFix](https://user-images.githubusercontent.com/18364158/60758884-ce2b8d80-a01c-11e9-9302-5fa29cb67299.png)

