### PR TITLE
Project Text is disappear when TE is running

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
@@ -35,9 +35,11 @@ final class ProjectAutoCompleteTextField: AutoCompleteTextField {
     func setTimeEntry(_ timeEntry: TimeEntryViewItem) {
         projectCreationView.selectedTimeEntry = timeEntry
 
-        stringValue = timeEntry.projectLabel
-        layoutProject(with: stringValue)
-        applyColor(with: timeEntry.projectColor)
+        if currentEditor() == nil {
+            stringValue = timeEntry.projectLabel
+            layoutProject(with: stringValue)
+            applyColor(with: timeEntry.projectColor)
+        }
     }
 
     override func didTapOnCreateButton() {

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -80,7 +80,7 @@ NSString *kInactiveTimerColor = @"#999999";
 													 name:kDisplayTimeEntryEditor
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(focusTimer:)
+												 selector:@selector(focusTimer)
 													 name:kFocusTimer
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
@@ -100,7 +100,7 @@ NSString *kInactiveTimerColor = @"#999999";
 													 name:kCommandStop
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(focusTimer:)
+												 selector:@selector(windowDidBecomeKeyNotification:)
 													 name:NSWindowDidBecomeKeyNotification
 												   object:nil];
 
@@ -156,7 +156,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	[self clear];
 }
 
-- (void)focusTimer:(NSNotification *)notification
+- (void)focusTimer
 {
 	if (self.time_entry.duration < 0 || ![self.manualBox isHidden])
 	{
@@ -166,6 +166,17 @@ NSString *kInactiveTimerColor = @"#999999";
 	{
 		[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
 	}
+}
+
+- (void)windowDidBecomeKeyNotification:(NSNotification *)notification
+{
+	// Only focus if the window is main
+	// Otherwise, shouldn't override the firstResponder
+	if (notification.object != self.view.window)
+	{
+		return;
+	}
+	[self focusTimer];
 }
 
 - (void)startDisplayTimerState:(NSNotification *)notification


### PR DESCRIPTION
### 📒 Description
If the TE is running, there is a chance that Project Text Field in 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Ignore the Project Text Field update if the user is editing it
- [x] Ignore focus on Timer if a different Window (AutoComplete) becomes "Key". Otherwise, we can't `Tab` to focus on "Add new project" button
 
### 👫 Relationships
Close #3038 

### 🔎 Review hints
- Start empty TE -> Open the Editor -> Tab to Project TextField and type something quickly -> Observe that if the text in Project TextField doesn't update -> 💯 
- If we're editing the Project TextField -> Press "Tab" -> The "Add new project" button should be focus, not the Timer
