### PR TITLE
Store the project and task names in the timer

### DIFF
--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -18,7 +18,8 @@ TimerWidget::TimerWidget(QWidget *parent) : QFrame(parent),
 ui(new Ui::TimerWidget),
 timer(new QTimer(this)),
 duration(0),
-project(""),
+projectName(""),
+taskName(""),
 tagsHolder(""),
 timeEntryAutocompleteNeedsUpdate(false),
 descriptionModel(new AutocompleteListModel(this)),
@@ -197,6 +198,7 @@ void TimerWidget::displayRunningTimerState(
     if (!te->ProjectLabel.isEmpty()) {
         ui->projectFrame->setVisible(true);
         ui->deleteProject->setVisible(true);
+        projectName = te->ProjectLabel;
         setEllipsisTextToLabel(ui->project, te->ProjectLabel);
     }
     else {
@@ -206,6 +208,7 @@ void TimerWidget::displayRunningTimerState(
     if (!te->TaskLabel.isEmpty()) {
         ui->taskFrame->setVisible(true);
         ui->deleteTask->setVisible(true);
+        taskName = te->TaskLabel;
         setEllipsisTextToLabel(ui->task, te->TaskLabel);
     }
     else {
@@ -360,7 +363,8 @@ void TimerWidget::on_duration_returnPressed() {
 
 void TimerWidget::resizeEvent(QResizeEvent* event)
 {
-    setEllipsisTextToLabel(ui->project, project);
+    setEllipsisTextToLabel(ui->project, projectName);
+    setEllipsisTextToLabel(ui->task, taskName);
     QWidget::resizeEvent(event);
 }
 

--- a/src/ui/linux/TogglDesktop/timerwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timerwidget.cpp
@@ -199,7 +199,9 @@ void TimerWidget::displayRunningTimerState(
         ui->projectFrame->setVisible(true);
         ui->deleteProject->setVisible(true);
         projectName = te->ProjectLabel;
-        setEllipsisTextToLabel(ui->project, te->ProjectLabel);
+        if (!te->ClientLabel.isEmpty())
+            projectName += ". " + te->ClientLabel;
+        setEllipsisTextToLabel(ui->project, projectName);
     }
     else {
         ui->deleteProject->setVisible(true);

--- a/src/ui/linux/TogglDesktop/timerwidget.h
+++ b/src/ui/linux/TogglDesktop/timerwidget.h
@@ -73,7 +73,8 @@ class TimerWidget : public QFrame {
 
     int64_t duration;
 
-    QString project;
+    QString projectName;
+    QString taskName;
     QString descriptionPlaceholder;
     QString tagsHolder;
 


### PR DESCRIPTION
### 📒 Description
This PR makes the timer widget store the current task and project names for when the timer widget needs to be repainted (on window size change, especially)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux - Project and Task information in the Timer no longer disappears on window size change

### 👫 Relationships
Closes #3102
Closes #3103 

### 🔎 Review hints
Check if the project and task names in the running timer widget are displayed as expected, even when you change the size of the window.

