### PR TITLE
Checkbox to run app on Windows login

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml
@@ -2,8 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:toggl="clr-namespace:TogglDesktop"
-             ShutdownMode="OnExplicitShutdown"
-             StartupUri="ui/windows/MainWindow.xaml">
+             ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/App.xaml.cs
@@ -1,11 +1,25 @@
-﻿
+﻿using System;
+using System.Linq;
+using System.Windows;
+
 namespace TogglDesktop
 {
-partial class App
-{
-    public App()
+    partial class App
     {
-        this.InitializeComponent();
+        public App()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            var mainWindow = new MainWindow();
+            var startMinimized = Environment.GetCommandLineArgs().Contains("--minimize");
+            if (!startMinimized)
+            {
+                mainWindow.Show();
+            }
+        }
     }
-}
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:converters="clr-namespace:TogglDesktop.Converters"
         xmlns:toggl="clr-namespace:TogglDesktop"
         mc:Ignorable="d" 
-        Height="528" Width="500"
+        Height="554" Width="500"
         KeyDown="windowKeyDown"
         IsToolWindow="True"
         Title="Preferences"
@@ -16,7 +16,7 @@
         <converters:AndConverter x:Key="AndConverter" />
     </toggl:TogglWindow.Resources>
     <!-- content -->
-    <Grid Background="{StaticResource ViewBackgroundLight}" Height="482">
+    <Grid Background="{StaticResource ViewBackgroundLight}">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -28,8 +28,8 @@
         <!-- tabbed content -->
         <TabControl Grid.Row="0" TabStripPlacement="Top">
             <TabItem Header="GENERAL">
-                <StackPanel Margin="11" Height="373">
-                    <Grid>
+                <StackPanel Margin="11">
+                    <Grid Margin="0,0,0,2">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
@@ -40,7 +40,8 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="28"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
                         <CheckBox Grid.Column="0" Grid.Row="0"
@@ -98,6 +99,9 @@
                         <CheckBox Grid.Column="0" Grid.Row="5"
                             x:Name="onStopEntryCheckBox" x:FieldModifier="private"
                             Margin="5" Content="Stop running entry on computer sleep/shutdown"/>
+                        <CheckBox Grid.Column="0" Grid.Row="6"
+                                  x:Name="launchOnStartupCheckBox" x:FieldModifier="private"
+                                  Margin="5" Content="Run the app on Windows login"/>
 
                     </Grid>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using Microsoft.Win32;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Implementation;
 using TogglDesktop.Diagnostics;
@@ -128,6 +130,7 @@ namespace TogglDesktop
             this.keepEndTimeFixedCheckbox.IsChecked = Toggl.GetKeepEndTimeFixed();
 
             this.onStopEntryCheckBox.IsChecked = settings.StopEntryOnShutdownSleep;
+            this.launchOnStartupCheckBox.IsChecked = Utils.GetLaunchOnStartupRegistry();
 
             #endregion
 
@@ -298,6 +301,7 @@ namespace TogglDesktop
 
             Toggl.SetDefaultProject(settings.DefaultProject.ProjectID, settings.DefaultProject.TaskID);
             Toggl.SetKeepEndTimeFixed(settings.KeepEndTimeFixed);
+            Utils.SaveLaunchOnStartupRegistry(settings.LaunchOnStartup);
 
             return Toggl.SetSettings(settings.TogglSettings);
         }
@@ -372,6 +376,7 @@ namespace TogglDesktop
                 TogglSettings = settings,
                 DefaultProject = this.selectedDefaultProject,
                 KeepEndTimeFixed = isChecked(this.keepEndTimeFixedCheckbox),
+                LaunchOnStartup = isChecked(this.launchOnStartupCheckBox)
             };
         }
 
@@ -380,6 +385,7 @@ namespace TogglDesktop
             public Toggl.TogglSettingsView TogglSettings { get; set; }
             public Toggl.TogglAutocompleteView DefaultProject { get; set; }
             public bool KeepEndTimeFixed { get; set; }
+            public bool LaunchOnStartup { get; set; }
         }
 
         #endregion


### PR DESCRIPTION
### 📒 Description
Adds a Preferences checkbox which, when enabled, will make the app start minimized when the user logs in to Windows. 
This is done by the means of adding a registry entry into `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run`.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Added command line option `--minimize` to start minimized
- Added checkbox to Preferences
- Implemented the logic to read/write/delete the specific registry value

### 👫 Relationships
Closes #2223

### 🔎 Review hints
Check the checkbox, press Save -> The entry `TogglDesktop` is added to `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run` with value `"path to exe" --minimize`. When restarting the PC and logging in with the same user Toggl Desktop should start minimized in the tray, with the autotracker, notifications, etc. working.

![image](https://user-images.githubusercontent.com/16451391/60871905-62277000-a23c-11e9-970c-60d6178246a2.png)