### PR TITLE
Always select time entry workspace by default when opening 'Add project'

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -361,6 +361,15 @@ void TimeEntryEditorWidget::on_addNewProject_clicked() {
 
     if (!hasMultipleWorkspaces) {
         ui->newProjectWorkspace->setCurrentIndex(0);
+    } else {
+        int i = 0;
+        foreach(GenericView *view, workspaceSelectUpdate) {
+            if(view->ID == timeEntry->WID) {
+                ui->newProjectWorkspace->setCurrentIndex(i);
+                break;
+            }
+            i++;
+        }
     }
 }
 


### PR DESCRIPTION
### 📒 Description
When a user had more than 1 workspace no workspace was selected by default in the "Add project" form. When the user did not select the workspace the form would not close and it would not show any error message to the user making them guess what has happened. Setting the default value to the most logical (The WS of the time entry edited) fixes this issue.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
Select WS by the currently selected time entry in edit view

### 👫 Relationships
Found a bug when testing and fixed it. No relationships to any issues.

### 🔎 Review hints
- Get an account with multiple workspaces.
- Have entries that are in different workspaces
- open edit view -> add project
- See if the workspace select has selected the same workspace that is at the bottom of the edit form
