### PR TITLE
Improve keyboard

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
@@ -423,9 +423,8 @@ extension TimeEntryDatasource {
     func collectionView(_ collectionView: NSCollectionView, pasteboardWriterForItemAt indexPath: IndexPath) -> NSPasteboardWriting? {
         guard let item = object(at: indexPath) else { return nil }
         guard !item.loadMore else { return nil }
-
         // Save indexpath
-        let data = NSKeyedArchiver.archivedData(withRootObject: indexPath)
+        let data = NSKeyedArchiver.archivedData(withRootObject: Array(collectionView.selectionIndexPaths))
         let pbItem = NSPasteboardItem()
         pbItem.setData(data, forType: NSPasteboard.PasteboardType.string)
         return pbItem

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
@@ -98,6 +98,17 @@ class TimeEntryDatasource: NSObject {
     
     // MARK: Public
 
+    func selectFirstItem() {
+        // Check if there is a least 1 item
+        guard sections.first?.entries.first != nil else { return }
+        collectionView.window?.makeFirstResponder(collectionView)
+
+        // Deselect all because TE is multiple-selections
+        collectionView.deselectAll(self)
+        collectionView.selectItems(at: Set<IndexPath>(arrayLiteral: IndexPath(item: 0, section: 0)),
+                                   scrollPosition: .left)
+    }
+
     func process(_ timeEntries: [TimeEntryViewItem], showLoadMore: Bool) {
         isShowLoadMore = showLoadMore
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) NSIndexPath *clickedIndexPath;
 
-- (TimeEntryCell *)getSelectedEntryCell;
+- (NSArray<TimeEntryCell *> *)getSelectedEntryCells;
 
 @end
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -66,13 +66,23 @@ extern void *ctx;
 	NSIndexPath *index = [self indexPathForItemAtPoint:curPoint];
 	NSCollectionViewItem *item = [self itemAtIndexPath:index];
 
-	if ([item isKindOfClass:[TimeEntryCell class]])
+	if (index && [item isKindOfClass:[TimeEntryCell class]])
 	{
 		TimeEntryCell *timeCell = (TimeEntryCell *)item;
 
 		// We have to store the click index
 		// so, the displayTimeEntryEditor can detect which cell should be show popover
 		self.clickedIndexPath = index;
+
+		// If we're pressing SHIFT and click
+		// Don't show Editor, just select
+		NSUInteger flags = [[NSApp currentEvent] modifierFlags];
+		if (flags & NSShiftKeyMask)
+		{
+			[self selectItemsAtIndexPaths:[NSSet setWithObject:index]
+						   scrollPosition:NSCollectionViewScrollPositionLeft];
+			return;
+		}
 
 		// Show popover or open group
 		if (timeCell.cellType == CellTypeGroup)

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -11,6 +11,7 @@
 #import "UIEvents.h"
 #import "TogglDesktop-Swift.h"
 #include <Carbon/Carbon.h>
+#import "Utils.h"
 
 @interface TimeEntryCollectionView ()
 @property (assign, nonatomic) NSIndexPath *latestSelectedIndexPath;
@@ -154,8 +155,8 @@ extern void *ctx;
 		{
 			toggl_continue(ctx, [cell.GUID UTF8String]);
 
-            // Focus on timer
-            [[NSNotificationCenter defaultCenter] postNotificationName:kFocusTimer object:nil];
+			// Focus on timer
+			[[NSNotificationCenter defaultCenter] postNotificationName:kFocusTimer object:nil];
 		}
 	}
 	else if (event.keyCode == kVK_UpArrow)
@@ -253,22 +254,9 @@ extern void *ctx;
 		}
 		return;
 	}
-	NSString *msg = [NSString stringWithFormat:@"Delete time entry \"%@\"?", cell.descriptionTextField.stringValue];
 
-	NSAlert *alert = [[NSAlert alloc] init];
-	[alert addButtonWithTitle:@"OK"];
-	[alert addButtonWithTitle:@"Cancel"];
-	[alert setMessageText:msg];
-	[alert setInformativeText:@"Deleted time entries cannot be restored."];
-	[alert setAlertStyle:NSWarningAlertStyle];
-	if ([alert runModal] != NSAlertFirstButtonReturn)
-	{
-		return;
-	}
-
-	NSLog(@"Deleting time entry %@", cell.GUID);
-
-	if (toggl_delete_time_entry(ctx, [cell.GUID UTF8String]))
+	// Delete and select preview cell
+	if ([Utils deleteTimeEntryWithConfirmationWithGUID:cell.GUID title:cell.descriptionTextField.stringValue])
 	{
 		[self selectPreviousRowFromIndexPath:self.latestSelectedIndexPath];
 	}

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -279,7 +279,14 @@ extern void *ctx;
 	NSIndexPath *previousIndexPath = [datasource previousIndexPathFrom:indexPath];
 	if (previousIndexPath != nil)
 	{
-		[self deselectAll:self];
+        // deselect all previous if we don't hold Shift
+		NSUInteger flags = [[NSApp currentEvent] modifierFlags];
+		if (!(flags & NSShiftKeyMask))
+		{
+			[self deselectAll:self];
+		}
+
+        // Select previous cell
 		[self selectItemsAtIndexPaths:[NSSet setWithCollectionViewIndexPath:previousIndexPath]
 					   scrollPosition:NSCollectionViewScrollPositionNone];
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -122,7 +122,21 @@ extern void *ctx;
 
 	if ((event.keyCode == kVK_Return) || (event.keyCode == kVK_ANSI_KeypadEnter))
 	{
-		[cells.firstObject openEdit];
+		TimeEntryCell *cell = cells.firstObject;
+		if (cell != nil)
+		{
+			if (cell.Group)
+			{
+				if (cell.GroupName.length)
+				{
+					toggl_toggle_entries_group(ctx, [cell.GroupName UTF8String]);
+				}
+			}
+			else
+			{
+				[cell openEdit];
+			}
+		}
 	}
 	else if (event.keyCode == kVK_Escape)
 	{

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -153,6 +153,9 @@ extern void *ctx;
 		if (cell != nil)
 		{
 			toggl_continue(ctx, [cell.GUID UTF8String]);
+
+            // Focus on timer
+            [[NSNotificationCenter defaultCenter] postNotificationName:kFocusTimer object:nil];
 		}
 	}
 	else if (event.keyCode == kVK_UpArrow)

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/TimeEntryCollectionView.m
@@ -188,7 +188,7 @@ extern void *ctx;
 	}
 	else if (event.keyCode == kVK_UpArrow)
 	{
-		NSIndexPath *index = [self.selectionIndexPaths.allObjects firstObject];
+		NSIndexPath *index = [self.selectionIndexPaths.allObjects lastObject];
 		if (index != nil)
 		{
 			[self selectPreviousRowFromIndexPath:index];
@@ -206,7 +206,7 @@ extern void *ctx;
 	{
 		return nil;
 	}
-	self.latestSelectedIndexPath = [[self.selectionIndexPaths allObjects] firstObject];
+	self.latestSelectedIndexPath = [[self.selectionIndexPaths allObjects] lastObject];
 
 	// Get all selected cells
 	NSMutableArray<TimeEntryCell *> *items = [@[] mutableCopy];
@@ -308,7 +308,14 @@ extern void *ctx;
 	{
 		// deselect all previous if we don't hold Shift
 		NSUInteger flags = [[NSApp currentEvent] modifierFlags];
-		if (!(flags & NSShiftKeyMask))
+		if (flags & NSShiftKeyMask)
+		{
+			if ([self.selectionIndexPaths.allObjects containsObject:previousIndexPath])
+			{
+				[self deselectItemsAtIndexPaths:[NSSet setWithCollectionViewIndexPath:indexPath]];
+			}
+		}
+		else
 		{
 			[self deselectAll:self];
 		}
@@ -316,6 +323,7 @@ extern void *ctx;
 		// Select previous cell
 		[self selectItemsAtIndexPaths:[NSSet setWithCollectionViewIndexPath:previousIndexPath]
 					   scrollPosition:NSCollectionViewScrollPositionNone];
+		self.latestSelectedIndexPath = previousIndexPath;
 
 		// Scroll to visible selected row
 		NSCollectionViewLayoutAttributes *attribute = [self layoutAttributesForItemAtIndexPath:previousIndexPath];

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorPopover.swift
@@ -10,10 +10,6 @@ import Cocoa
 
 final class EditorPopover: NoVibrantPopoverView {
 
-    private struct Constants {
-        static let FocusTimerNotification = NSNotification.Name(kFocusTimer)
-    }
-
     override init() {
         let size = CGSize(width: 274, height: 381)
         let maxSize = CGSize(width: size.width * 3, height: size.height)
@@ -30,13 +26,6 @@ final class EditorPopover: NoVibrantPopoverView {
         let size = DesktopLibraryBridge.shared().getEditorWindowSize()
         editor.view.frame.size = size
         contentViewController = editor
-    }
-
-    override func close(focusTimer: Bool) {
-        super.close(focusTimer: focusTimer)
-        if focusTimer {
-            NotificationCenter.default.post(name: Constants.FocusTimerNotification, object: nil)
-        }
     }
 
     @objc func setTimeEntry(_ timeEntry: TimeEntryViewItem) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/NoVibrantPopoverView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/NoVibrantPopoverView.swift
@@ -29,10 +29,4 @@ class NoVibrantPopoverView: ResizablePopover {
     @objc func present(from rect: NSRect, of view: NSView, preferredEdge: NSRectEdge = .maxX) {
         show(relativeTo: rect, of: view, preferredEdge: preferredEdge)
     }
-
-    @objc func close(focusTimer: Bool) {
-
-        // Close and notify delegate if need
-        performClose(self)
-    }
 }

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -270,7 +270,7 @@ extern void *ctx;
 	}
 
 	// Hightlight selected cell
-	[[self.collectionView getSelectedEntryCell] setFocused];
+	[[self.collectionView getSelectedEntryCells].firstObject setFocused];
 }
 
 - (void)resetEditPopover:(NSNotification *)notification
@@ -299,7 +299,7 @@ extern void *ctx;
 		self.runningEdit = (cmd.timeEntry.duration_in_seconds < 0);
 
 		NSView *ofView = self.view;
-		TimeEntryCell *selectedCell = [self.collectionView getSelectedEntryCell];
+		TimeEntryCell *selectedCell = [self.collectionView getSelectedEntryCells].firstObject;
 		CGRect positionRect = [self positionRectForItem:selectedCell];
 
 		if (self.runningEdit)
@@ -365,7 +365,7 @@ extern void *ctx;
 
 - (void)clearLastSelectedEntry
 {
-	[[self.collectionView getSelectedEntryCell] setupGroupMode];
+	[[self.collectionView getSelectedEntryCells].firstObject setupGroupMode];
 }
 
 - (void)resetEditPopoverSize:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -146,6 +146,10 @@ extern void *ctx;
 											 selector:@selector(windowSizeDidChange)
 												 name:NSWindowDidResizeNotification
 											   object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(deselectAllTimeEntryNotification)
+												 name:kDeselectAllTimeEntryList
+											   object:nil];
 }
 
 - (void)initCollectionView
@@ -704,6 +708,11 @@ extern void *ctx;
 - (BOOL)isEditorOpen
 {
 	return self.timeEntrypopover.shown;
+}
+
+- (void)deselectAllTimeEntryNotification
+{
+	[self.collectionView deselectAll:self];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -226,11 +226,6 @@ extern void *ctx;
 			[self.timeEntrypopover performClose:self];
 			[self setDefaultPopupSize];
 		}
-		// when timer not focused
-		if ([self.timerEditViewController.autoCompleteInput currentEditor] == nil)
-		{
-			[self focusListing:nil];
-		}
 	}
 
 	// Adjust the popover position if we change the date

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -485,27 +485,15 @@ extern void *ctx;
 	}
 
 	NSIndexPath *selectedIndexpath = [self.collectionView.selectionIndexPaths.allObjects firstObject];
