### PR TITLE
Description text field disappears when the TE is running

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -46,7 +46,7 @@ final class EditorViewController: NSViewController {
 
     var timeEntry: TimeEntryViewItem! {
         didSet {
-            fillData()
+            fillData(oldValue)
             registerUndoForAllFields()
 
             // Check if the Editor has update with new TimeEntry -> Reset focus to Description TextField
@@ -250,14 +250,19 @@ extension EditorViewController {
         tagDatasource.setup(with: tagTextField)
     }
 
-    fileprivate func fillData() {
+    fileprivate func fillData(_ oldValue: TimeEntryViewItem?) {
         guard let timeEntry = timeEntry else { return }
+
         workspaceLbl.stringValue = timeEntry.workspaceName
-        descriptionTextField.stringValue = timeEntry.descriptionName
         billableCheckBox.state = timeEntry.billable ? .on : .off
         billableCheckBox.isHidden = !timeEntry.canSeeBillable
         projectTextField.setTimeEntry(timeEntry)
         calendarViewControler.prepareLayout(with: timeEntry.started)
+
+        // Update description with condition to prevent lossing text
+        if !(oldValue?.guid == timeEntry.guid && descriptionTextField.currentEditor() != nil) {
+            descriptionTextField.stringValue = timeEntry.descriptionName
+        }
 
         // Disable if it's running entry
         let isRunning = timeEntry.isRunning()


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix when the description text field disappears in Editor View when the TE is running 

### Problems for this issues
The problem is actually how the Library works: Whenever we start a new TE -> The Library keep consistently updating the TE to Editor by notification (I believe that it's our shortcoming) => It results in the update of Editor -> The content, which the user is typing, will disappear ✈️ 

### Solution
- If the GUID of the current TimeEntry in Editor is `==` to the previous TE, and the Description TextField is focusing => Ignore the update
- Otherwise, it should be update as usual

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Update logic to prevent updating description text fields

### 👫 Relationships
Close #3140 

### 🔎 Review hints
- Start Empty TE then quickly opening the Editor and typying something in Description Text Field -> If the content doesn't disappear and it remains => 💯  