### PR TITLE
Force scrolling to items in the list only when tabbed to

### DIFF
--- a/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
+++ b/src/ui/linux/TogglDesktop/timeentrycellwidget.cpp
@@ -116,7 +116,9 @@ void TimeEntryCellWidget::deleteTimeEntry() {
 
 bool TimeEntryCellWidget::eventFilter(QObject *watched, QEvent *event) {
     if (event->type() == QEvent::FocusIn) {
-        focusInEvent(reinterpret_cast<QFocusEvent*>(event));
+        auto fe = reinterpret_cast<QFocusEvent*>(event);
+        if (fe->reason() == Qt::TabFocusReason || fe->reason() == Qt::BacktabFocusReason)
+            focusInEvent(fe);
     }
     return QWidget::eventFilter(watched, event);
 }


### PR DESCRIPTION
### 📒 Description
This PR makes stops the time entry list from scrolling around when an item is clicked (scrolling is still enabled for tabbing). This also fixes the behavior of the Continue button.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Linux - Clicking the continue button is necessary only once now

### 👫 Relationships
Closes #3120

### 🔎 Review hints
Check if tabbing through the time entry list, clicking the continue button and generally selecting items in the time entry list works consistently as expected.

