### PR TITLE
Fixed idle popup not being on top when shown

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -33,7 +33,7 @@ extern void *ctx;
 - (void)awakeFromNib
 {
 	[super awakeFromNib];
-
+	[self.window setLevel:NSFloatingWindowLevel];
 	[self initCommon];
 }
 


### PR DESCRIPTION
### 📒 Description
Made the idle popup to always be on top

### 🕶️ Types of changes

**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3070

### 🔎 Review hints
- start app
- make sure idle detection is turned on (1 min is best for testing)
- start timer
- move the app behind some other window
- wait 1 minute, then do an action to trigger idle popup
- Idle popup should be in the front