### PR TITLE
When adding an existing tag, just make it checked

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -491,9 +491,7 @@ void TimeEntryEditorWidget::on_tags_itemClicked(QListWidgetItem *item) {
             tags.push_back(widgetItem->text());
         }
     }
-    if (item) {
-        tags.push_back(item->text());
-    }
+
     tags.sort();
     QString list = tags.join("\t");
 
@@ -573,8 +571,10 @@ void TimeEntryEditorWidget::on_newTagButton_clicked() {
         for (int i = 0; i < ui->tags->count(); i++) {
             QListWidgetItem *widgetItem = ui->tags->item(i);
             if (widgetItem->text() == newTag) {
-                if (widgetItem->checkState() != Qt::Checked)
+                if (widgetItem->checkState() != Qt::Checked) {
+                    widgetItem->setCheckState(Qt::Checked);
                     on_tags_itemClicked(widgetItem);
+                }
                 return;
             }
             allTags << widgetItem->text();


### PR DESCRIPTION
### 📒 Description
This fixes how adding tags is handled - now when adding an existing tag, it's forced to be checked (no unchecking, though).

### 🕶️ Types of changes
 - **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- linux: adding an existing tag makes it selected for the current time entry

### 👫 Relationships
Closes #3084

### 🔎 Review hints
See if adding (new and existing) tags works as expected. Adding an existing tag should make the tag checked.
Also see if checking and unchecking of other (previously existing) tags works right when (re)opening the time entry editor.


