### PR TITLE
Linux appstream: add content rating and change metadata license

### DIFF
--- a/src/ui/linux/TogglDesktop/dist/com.toggl.TogglDesktop.appdata.xml.in
+++ b/src/ui/linux/TogglDesktop/dist/com.toggl.TogglDesktop.appdata.xml.in
@@ -2,7 +2,8 @@
 <component type="desktop">
     <id type="desktop">com.toggl.TogglDesktop.desktop</id>
     <project_license>BSD-3-Clause</project_license>
-    <metadata_license>MIT</metadata_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <content_rating>none</content_rating>
     <name>Toggl Desktop</name>
     <summary>Simple and Intuitive Time Tracking Software</summary>
     <description>


### PR DESCRIPTION
### 📒 Description
This changes the appdata license to CC0 from MIT (which doesn't really mean much to us) and also adds content rating because flathub started requiring these.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Check if the flathub build passes (It will, I tried it: https://flathub.org/builds/#/builders/10/builds/689 )

