### PR TITLE
Remember which client was created to select it when the update comes

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
+++ b/src/ui/linux/TogglDesktop/timeentryeditorwidget.h
@@ -51,6 +51,7 @@ class TimeEntryEditorWidget : public QWidget {
 
     QVector<GenericView *> clientSelectUpdate;
     bool clientSelectNeedsUpdate;
+    QString recentlyAddedClient;
 
     ColorPicker *colorPicker;
 


### PR DESCRIPTION
### 📒 Description
This PR adds the ability to remember the last created client to the Time Entry Editor (to not get overwritten when a UI update comes)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux - New clients are now properly added to new Projects

### 👫 Relationships
Closes #3104
Closes #3101

### 🔎 Review hints
Check if the right new client is added to a new project. Also check if the client field is not erroneously selected when switching the edited time entries, for example.