-	// If list is focused with keyboard shortcut
-	if (notification != nil && !self.timeEntrypopover.shown)
-	{
-		[self clearLastSelectedEntry];
-		selectedIndexpath = [NSIndexPath indexPathForItem:0 inSection:0];
-	}
 
-	if (selectedIndexpath == nil)
+	// Don't select the first item if the TE List is focusing with selected item
+	if (selectedIndexpath != nil && self.collectionView.isFirstResponder)
 	{
 		return;
 	}
 
-	[[self.collectionView window] makeFirstResponder:self.collectionView];
-	[self.collectionView selectItemsAtIndexPaths:[NSSet setWithObject:selectedIndexpath] scrollPosition:NSCollectionViewScrollPositionTop];
-
-	TimeEntryCell *cell = [self getTimeEntryCellAtIndexPath:selectedIndexpath];
-	if (cell != nil)
-	{
-		[self clearLastSelectedEntry];
-		[cell setFocused];
-	}
+	// Select first cell
+	[self.dataSource selectFirstItem];
 }
 
 - (void)escapeListing:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -223,7 +223,7 @@ extern void *ctx;
 	{
 		if (self.timeEntrypopover.shown)
 		{
-			[self.timeEntrypopover closeWithFocusTimer:YES];
+			[self.timeEntrypopover performClose:self];
 			[self setDefaultPopupSize];
 		}
 		// when timer not focused
@@ -472,7 +472,7 @@ extern void *ctx;
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 	if (cmd.open && self.timeEntrypopover.shown)
 	{
-		[self.timeEntrypopover closeWithFocusTimer:YES];
+		[self.timeEntrypopover performClose:self];
 		[self setDefaultPopupSize];
 	}
 }

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,7 +34,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="252" height="174"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView selectable="YES" id="96l-2I-0G5" customClass="TimeEntryCollectionView">
+                            <collectionView selectable="YES" allowsMultipleSelection="YES" id="96l-2I-0G5" customClass="TimeEntryCollectionView">
                                 <rect key="frame" x="0.0" y="0.0" width="252" height="164"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="wqE-DF-86P" customClass="VertificalTimeEntryFlowLayout" customModule="TogglDesktop" customModuleProvider="target">

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -20,6 +20,7 @@
 #import "DisplayCommand.h"
 #import "TogglDesktop-Swift.h"
 #import "ProjectTextField.h"
