### PR TITLE
Save last Editor Window size

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -60,6 +60,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateDescriptionForTimeEntry:(TimeEntryViewItem *)timeEntry
 						 autocomplete:(AutocompleteItem *)autocomplete;
+
+- (void)setEditorWindowSize:(CGSize)size;
+- (CGSize)getEditorWindowSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -190,6 +190,7 @@ void *ctx;
 
 	// Prevent small size
 	const CGSize minimumSize = CGSizeMake(274.0, 381.0);
+
 	width = MAX(minimumSize.width, width);
 	height = MAX(minimumSize.height, height);
 	return CGSizeMake(width, height);

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -177,4 +177,22 @@ void *ctx;
 	return [newValue copy];
 }
 
+- (void)setEditorWindowSize:(CGSize)size
+{
+	toggl_set_window_edit_size_width(ctx, size.width);
+	toggl_set_window_edit_size_height(ctx, size.height);
+}
+
+- (CGSize)getEditorWindowSize
+{
+	NSInteger width = toggl_get_window_edit_size_width(ctx);
+	NSInteger height = toggl_get_window_edit_size_height(ctx);
+
+	// Prevent small size
+	const CGSize minimumSize = CGSizeMake(274.0, 381.0);
+	width = MAX(minimumSize.width, width);
+	height = MAX(minimumSize.height, height);
+	return CGSizeMake(width, height);
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
@@ -27,6 +27,8 @@ final class EditorPopover: NoVibrantPopoverView {
     @objc func prepareViewController() {
         let editor = EditorViewController(nibName: NSNib.Name("EditorViewController"), bundle: nil)
         editor.view.appearance = appearance
+        let size = DesktopLibraryBridge.shared().getEditorWindowSize()
+        editor.view.frame.size = size
         contentViewController = editor
     }
 
@@ -41,5 +43,9 @@ final class EditorPopover: NoVibrantPopoverView {
         if let editor = contentViewController as? EditorViewController {
             editor.timeEntry = timeEntry
         }
+    }
+
+    override func popoverDidResize() {
+        DesktopLibraryBridge.shared().setEditorWindowSize(contentSize)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/ResizablePopover.swift
@@ -163,7 +163,12 @@ class ResizablePopover: NSPopover {
             setCursor()
             setTrackers()
             down = nil
+            popoverDidResize()
         }
+    }
+
+    func popoverDidResize() {
+        // for overriden
     }
 
     // MARK: Private


### PR DESCRIPTION
### 📒 Description
This free feature has been implemented in library. This PR will adopt it in macOS Desktop.

### 🕶️ Types of changes
 **New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Get / Set editor window size. Return default size if the size is lesser than the default size
- [x] Set Editor size after resizing.
- [x] Override the Editor window size

### 👫 Relationships
Close #3047 

### 🔎 Review hints
- Resize the Editor -> Close app -> Open again -> If the Editor window size is remained -> Correct
- Try to set invalid size in database or in code => Editor window falls into default size -> Correct
