### PR TITLE
Rework auto-update system to use github pages instead of v8 API

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1398,7 +1398,11 @@ error Context::downloadUpdate() {
             }
             auto latestVersion = root[shortOSName()][update_channel];
             url = latestVersion[installerPlatform()].asString();
-            version_number = latestVersion["version"].asString();
+            auto versionNumberJsonToken = latestVersion["version"];
+            if (versionNumberJsonToken.empty()) {
+                return error("No versions found for OS " + shortOSName() + ", platform " + installerPlatform() + ", channel " + update_channel);
+            }
+            version_number = versionNumberJsonToken.asString();
 
             if (lessThanVersion(HTTPSClient::Config.AppVersion, version_number)) {
                 std::stringstream ss;
@@ -1541,7 +1545,7 @@ bool Context::lessThanVersion(const std::string& version1, const std::string& ve
     int parsed1[4] {}, parsed2[4] {};
     parseVersion(parsed1, version1);
     parseVersion(parsed2, version2);
-    return std::lexicographical_compare(parsed1, parsed1 + 4, parsed2, parsed2 + 4);
+    return std::lexicographical_compare(parsed1, &parsed1[4], parsed2, &parsed2[4]);
 }
 
 void Context::TimelineUpdateServerSettings() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1492,6 +1492,11 @@ const std::string Context::linuxPlatformName() {
 const std::string Context::windowsPlatformName() {
 #if defined(_WIN64)
     return "windows64";
+#elif defined(_WIN32)
+    BOOL f64 = FALSE;
+    if (IsWow64Process(GetCurrentProcess(), &f64) && f64)
+        return "windows64";
+    return "windows";
 #else
     return "windows";
 #endif

--- a/src/context.cc
+++ b/src/context.cc
@@ -1373,11 +1373,8 @@ error Context::downloadUpdate() {
             return err;
         }
 
-        // Get update check URL
-        std::string update_url("");
-        err = updateURL(&update_url);
-        if (err != noError) {
-            return err;
+        if (HTTPSClient::Config.AppVersion.empty()) {
+            return error("Cannot check for updates without app version");
         }
 
         // Ask Toggl server if we have updates
@@ -1385,8 +1382,8 @@ error Context::downloadUpdate() {
         std::string version_number("");
         {
             HTTPSRequest req;
-            req.host = urls::API();
-            req.relative_url = update_url;
+            req.host = "https://toggl.github.io";
+            req.relative_url = "/toggldesktop/assets/releases/updates.json";
 
             TogglClient client;
             HTTPSResponse resp = client.Get(req);
@@ -1394,27 +1391,27 @@ error Context::downloadUpdate() {
                 return resp.err;
             }
 
-            if ("null" == resp.body) {
+            Json::Value root;
+            Json::Reader reader;
+            if (!reader.parse(resp.body, root)) {
+                return error("Error parsing update check response body");
+            }
+            auto latestVersion = root[shortOSName()][update_channel];
+            url = latestVersion[installerPlatform()].asString();
+            version_number = latestVersion["version"].asString();
+
+            if (lessThanVersion(HTTPSClient::Config.AppVersion, version_number)) {
+                std::stringstream ss;
+                ss << "Found update " << version_number
+                   << " (" << url << ")";
+                logger().debug(ss.str());
+            } else {
                 logger().debug("The app is up to date");
                 if (UI()->CanDisplayUpdate()) {
                     UI()->DisplayUpdate("");
                 }
                 return noError;
             }
-
-            Json::Value root;
-            Json::Reader reader;
-            if (!reader.parse(resp.body, root)) {
-                return error("Error parsing update check response body");
-            }
-
-            url = root["url"].asString();
-            version_number = root["version"].asString();
-
-            std::stringstream ss;
-            ss << "Found update " << version_number
-               << " (" << url << ")";
-            logger().debug(ss.str());
         }
 
         // linux has non-silent updates, just pass on the URL
@@ -1485,31 +1482,6 @@ error Context::downloadUpdate() {
     return noError;
 }
 
-error Context::updateURL(std::string *result) {
-    std::string update_channel("");
-    error err = db()->LoadUpdateChannel(&update_channel);
-    if (err != noError) {
-        return err;
-    }
-
-    if (HTTPSClient::Config.AppVersion.empty()) {
-        return error("Cannot check for updates without app version");
-    }
-
-    // Not implemented in v9 as of 12.05.2017
-    std::stringstream relative_url;
-    relative_url << "/api/v8/updates?app=td"
-                 << "&channel=" << update_channel
-                 << "&platform=" << installerPlatform()
-                 << "&version=" << HTTPSClient::Config.AppVersion
-                 << "&osname=" << Poco::Environment::osName()
-                 << "&osversion=" << Poco::Environment::osVersion()
-                 << "&osarch=" << Poco::Environment::osArchitecture();
-    *result = relative_url.str();
-
-    return noError;
-}
-
 const std::string Context::linuxPlatformName() {
     if (kDebianPackage) {
         return "deb64";
@@ -1517,14 +1489,22 @@ const std::string Context::linuxPlatformName() {
     return std::string("linux");
 }
 
+const std::string Context::windowsPlatformName() {
+#if defined(_WIN64)
+    return "windows64";
+#else
+    return "windows";
+#endif
+}
+
 const std::string Context::installerPlatform() {
     std::stringstream ss;
     if (POCO_OS_LINUX == POCO_OS) {
         ss <<  linuxPlatformName();
     } else if (POCO_OS_WINDOWS_NT == POCO_OS) {
-        ss << "windows";
+        ss << windowsPlatformName();
     } else {
-        ss << "darwin";
+        ss << "macos";
     }
     if (kEnterpriseInstall) {
         ss << "_enterprise";
@@ -1541,6 +1521,22 @@ const std::string Context::shortOSName() {
         return "mac";
     }
     return "unknown";
+}
+
+void Context::parseVersion(int result[4], const std::string& input) {
+    std::istringstream parser(input);
+    parser >> result[0];
+    for (auto idx = 1; idx < 4; idx++) {
+        parser.get(); //Skip period
+        parser >> result[idx];
+    }
+}
+
+bool Context::lessThanVersion(const std::string& version1, const std::string& version2) {
+    int parsed1[4] {}, parsed2[4] {};
+    parseVersion(parsed1, version1);
+    parseVersion(parsed2, version2);
+    return std::lexicographical_compare(parsed1, parsed1 + 4, parsed2, parsed2 + 4);
 }
 
 void Context::TimelineUpdateServerSettings() {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1374,7 +1374,7 @@ error Context::downloadUpdate() {
         }
 
         if (HTTPSClient::Config.AppVersion.empty()) {
-            return error("Cannot check for updates without app version");
+            return error("This version cannot check for updates. This has been probably already fixed. Please check https://toggl.com/toggl-desktop/ for a newer version.");
         }
 
         // Ask Toggl server if we have updates

--- a/src/context.h
+++ b/src/context.h
@@ -483,11 +483,13 @@ class Context : public TimelineDatasource {
     void syncerActivity();
 
  private:
-    error updateURL(std::string *result);
-
     static const std::string installerPlatform();
     static const std::string linuxPlatformName();
+    static const std::string windowsPlatformName();
     static const std::string shortOSName();
+
+    static void parseVersion(int result[4], const std::string& input);
+    static bool lessThanVersion(const std::string& version1, const std::string& version2);
 
     Poco::Logger &logger() const;
 

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -79,7 +79,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
             timeline_datasource_->StartAutotrackerEvent(event);
         }
     }
-	idle = idle || getIsLocked() || getIsSleeping();
+    idle = idle || getIsLocked() || getIsSleeping();
     bool idleChanged = hasIdlenessChanged(idle);
 
     if (idleChanged) {

--- a/src/window_change_recorder.h
+++ b/src/window_change_recorder.h
@@ -28,8 +28,8 @@ class WindowChangeRecorder {
     , recording_(this, &WindowChangeRecorder::recordLoop)
     , last_autotracker_title_("")
     , shutdown_(false)
-	, isLocked_(false)
-	, isSleeping_(false)
+    , isLocked_(false)
+    , isSleeping_(false)
     , timeline_errors_() {
         recording_.start();
     }
@@ -38,15 +38,15 @@ class WindowChangeRecorder {
         Shutdown();
     }
 
-	void SetIsLocked(bool isLocked) {
-		Poco::Mutex::ScopedLock lock(isLocked_m_);
-		isLocked_ = isLocked;
+    void SetIsLocked(bool isLocked) {
+        Poco::Mutex::ScopedLock lock(isLocked_m_);
+        isLocked_ = isLocked;
     }
 
-	void SetIsSleeping(bool isSleeping) {
-		Poco::Mutex::ScopedLock lock(isSleeping_m_);
-		isSleeping_ = isSleeping;
-	}
+    void SetIsSleeping(bool isSleeping) {
+        Poco::Mutex::ScopedLock lock(isSleeping_m_);
+        isSleeping_ = isSleeping;
+    }
 
     error Shutdown();
 
@@ -64,15 +64,15 @@ class WindowChangeRecorder {
 
     Poco::Logger &logger();
 
-	bool getIsLocked() {
-		Poco::Mutex::ScopedLock lock(isLocked_m_);
-		return isLocked_;
-	}
+    bool getIsLocked() {
+        Poco::Mutex::ScopedLock lock(isLocked_m_);
+        return isLocked_;
+    }
 
-	bool getIsSleeping() {
-		Poco::Mutex::ScopedLock lock(isSleeping_m_);
-		return isSleeping_;
-	}
+    bool getIsSleeping() {
+        Poco::Mutex::ScopedLock lock(isSleeping_m_);
+        return isSleeping_;
+    }
 
     // Last window focus event data
     std::string last_title_;
@@ -89,11 +89,11 @@ class WindowChangeRecorder {
     Poco::Mutex shutdown_m_;
     bool shutdown_;
 
-	Poco::Mutex isLocked_m_;
-	bool isLocked_;
+    Poco::Mutex isLocked_m_;
+    bool isLocked_;
 
-	Poco::Mutex isSleeping_m_;
-	bool isSleeping_;
+    Poco::Mutex isSleeping_m_;
+    bool isSleeping_;
 
     std::map<const int, int> timeline_errors_;
 };

--- a/third_party/google-astyle/astyle_main.h
+++ b/third_party/google-astyle/astyle_main.h
@@ -69,7 +69,7 @@
 
 // for mingw BOM, UTF-16, and Unicode functions
 #if defined(__MINGW32__)
-#if (__MINGW32_MAJOR_VERSION > 3)  || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 16))
+#if (__MINGW32_MAJOR_VERSION < 3)  || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION < 16))
 #error - Use MinGW compiler version 4 or higher
 #endif
 #endif


### PR DESCRIPTION
### 📒 Description
Rework auto-update system to use github pages instead of v8 API

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- Use updates.json from github pages for auto-update instead of v8 API
- Auto-update from 32-bit versions on 64-bit systems to 64-bit versions on Windows
- Fixed error in `google-astyle` (`make fmt` didn't work on my machine due to this error)

### 👫 Relationships
Closes #3097

### 🔎 Review hints
- The Windows and Linux applications are now using https://toggl.github.io/toggldesktop/assets/releases/updates.json for update checking.
- On a 64-bit Windows users get a 64-bit Toggl Desktop update.
- On a 32-bit Windows users get a 32-bit Toggl Desktop update. 
- The app does not crash when the JSON file does not have the expected format.