+#import "Utils.h"
 
 typedef enum : NSUInteger
 {
@@ -172,6 +173,11 @@ NSString *kInactiveTimerColor = @"#999999";
 			if (self.time_entry.isRunning)
 			{
 				[self.view.window makeFirstResponder:self.view];
+
+				// Deselect all selected in TE list
+				// Because we're focusing on the Timer bar since the TE is running
+				[[NSNotificationCenter defaultCenter] postNotificationName:kDeselectAllTimeEntryList
+																	object:nil];
 			}
 			else
 			{
@@ -263,6 +269,8 @@ NSString *kInactiveTimerColor = @"#999999";
 
 		self.durationTextField.toolTip = [NSString stringWithFormat:@"Started: %@", self.time_entry.startTimeString];
 		self.descriptionLabel.editable = NO;
+
+		[self focusTimer];
 	}
 	else
 	{
@@ -717,20 +725,22 @@ NSString *kInactiveTimerColor = @"#999999";
 {
 	[super keyDown:event];
 
-	if (self.time_entry != nil && self.time_entry.isRunning)
+	if (self.time_entry.GUID != nil && self.time_entry.isRunning)
 	{
-        if ((event.keyCode == kVK_Return) || (event.keyCode == kVK_ANSI_KeypadEnter))
-        {
-            // Edit
-        }
-        else if (event.keyCode == kVK_Delete)
-        {
-            // Delete
-        }
-        else if (event.keyCode == kVK_Space)
-        {
-            // Stop
-        }
+		if ((event.keyCode == kVK_Return) || (event.keyCode == kVK_ANSI_KeypadEnter))
+		{
+			toggl_edit(ctx, [self.time_entry.GUID UTF8String], false, "");
+		}
+		else if (event.keyCode == kVK_Delete)
+		{
+			[Utils deleteTimeEntryWithConfirmationWithGUID:self.time_entry.GUID
+													 title:self.descriptionLabel.stringValue];
+		}
+		else if (event.keyCode == kVK_Space)
+		{
+			[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandStop
+																		object:nil];
+		}
 	}
 }
 

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -54,7 +54,7 @@ typedef enum : NSUInteger
 @property (strong, nonatomic) NSTimer *timer;
 @property (assign, nonatomic) BOOL disableChange;
 @property (assign, nonatomic) BOOL focusNotSet;
-@property (assign, nonatomic) BOOL displayMode;
+@property (assign, nonatomic) DisplayMode displayMode;
 
 @end
 
@@ -169,6 +169,9 @@ NSString *kInactiveTimerColor = @"#999999";
 			[self.view.window makeFirstResponder:self.startButton];
 			return;
 
+		case DisplayModeInput :
+			[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
+			break;
 		case DisplayModeTimer :
 			if (self.time_entry.isRunning)
 			{
@@ -178,10 +181,6 @@ NSString *kInactiveTimerColor = @"#999999";
 				// Because we're focusing on the Timer bar since the TE is running
 				[[NSNotificationCenter defaultCenter] postNotificationName:kDeselectAllTimeEntryList
 																	object:nil];
-			}
-			else
-			{
-				[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
 			}
 			break;
 	}
@@ -670,7 +669,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	return retval;
 }
 
-- (void)setDisplayMode:(BOOL)displayMode
+- (void)setDisplayMode:(DisplayMode)displayMode
 {
 	_displayMode = displayMode;
 	switch (displayMode)

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -162,13 +162,22 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)focusTimer
 {
-	if (self.time_entry.duration < 0 || ![self.manualBox isHidden])
+	switch (self.displayMode)
 	{
-		[self.view.window makeFirstResponder:self.startButton];
-	}
-	else
-	{
-		[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
+		case DisplayModeManual :
+			[self.view.window makeFirstResponder:self.startButton];
+			return;
+
+		case DisplayModeTimer :
+			if (self.time_entry.isRunning)
+			{
+				[self.view.window makeFirstResponder:self.view];
+			}
+			else
+			{
+				[self.autoCompleteInput.window makeFirstResponder:self.autoCompleteInput];
+			}
+			break;
 	}
 }
 
@@ -702,6 +711,27 @@ NSString *kInactiveTimerColor = @"#999999";
 - (void)startNewShortcut:(NSNotification *)notification
 {
 	[self startButtonClicked:self];
+}
+
+- (void)keyDown:(NSEvent *)event
+{
+	[super keyDown:event];
+
+	if (self.time_entry != nil && self.time_entry.isRunning)
+	{
+        if ((event.keyCode == kVK_Return) || (event.keyCode == kVK_ANSI_KeypadEnter))
+        {
+            // Edit
+        }
+        else if (event.keyCode == kVK_Delete)
+        {
+            // Delete
+        }
+        else if (event.keyCode == kVK_Space)
+        {
+            // Stop
+        }
+	}
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="101400" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -307,7 +307,7 @@
     </objects>
     <resources>
         <image name="add-icon" width="12" height="12"/>
-        <image name="start-timer-button" width="30" height="30"/>
+        <image name="start-timer-button" width="45" height="45"/>
         <image name="stop-timer-button" width="30" height="30"/>
         <image name="time-entry-billable" width="17" height="17"/>
         <image name="time-entry-dot" width="8" height="8"/>

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -54,6 +54,7 @@ extern NSString *const kToggleGroup;
 extern NSString *const kDisplayCountries;
 extern NSString *const kUpdateIconTooltip;
 extern NSString *const kUserHasBeenSignup;
+extern NSString *const kDeselectAllTimeEntryList;
 
 const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -52,6 +52,8 @@ NSString *const kDisplayCountries = @"kDisplayCountries";
 NSString *const kUpdateIconTooltip = @"kUpdateIconTooltip";
 NSString *const kUserHasBeenSignup = @"kUserHasBeenSignup";
 
+NSString *const kDeselectAllTimeEntryList = @"kDeselectAllTimeEntryList";
+
 const char *kFocusedFieldNameDuration = "duration";
 const char *kFocusedFieldNameDescription = "description";
 const char *kFocusedFieldNameProject = "project";

--- a/src/ui/osx/TogglDesktop/Utils.h
+++ b/src/ui/osx/TogglDesktop/Utils.h
@@ -24,6 +24,7 @@
 + (void)setUpdaterChannel:(NSString *)channel;
 + (ScriptResult *)runScript:(NSString *)script;
 + (void)runClearCommand;
++ (BOOL)deleteTimeEntryWithConfirmationWithGUID:(NSString *)guid title:(NSString *)title;
 @end
 
 BOOL wasLaunchedAsLoginOrResumeItem();

--- a/src/ui/osx/TogglDesktop/Utils.m
+++ b/src/ui/osx/TogglDesktop/Utils.m
@@ -146,6 +146,25 @@ extern void *ctx;
 	return path;
 }
 
++ (BOOL)deleteTimeEntryWithConfirmationWithGUID:(NSString *)guid title:(NSString *)title
+{
+	NSString *msg = [NSString stringWithFormat:@"Delete time entry \"%@\"?", title];
+
+	NSAlert *alert = [[NSAlert alloc] init];
+
+	[alert addButtonWithTitle:@"OK"];
+	[alert addButtonWithTitle:@"Cancel"];
+	[alert setMessageText:msg];
+	[alert setInformativeText:@"Deleted time entries cannot be restored."];
+	[alert setAlertStyle:NSWarningAlertStyle];
+	if ([alert runModal] != NSAlertFirstButtonReturn)
+	{
+		return NO;
+	}
+
+	return toggl_delete_time_entry(ctx, [guid UTF8String]);
+}
+
 /*
  * Returns whether or not an NSString represents a numeric value.
  * For more info see:  http://appliedsoftwaredesign.com/blog/iphone-sdk-nsstring-numeric/


### PR DESCRIPTION
### 📒 Description
This PR introduce some improvement in term of keyboard-based users, which are carefully mentioned in https://github.com/toggl/toggldesktop/issues/2926#issuecomment-511784646

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Support multiple selection on Time Entry list (Shift + Up / Down to select more)
- [x] Bulk action for deleting. If it's multiple selection -> Show warning. If it's single -> Old Logic
- [x] Bulk action for dragging.
- [x] Shift-Down -> Only select first Item if we're focusing on the Timer View. Otherwise, it's just like select next item (Multiple selection behavior)
- [x] If TE is running in Timer Bar and we're selecting any TE in TimeEntryList => Then we hide app -> Open app => The TimerBar will be focus (It's current logic) => Thus, we `de-select` all selection. I intentionally do it, because we can use keyboard to do action on Timer Bar (Edit, delete, stop) => It's make more sense, because we're focuing on the Timer, not TimeEntry List anymore. @IndrekV need your thought here 😄 
- [x] If the TE is running and there is no selection on TE list -> We can use Keyboard on the running TE (Edit, delete, stop)

### 👫 Relationships
Close #2926 

### 🔎 Review hints
- All acceptance criteria should be met https://github.com/toggl/toggldesktop/issues/2926#issuecomment-511784646