### PR TITLE
Fixes ugly grey input backgrounds in macos 10.11

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
@@ -26,6 +26,7 @@ final class EditorPopover: NoVibrantPopoverView {
 
     @objc func prepareViewController() {
         let editor = EditorViewController(nibName: NSNib.Name("EditorViewController"), bundle: nil)
+        editor.view.appearance = appearance
         contentViewController = editor
     }
 


### PR DESCRIPTION
### 📒 Description
changed the Appearance of the edit view to always be `aqua` when on a system that does not support dark mode

### 🕶️ Types of changes
**Bug fix**

### 👫 Relationships
Closes #3076

### 🔎 Review hints
Start the app on macos 10.11 and make sure the app looks like this 

![Screen Shot 2019-07-12 at 23 39 03](https://user-images.githubusercontent.com/842229/61158972-34c01800-a503-11e9-96ed-0663b7a5bbb4.png)

and not like on the screenshot in the issue

![Screen Shot 2019-06-26 at 07 45 07](https://user-images.githubusercontent.com/842229/61158798-b794a300-a502-11e9-8e76-a34c221d46e5.png)

Some small grey corners are still visible in the input edges in the edit form. I just could not figure out why they are there. Maybe it's also connected to the appearance setting, but I tested and was not able to detect the cause. Luckily these small corners are very very small and we can ship the new version with them. Maybe once @NghiaTranUIT is back he can take another look at the corners.

