### PR TITLE
Keyboard on Calendar Editor

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarCollectionView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarCollectionView.swift
@@ -1,0 +1,57 @@
+//
+//  CalendarCollectionView.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 7/23/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+protocol CalendarCollectionViewDelegate: class {
+
+    func calendarCollectionViewDidClicked(on item: NSCollectionViewItem)
+    func calendarCollectionViewDidPress(_ key: Key)
+}
+
+class CalendarCollectionView: NSCollectionView {
+
+    // MARK: Variables
+
+    weak var calendarDelegate: CalendarCollectionViewDelegate?
+
+    // MARK: Overriden
+
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+
+        if #available(OSX 10.12, *) {
+            handleClickAction(with: event)
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        super.mouseDown(with: event)
+
+        if #available(OSX 10.12, *) {} else {
+            handleClickAction(with: event)
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        super.keyDown(with: event)
+
+        guard let key = Key(rawValue: Int(event.keyCode)) else { return }
+        calendarDelegate?.calendarCollectionViewDidPress(key)
+    }
+
+    // MARK: Private
+
+    private func handleClickAction(with event: NSEvent) {
+        let clickedPoint = convert(event.locationInWindow, from: nil)
+        guard event.clickCount == 1,
+            let indexPath = indexPathForItem(at: clickedPoint),
+            let item = item(at: indexPath) else { return }
+        calendarDelegate?.calendarCollectionViewDidClicked(on: item)
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarCollectionView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarCollectionView.swift
@@ -10,11 +10,11 @@ import Cocoa
 
 protocol CalendarCollectionViewDelegate: class {
 
-    func calendarCollectionViewDidClicked(on item: NSCollectionViewItem)
+    func calendarCollectionViewDidClicked(at indexPath: IndexPath)
     func calendarCollectionViewDidPress(_ key: Key)
 }
 
-class CalendarCollectionView: NSCollectionView {
+final class CalendarCollectionView: NSCollectionView {
 
     // MARK: Variables
 
@@ -50,8 +50,7 @@ class CalendarCollectionView: NSCollectionView {
     private func handleClickAction(with event: NSEvent) {
         let clickedPoint = convert(event.locationInWindow, from: nil)
         guard event.clickCount == 1,
-            let indexPath = indexPathForItem(at: clickedPoint),
-            let item = item(at: indexPath) else { return }
-        calendarDelegate?.calendarCollectionViewDidClicked(on: item)
+            let indexPath = indexPathForItem(at: clickedPoint) else { return }
+        calendarDelegate?.calendarCollectionViewDidClicked(at: indexPath)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarDataSource.swift
@@ -40,16 +40,18 @@ final class CalendarDataSource: NSObject {
     // MARK: Variables
 
     weak var delegate: CalendarDataSourceDelegate?
-    private var selectedData: DateInfo?
+    private var currentDate: DateInfo?
+    private var selectedDate: DateInfo?
     private var calendar: [DateInfo] = []
     private(set) var indexForCurrentDate: Int = 0
 
     // MARK: Init
 
     func render(at date: Date) {
-        selectedData = DateInfo(date: date)
+        currentDate = DateInfo(date: date)
+        selectedDate = currentDate
         calendar = calculateDates(from: date)
-        indexForCurrentDate = calendar.firstIndex(where: { $0.isSameDay(with: selectedData!) }) ?? calendar.count / 2
+        indexForCurrentDate = calendar.firstIndex(where: { $0.isSameDay(with: currentDate!) }) ?? calendar.count / 2
     }
 
     private func calculateDates(from selectedDate: Date) -> [DateInfo] {
@@ -124,8 +126,8 @@ extension CalendarDataSource: NSCollectionViewDelegate, NSCollectionViewDataSour
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
         guard let view = collectionView.makeItem(withIdentifier: Constants.cellID, for: indexPath) as? DateCellViewItem else { return NSCollectionViewItem() }
         let info = calendar[indexPath.item]
-        let isCurrentDate = info.isSameDay(with: selectedData!)
-        let isCurrentMonth = info.month == selectedData!.month
+        let isCurrentDate = info.isSameDay(with: currentDate!)
+        let isCurrentMonth = info.month == currentDate!.month
         view.render(with: info, highlight: isCurrentDate, isCurrentMonth: isCurrentMonth)
         return view
     }
@@ -134,6 +136,7 @@ extension CalendarDataSource: NSCollectionViewDelegate, NSCollectionViewDataSour
         guard let selectedIndex = indexPaths.first,
             let date = calendar[safe: selectedIndex.item]
             else { return }
-        delegate?.calendarDidSelect(buildDate(day: date.day, month: date.month, year: date.year))
+        selectedDate = date
+//        delegate?.calendarDidSelect(buildDate(day: date.day, month: date.month, year: date.year))
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarDataSource.swift
@@ -54,6 +54,17 @@ final class CalendarDataSource: NSObject {
         indexForCurrentDate = calendar.firstIndex(where: { $0.isSameDay(with: currentDate!) }) ?? calendar.count / 2
     }
 
+    func selectDate(at indexPath: IndexPath) {
+        guard let date = calendar[safe: indexPath.item] else { return }
+        selectedDate = date
+        selectSelectedDate()
+    }
+
+    func selectSelectedDate() {
+        guard let selectedDate = selectedDate else { return }
+        delegate?.calendarDidSelect(buildDate(day: selectedDate.day, month: selectedDate.month, year: selectedDate.year))
+    }
+    
     private func calculateDates(from selectedDate: Date) -> [DateInfo] {
         let firstDayOfWeek = selectedDate.firstDayOfWeek() ?? selectedDate
         let from = Calendar.current.date(byAdding: .weekOfYear, value: -Constants.shiftWeek, to: firstDayOfWeek)!
@@ -137,6 +148,5 @@ extension CalendarDataSource: NSCollectionViewDelegate, NSCollectionViewDataSour
             let date = calendar[safe: selectedIndex.item]
             else { return }
         selectedDate = date
-//        delegate?.calendarDidSelect(buildDate(day: date.day, month: date.month, year: date.year))
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
@@ -69,8 +69,17 @@ final class CalendarViewController: NSViewController {
 
         // Scroll to selected date
         DispatchQueue.main.asyncAfter(deadline: .now()) {
-            self.collectionView.scrollToItems(at: Set<IndexPath>(arrayLiteral: IndexPath(item: self.dataSource.indexForCurrentDate, section: 0)),
-                                         scrollPosition: [.centeredVertically])
+            let indexPath = Set<IndexPath>(arrayLiteral: IndexPath(item: self.dataSource.indexForCurrentDate, section: 0))
+            let position = NSCollectionView.ScrollPosition.centeredVertically
+
+            // Scroll to selected position because it's in middle of the list
+            self.collectionView.scrollToItems(at: indexPath,
+                                              scrollPosition: position)
+
+            // Select this row to make this collectionView become firstResponder
+            // Able to navigate by keyboard
+            self.collectionView.selectItems(at: indexPath,
+                                            scrollPosition: position)
         }
 
 

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
@@ -17,7 +17,7 @@ final class CalendarViewController: NSViewController {
 
     // MARK: OUTLET
 
-    @IBOutlet weak var collectionView: NSCollectionView!
+    @IBOutlet weak var collectionView: CalendarCollectionView!
     @IBOutlet weak var popverWidth: NSLayoutConstraint!
     @IBOutlet weak var clipView: NSClipView!
     @IBOutlet weak var stackViewTrailing: NSLayoutConstraint!
@@ -29,6 +29,7 @@ final class CalendarViewController: NSViewController {
     fileprivate lazy var dataSource: CalendarDataSource = CalendarDataSource()
     private var isViewAppearing = false
     private var selectedDate = Date()
+    private var firstLaunch = true
 
     // MARK: View Cycle
 
@@ -78,8 +79,11 @@ final class CalendarViewController: NSViewController {
 
             // Select this row to make this collectionView become firstResponder
             // Able to navigate by keyboard
-            self.collectionView.selectItems(at: indexPath,
-                                            scrollPosition: position)
+            if self.firstLaunch {
+                self.firstLaunch = false
+                self.collectionView.selectItems(at: indexPath,
+                                                scrollPosition: position)
+            }
         }
 
 
@@ -106,6 +110,7 @@ extension CalendarViewController {
     }
 
     fileprivate func initCollectionView() {
+        collectionView.calendarDelegate = self
         collectionView.register(NSNib(nibNamed: CalendarDataSource.Constants.cellNibName, bundle: nil),
                                 forItemWithIdentifier: CalendarDataSource.Constants.cellID)
         collectionView.dataSource = dataSource
@@ -143,5 +148,23 @@ extension CalendarViewController: CalendarDataSourceDelegate {
 
     func calendarDidSelect(_ date: Date) {
         delegate?.calendarViewControllerDidSelect(date: date)
+    }
+}
+
+// MARK: CalendarCollectionViewDelegate
+
+extension CalendarViewController: CalendarCollectionViewDelegate {
+
+    func calendarCollectionViewDidPress(_ key: Key) {
+        switch key {
+        case .enter, .space:
+            dataSource.selectSelectedDate()
+        case .escape:
+            break
+        }
+    }
+
+    func calendarCollectionViewDidClicked(at indexPath: IndexPath) {
+        dataSource.selectDate(at: indexPath)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -66,7 +66,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="240" height="273"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <collectionView selectable="YES" allowsEmptySelection="NO" id="V4G-fh-5PF">
+                                        <collectionView selectable="YES" allowsEmptySelection="NO" id="V4G-fh-5PF" customClass="CalendarCollectionView" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="240" height="273"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                             <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="OPE-W1-KLS">

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
@@ -19,6 +19,7 @@ final class DateCellViewItem: NSCollectionViewItem {
 
     // MARK: Variables
 
+    private var isHightlight = false
     private lazy var titleColor: NSColor = {
         if #available(OSX 10.13, *) {
             return NSColor(named: NSColor.Name("grey-text-color"))!
@@ -26,6 +27,13 @@ final class DateCellViewItem: NSCollectionViewItem {
             return ConvertHexColor.hexCode(toNSColor: "#555555")
         }
     }()
+
+    override var isSelected: Bool {
+        didSet {
+            guard !isHightlight else { return }
+            backgroundBox.isHidden = !isSelected
+        }
+    }
 
     // MARK: Public
 
@@ -41,6 +49,7 @@ final class DateCellViewItem: NSCollectionViewItem {
     }
 
     func render(with info: DateInfo, highlight: Bool, isCurrentMonth: Bool) {
+        isHightlight = highlight
         titleLbl.stringValue = "\(info.day)"
         backgroundBox.isHidden = !highlight
 

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
@@ -31,6 +31,7 @@ final class DateCellViewItem: NSCollectionViewItem {
     override var isSelected: Bool {
         didSet {
             guard !isHightlight else { return }
+            hoverView.isHidden = false
             hoverView.alphaValue = isSelected ? 1.0 : 0.0
         }
     }

--- a/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/Cell/DateCellViewItem.swift
@@ -31,7 +31,7 @@ final class DateCellViewItem: NSCollectionViewItem {
     override var isSelected: Bool {
         didSet {
             guard !isHightlight else { return }
-            backgroundBox.isHidden = !isSelected
+            hoverView.alphaValue = isSelected ? 1.0 : 0.0
         }
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -229,6 +229,8 @@ extension EditorViewController {
                 strongSelf.closeBtnOnTap(strongSelf)
             case .space:
                 strongSelf.dayButtonOnTap(strongSelf)
+            default:
+                break
             }
         }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -222,9 +222,14 @@ extension EditorViewController {
         calendar.timeZone = TimeZone.current
 
         // Date picker
-        datePickerView.escapeKeyOnAction = {[weak self] in
+        datePickerView.keyOnAction = {[weak self] key in
             guard let strongSelf = self else { return }
-            strongSelf.closeBtnOnTap(strongSelf)
+            switch key {
+            case .escape:
+                strongSelf.closeBtnOnTap(strongSelf)
+            case .space:
+                strongSelf.dayButtonOnTap(strongSelf)
+            }
         }
 
         // Tags

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Key.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Key.swift
@@ -1,0 +1,29 @@
+//
+//  Key.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 7/23/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+import Carbon.HIToolbox
+
+enum Key {
+    case escape
+    case space
+    case enter
+
+    init?(rawValue: Int) {
+        switch rawValue {
+        case kVK_Escape:
+            self = .escape
+        case kVK_Space:
+            self = .space
+        case kVK_Return:
+            self = .enter
+        default:
+            return nil
+        }
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/KeyboardDatePicker.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/KeyboardDatePicker.swift
@@ -7,25 +7,8 @@
 //
 
 import Foundation
-import Carbon.HIToolbox
 
 final class KeyboardDatePicker: NSDatePicker {
-
-    enum Key {
-        case escape
-        case space
-
-        init?(rawValue: Int) {
-            switch rawValue {
-            case kVK_Escape:
-                self = .escape
-            case kVK_Space:
-                self = .space
-            default:
-                return nil
-            }
-        }
-    }
 
     // MARK: Variable
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/KeyboardDatePicker.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/KeyboardDatePicker.swift
@@ -11,13 +11,30 @@ import Carbon.HIToolbox
 
 final class KeyboardDatePicker: NSDatePicker {
 
-    var escapeKeyOnAction: (() -> Void)?
+    enum Key {
+        case escape
+        case space
+
+        init?(rawValue: Int) {
+            switch rawValue {
+            case kVK_Escape:
+                self = .escape
+            case kVK_Space:
+                self = .space
+            default:
+                return nil
+            }
+        }
+    }
+
+    // MARK: Variable
+
+    var keyOnAction: ((Key) -> Void)?
 
     override func keyDown(with event: NSEvent) {
         super.keyDown(with: event)
 
-        if event.keyCode == UInt16(kVK_Escape) {
-            escapeKeyOnAction?()
-        }
+        guard let key = Key(rawValue: Int(event.keyCode)) else { return }
+        keyOnAction?(key)
     }
 }

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		BA2E5FB1223787C300EB866E /* EditorPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E5FB0223787C300EB866E /* EditorPopover.swift */; };
 		BA34F10022439C3000C27A15 /* EditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA34F0FE22439C3000C27A15 /* EditorViewController.swift */; };
 		BA34F10122439C3000C27A15 /* EditorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA34F0FF22439C3000C27A15 /* EditorViewController.xib */; };
+		BA35B21F22E6E95200FA560E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA35B21E22E6E95200FA560E /* CalendarCollectionView.swift */; };
+		BA35B22122E6E9E200FA560E /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA35B22022E6E9E200FA560E /* Key.swift */; };
 		BA3E75D422291CEB009AD291 /* SystemMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3E75D322291CEB009AD291 /* SystemMessage.swift */; };
 		BA3E75D62229356D009AD291 /* SystemMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3E75D52229356D009AD291 /* SystemMessageView.swift */; };
 		BA3E75D822293576009AD291 /* SystemMessageView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA3E75D722293576009AD291 /* SystemMessageView.xib */; };
@@ -812,6 +814,8 @@
 		BA2E5FB0223787C300EB866E /* EditorPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorPopover.swift; sourceTree = "<group>"; };
 		BA34F0FE22439C3000C27A15 /* EditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewController.swift; sourceTree = "<group>"; };
 		BA34F0FF22439C3000C27A15 /* EditorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditorViewController.xib; sourceTree = "<group>"; };
+		BA35B21E22E6E95200FA560E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
+		BA35B22022E6E9E200FA560E /* Key.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Key.swift; sourceTree = "<group>"; };
 		BA3E75D322291CEB009AD291 /* SystemMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessage.swift; sourceTree = "<group>"; };
 		BA3E75D52229356D009AD291 /* SystemMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageView.swift; sourceTree = "<group>"; };
 		BA3E75D722293576009AD291 /* SystemMessageView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SystemMessageView.xib; sourceTree = "<group>"; };
@@ -1394,6 +1398,7 @@
 				BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */,
 				BAB0027E22731248005ECC93 /* DayLabel.swift */,
 				BAB0029E2273125C005ECC93 /* DayLabel.xib */,
+				BA35B21E22E6E95200FA560E /* CalendarCollectionView.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -1445,6 +1450,7 @@
 				BA053658225DDDBB00C26E1F /* CustomFocusRingButton.swift */,
 				BAD307D2229C1BD000C727DB /* KeyboardDatePicker.swift */,
 				BAE6379922B225C70024DD08 /* AddTagButton.swift */,
+				BA35B22022E6E9E200FA560E /* Key.swift */,
 			);
 			path = TimeEntryEditor;
 			sourceTree = "<group>";
@@ -2308,6 +2314,7 @@
 				BA7D335722489BD000B953A8 /* AutoCompleteViewDataSource.swift in Sources */,
 				BA01404C22570967000E5B91 /* TagStorage.swift in Sources */,
 				74BAD31E18BD7D83002FD4CF /* ViewItem.m in Sources */,
+				BA35B21F22E6E95200FA560E /* CalendarCollectionView.swift in Sources */,
 				3CD7AD6F19ED579700372797 /* NSResize.m in Sources */,
 				BA08E012222E32C90075F68E /* NSView+LayoutConstraint.swift in Sources */,
 				BA7D335A22489C8000B953A8 /* ProjectDataSource.swift in Sources */,
@@ -2335,6 +2342,7 @@
 				741104BF18C7682700BC7A49 /* NSTextFieldWithBackground.m in Sources */,
 				BA80BEB2221EAE6F00BDFD35 /* Array+ByGroup.swift in Sources */,
 				74F8FBA318313FA6000F09EE /* NSTextFieldClickable.m in Sources */,
+				BA35B22122E6E9E200FA560E /* Key.swift in Sources */,
 				BA7B4BCB21C0EF8800B75B14 /* NSAlert+Utils.m in Sources */,
 				BA403BAE2230CFBC008B202C /* BetterFocusAutoCompleteInput.m in Sources */,
 				BA50ED8522705F9E008323FA /* CalendarFlowLayout.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
Tiny improvement to support keyboard in Calendar Editor.

### 🕶️ Types of changes
**Improvement** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Select the selected date in Calendar in order to make it become first responder. -> Able to navigate around by keyboard.

### 👫 Relationships
Close #2982 

### 🔎 Review hints
- After the Calendar pop-up, we could select dates by keyboard => 💯 

