### PR TITLE
Select date based on actual selected value instead of parsing string representation

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -397,18 +397,11 @@ namespace TogglDesktop
             }
 
             DateTime currentDate = Toggl.DateTimeFromUnix(timeEntry.Started);
-            try { 
-                DateTime selected = Convert.ToDateTime(this.startDatePicker.Text);
-           
-                if (!currentDate.Date.Equals(selected.Date))
-                {
-                    currentDate = selected;
-                    Toggl.SetTimeEntryDate(this.timeEntry.GUID, selected);
-                }
-            }
-            catch (Exception e)
+
+            if (!currentDate.Equals(this.startDatePicker.SelectedDate.Value))
             {
-                System.Console.WriteLine("Catched error: " + e.Message);
+                currentDate = this.startDatePicker.SelectedDate.Value;
+                Toggl.SetTimeEntryDate(this.timeEntry.GUID, currentDate);
             }
         }
 


### PR DESCRIPTION
### 📒 Description
Selects date based on actual selected value instead of parsing string representation.
Fixed issues if the user's date format didn't contain a year.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2841

### 🔎 Review hints
1. Control Panel -> Clock and Region -> Change date, time, or number formats -> Additional settings... -> "Date" tab -> Date formats -> Short date -> anything that does not include a year, e.g. "dd/MMM ddd".
2. In Toggl Desktop change the TE date to any date from the previous year.