### PR TITLE
Fix for Idle popup not visible

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/chrome/ChromelessWindow.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/chrome/ChromelessWindow.cs
@@ -96,13 +96,14 @@ namespace TogglDesktop
 
         protected override void OnLocationChanged(EventArgs e)
         {
-            this.updateMaximumSize();
-
-            if (!this.isToolWindow
-                && this.WindowState != WindowState.Maximized
-                && this.ResizeMode != ResizeMode.CanResize)
+            if (!this.IsToolWindow)
             {
-                this.ResizeMode = ResizeMode.CanResize;
+                this.updateMaximumSize();
+                if (this.WindowState != WindowState.Maximized
+                    && this.ResizeMode != ResizeMode.CanResize)
+                {
+                    this.ResizeMode = ResizeMode.CanResize;
+                }
             }
 
             base.OnLocationChanged(e);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:toggl="clr-namespace:TogglDesktop"
         mc:Ignorable="d" 
         Height="350" Width="280"
+        MinHeight="350" MinWidth="280"
         KeyDown="windowKeyDown"
         IsToolWindow="True"
         Title="Idle Notification"


### PR DESCRIPTION
### 📒 Description
`updateMaximumSize()` was the only place in the code that can change the size of the window, so I made sure it's not called for our tool windows, as even the largest of tool windows does not have to be resized.
Also set the minimum size for the idle notification window, just in case.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3009
Closes #2479 

### 🔎 Review hints
I wasn't able to reproduce this exact issue, but the `updateMaximumSize()` method triggered some other methods that are not guaranteed to work correctly.