### PR TITLE
Look into relative ../share folder for the cacert file, too (linux)

### DIFF
--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -250,6 +250,9 @@ TogglApi::TogglApi(
     QString executablePath = QCoreApplication::applicationDirPath();
     QDir executableDir = QDir(executablePath);
     QString cacertPath = executableDir.filePath("cacert.pem");
+    if (!QFile::exists(cacertPath)) {
+        cacertPath = QString("%1/../share/toggldesktop/cacert.pem").arg(executableDir.path());
+    }
 #ifdef TOGGL_DATA_DIR
     if (!QFile::exists(cacertPath)) {
         cacertPath = QString("%1/cacert.pem").arg(TOGGL_DATA_DIR);


### PR DESCRIPTION
### 📒 Description
While doing changes for .deb packages, I moved the `cacert.pem` file to a different folder. I didn't pick it up in the tarball, though (and didn't notice it when testing because I had one installed). This PR fixes the problem by adding a relative search for the `share` folder like this:
`<BINARY_FOLDER>/../share/toggldesktop/` in addition to searching in the `<BINARY_FOLDER>` directly and `<INSTALL_DIR>/share/toggldesktop` we had in place before.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- `cacert.pem` is handled correctly in Linux `.tar.gz` release

### 👫 Relationships
Closes #3078 

### 🔎 Review hints
Check if `TogglDesktop` finds the `cacert.pem` file right when started from the tarball, flatpak, flathub, deb and snap packages. It should not complain about it (as seen in the related bug report). 

