### PR TITLE
Force focus to the delete button when backtabbing on the description field

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.cpp
@@ -342,6 +342,17 @@ bool TimeEntryEditorWidget::eventFilter(QObject *object, QEvent *event) {
                                                     "");
         }
     }
+    if (event->type() == QEvent::KeyPress) {
+        if (object == ui->description) {
+            ui->deleteButton->setFocusPolicy(Qt::StrongFocus);
+            auto ke = static_cast<QKeyEvent*>(event);
+            if (ke && ke->key() == Qt::Key_Backtab) {
+                // this is an ugly hack for the focus chain - backtabbing selected the date picker for some reason
+                ui->deleteButton->setFocus(Qt::FocusReason::MouseFocusReason);
+                return true;
+            }
+        }
+    }
 
     return false;
 }


### PR DESCRIPTION
### 📒 Description
This PR forces backtabbing to focus the delete button when the user backtabs on the description field.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux: backtabbing works as expected in the time entry editor

### 👫 Relationships
Closes #3105

### 🔎 Review hints
Test if tabbing and backtabbing works as expected in the time entry editor.

