### PR TITLE
Fix font color in idle and feedback dialogs

### DIFF
--- a/src/ui/linux/TogglDesktop/feedbackdialog.ui
+++ b/src/ui/linux/TogglDesktop/feedbackdialog.ui
@@ -14,7 +14,7 @@
    <string>Send Feedback</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">color:rgb(85, 85, 85);font-size:13px;</string>
+   <string notr="true">font-size:13px;</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.ui
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>264</width>
-    <height>254</height>
+    <height>274</height>
    </rect>
   </property>
   <property name="styleSheet">
-   <string notr="true">color:rgb(85, 85, 85);font-size:13px;</string>
+   <string notr="true">font-size:13px;</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
### 📒 Description
We try to avoid using CSS as possible, especially to modify the color of the fonts and widgets (and to rely on the systemwide theme instead). These two pieces of code were a remainder of when we tried to style every single widget inside the app to a certain color.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux - idle and feedback dialog fonts are easier to read

### 👫 Relationships
Closes #3118

### 🔎 Review hints
Check if the text in the whole app is readable.
