### PR TITLE
Add text if app is 32bit or 64bit into the about view (win)

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace TogglDesktop
             this.updateText.Text = "";
             this.restartButton.Visibility = Visibility.Collapsed;
 
-            this.versionText.Text = Program.Version();
+            this.versionText.Text = Program.Version() + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)");
 
             var isUpdatCheckDisabled = Toggl.IsUpdateCheckDisabled();
             this.releaseChannelComboBox.ShowOnlyIf(!isUpdatCheckDisabled, true);


### PR DESCRIPTION
### 📒 Description
Adds ` (64-bit)` if the current process is 64-bit, otherwise adds ` (32-bit)`.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3134.

