### PR TITLE
Windows keyboard UX improvements - Part 1

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace TogglDesktop
 {
@@ -84,6 +86,13 @@ static class UIExtensions
         {
             parentAsDecorator.Child = null;
         }
+    }
+
+    public static void HideWindowOnClosing(this Window window, object sender, CancelEventArgs e)
+    {
+        e.Cancel = true;
+        Action hideAction = window.Hide;
+        window.Dispatcher.BeginInvoke(DispatcherPriority.Background, hideAction);
     }
 
     public static void ClearUndoHistory(this TextBoxBase textBox)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryCell.xaml.cs
@@ -28,7 +28,8 @@ namespace TogglDesktop
 
         private string guid { get; set; }
         private string groupName { get; set; }
-        private Boolean group = false;
+        private bool group = false;
+        private bool groupOpen = false;
 
         public bool Selected
         {
@@ -179,6 +180,22 @@ namespace TogglDesktop
             this.setupGroupedMode(item);
         }
 
+        public bool TryCollapse()
+        {
+            var canCollapse = this.groupOpen;
+            if (!canCollapse) return false;
+            Toggl.ToggleEntriesGroup(groupName);
+            return true;
+        }
+
+        public bool TryExpand()
+        {
+            var canExpand = this.group && !this.groupOpen;
+            if (!canExpand) return false;
+            Toggl.ToggleEntriesGroup(groupName);
+            return true;
+        }
+
         private void setupGroupedMode(Toggl.TogglTimeEntryView item)
         {
             String groupItemsText = "";
@@ -189,6 +206,7 @@ namespace TogglDesktop
             Visibility visibility = Visibility.Collapsed;
             group = item.Group;
             groupName = item.GroupName;
+            groupOpen = item.GroupOpen;
             SubItem = (item.GroupItemCount > 0 && item.GroupOpen && !item.Group);
             // subitem that is open
             if (SubItem)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml
@@ -50,6 +50,7 @@
         <KeyBinding Key="Enter" Command="{StaticResource HighlightEdit}" />
         <KeyBinding Key="Space" Command="{StaticResource HighlightContinue}" />
         <KeyBinding Key="Back" Command="{StaticResource HighlightDelete}" />
+        <KeyBinding Key="Delete" Command="{StaticResource HighlightDelete}" />
         <KeyBinding Key="Escape" Command="{StaticResource FocusTimer}" />
         <KeyBinding Key="Right" Command="{StaticResource ExpandDay}" />
         <KeyBinding Key="Left" Command="{StaticResource CollapseDay}" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml
@@ -24,9 +24,8 @@
         <RoutedUICommand x:Key="HighlightContinue" />
         <RoutedUICommand x:Key="HighlightDelete" />
         <RoutedUICommand x:Key="FocusTimer" />
-
-        <RoutedUICommand x:Key="ExpandDay" />
-        <RoutedUICommand x:Key="CollapseDay" />
+        <RoutedUICommand x:Key="ExpandSelectedItem" />
+        <RoutedUICommand x:Key="CollapseSelectedItem" />
         <RoutedUICommand x:Key="ExpandAllDays" />
         <RoutedUICommand x:Key="CollapseAllDays" />
     </UserControl.Resources>
@@ -38,8 +37,8 @@
         <CommandBinding Command="{StaticResource HighlightContinue}" Executed="onHighlightContinue"/>
         <CommandBinding Command="{StaticResource HighlightDelete}" Executed="onHighlightDelete"/>
         <CommandBinding Command="{StaticResource FocusTimer}" Executed="onFocusTimer"/>
-        <CommandBinding Command="{StaticResource ExpandDay}" Executed="onExpandDay"/>
-        <CommandBinding Command="{StaticResource CollapseDay}" Executed="onCollapseDay"/>
+        <CommandBinding Command="{StaticResource ExpandSelectedItem}" Executed="onExpandSelectedItem"/>
+        <CommandBinding Command="{StaticResource CollapseSelectedItem}" Executed="onCollapseSelectedItem"/>
         <CommandBinding Command="{StaticResource ExpandAllDays}" Executed="onExpandAllDays"/>
         <CommandBinding Command="{StaticResource CollapseAllDays}" Executed="onCollapseAllDays"/>
     </UserControl.CommandBindings>
@@ -52,8 +51,8 @@
         <KeyBinding Key="Back" Command="{StaticResource HighlightDelete}" />
         <KeyBinding Key="Delete" Command="{StaticResource HighlightDelete}" />
         <KeyBinding Key="Escape" Command="{StaticResource FocusTimer}" />
-        <KeyBinding Key="Right" Command="{StaticResource ExpandDay}" />
-        <KeyBinding Key="Left" Command="{StaticResource CollapseDay}" />
+        <KeyBinding Key="Right" Command="{StaticResource ExpandSelectedItem}" />
+        <KeyBinding Key="Left" Command="{StaticResource CollapseSelectedItem}" />
         <KeyBinding Key="Right" Modifiers="Control" Command="{StaticResource ExpandAllDays}" />
         <KeyBinding Key="Left" Modifiers="Control" Command="{StaticResource CollapseAllDays}" />
     </UserControl.InputBindings>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
@@ -210,14 +210,22 @@ namespace TogglDesktop
             Toggl.Edit(this.keyboardHighlightedGUID, false, "");
         }
 
-        private void onExpandDay(object sender, ExecutedRoutedEventArgs e)
+        private void onExpandSelectedItem(object sender, ExecutedRoutedEventArgs e)
         {
-            this.tryExpandSelectedDay();
+            var expandedSelectedGroup = this.tryExpandSelectedGroup();
+            if (!expandedSelectedGroup)
+            {
+                this.tryExpandSelectedDay();
+            }
         }
 
-        private void onCollapseDay(object sender, ExecutedRoutedEventArgs e)
+        private void onCollapseSelectedItem(object sender, ExecutedRoutedEventArgs e)
         {
-            this.tryCollapseCurrentDay();
+            var collapsedSelectedGroup = this.tryCollapseSelectedGroup();
+            if (!collapsedSelectedGroup)
+            {
+                this.tryCollapseCurrentDay();
+            }
         }
 
         private void onExpandAllDays(object sender, ExecutedRoutedEventArgs e)
@@ -282,6 +290,28 @@ namespace TogglDesktop
             this.refreshKeyboardHighlight();
 
             return true;
+        }
+
+        private bool tryCollapseSelectedGroup()
+        {
+            var collapsed = this.hasKeyboardSelection && this.keyboardHighlightedCell.TryCollapse();
+            if (collapsed)
+            {
+                this.refreshKeyboardHighlight();
+            }
+
+            return collapsed;
+        }
+
+        private bool tryExpandSelectedGroup()
+        {
+            var expanded = this.hasKeyboardSelection && this.keyboardHighlightedCell.TryExpand();
+            if (expanded)
+            {
+                this.refreshKeyboardHighlight();
+            }
+
+            return expanded;
         }
 
         private bool tryExpandSelectedDay()

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml
@@ -276,6 +276,7 @@
         <Button Style="{StaticResource EditViewImageButton}"
                 HorizontalAlignment="right" VerticalAlignment="top" Margin="0"
                 Width="32" Height="32"
+                Focusable="False"
                 Content="/TogglDesktop;component/Resources/ic_close_grey600_36dp.png"
                 Click="backButton_OnClick"/>
     </Grid>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace TogglDesktop
         public AboutWindow()
         {
             this.InitializeComponent();
+            this.Closing += this.HideWindowOnClosing;
 
             this.updateText.Text = "";
             this.restartButton.Visibility = Visibility.Collapsed;
@@ -60,11 +61,6 @@ namespace TogglDesktop
                 this.Hide();
                 e.Handled = true;
             }
-        }
-
-        protected override void onCloseButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.Hide();
         }
 
         private void onReleaseChannelSelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/FeedbackWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/FeedbackWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Win32;
 
@@ -11,6 +12,13 @@ namespace TogglDesktop
         public FeedbackWindow()
         {
             this.InitializeComponent();
+            this.Closing += this.HideWindowOnClosing;
+            this.Closing += ResetOnClosing;
+            this.reset();
+        }
+
+        private void ResetOnClosing(object sender, CancelEventArgs e)
+        {
             this.reset();
         }
 
@@ -22,12 +30,6 @@ namespace TogglDesktop
             this.errorText.Visibility = Visibility.Hidden;
             this.topicEmptyText.Visibility = Visibility.Visible;
             this.attachedFileName = null;
-        }
-
-        protected override void onCloseButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.Hide();
-            this.reset();
         }
 
         private void onTopicSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -80,6 +82,5 @@ namespace TogglDesktop
             this.reset();
             this.Hide();
         }
-
     }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/IdleNotificationWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace TogglDesktop
         public IdleNotificationWindow()
         {
             this.InitializeComponent();
-            this.Closing += OnClosing;
+            this.Closing += this.HideWindowOnClosing;
             Toggl.OnIdleNotification += this.onIdleNotification;
             Toggl.OnStoppedTimerState += this.onStoppedTimerState;
         }
@@ -36,13 +36,6 @@ namespace TogglDesktop
             this.Show();
             this.Topmost = true;
             this.Activate();
-        }
-
-        private void OnClosing(object sender, CancelEventArgs e)
-        {
-            e.Cancel = true;
-            Action hideAction = () => this.Hide();
-            Dispatcher.BeginInvoke(DispatcherPriority.Background, hideAction);
         }
 
         protected override void OnDeactivated(EventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml
@@ -25,17 +25,14 @@
         <KeyBinding Key="N" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.New}" />
         <KeyBinding Key="O" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Continue}" />
         <KeyBinding Key="S" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Stop}" />
-        
         <KeyBinding Key="W" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Hide}" />
         <KeyBinding Key="F4" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Hide}" />
         <KeyBinding Key="R" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Sync}" />
-        
         <KeyBinding Key="E" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.EditRunning}" />
-
         <KeyBinding Key="D" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.ToggleManualMode}" />
-
         <KeyBinding Key="V" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.NewFromPaste}" />
-
+        <KeyBinding Key="Q" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Quit}" />
+        <KeyBinding Key="OemComma" Modifiers="Control" Command="{x:Static toggl:KeyboardShortcuts.Preferences}" />
         <KeyBinding Key="Escape" Command="{StaticResource EscapeCommand}" />
     </Window.InputBindings>
     
@@ -89,7 +86,7 @@
                       Command="{x:Static toggl:KeyboardShortcuts.Sync}"/>
             <MenuItem Header="Reports"
                       Command="{x:Static toggl:KeyboardShortcuts.Reports}"/>
-            <MenuItem Header="Preferences"
+            <MenuItem Header="Preferences" InputGestureText="Ctrl+,"
                       Command="{x:Static toggl:KeyboardShortcuts.Preferences}"/>
             <MenuItem Header="Use manual mode" InputGestureText="Ctrl+D"
                       Name="togglManualModeMenuItem" x:FieldModifier="private"
@@ -110,7 +107,7 @@
                       Command="{x:Static toggl:KeyboardShortcuts.About}"/>
             <MenuItem Header="Logout"
                       Command="{x:Static toggl:KeyboardShortcuts.Logout}"/>
-            <MenuItem Header="Quit"
+            <MenuItem Header="Quit" InputGestureText="Ctrl+Q"
                       Command="{x:Static toggl:KeyboardShortcuts.Quit}"/>
         </ContextMenu>
     </Window.ContextMenu>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MiniTimerWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MiniTimerWindow.xaml.cs
@@ -1,6 +1,5 @@
-﻿
-
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -23,11 +22,18 @@ namespace TogglDesktop
         {
             this.contextMenu = mainWindow.ContextMenu;
             this.InitializeComponent();
+            this.Closing += OnClosing;
             this.WindowStyle = WindowStyle.SingleBorderWindow;
 
             this.interopHelper = new WindowInteropHelper(this);
 
             KeyboardShortcuts.RegisterShortcuts(this);
+        }
+
+        static void OnClosing(object sender, CancelEventArgs e)
+        {
+            // disallow closing via Alt+F4
+            e.Cancel = true;
         }
 
         protected override void OnMouseRightButtonDown(MouseButtonEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using Microsoft.Win32;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Implementation;
 using TogglDesktop.Diagnostics;
@@ -29,6 +27,7 @@ namespace TogglDesktop
         public PreferencesWindow()
         {
             this.InitializeComponent();
+            this.Closing += this.HideWindowOnClosing;
 
             Toggl.OnSettings += this.onSettings;
             Toggl.OnLogin += this.onLogin;
@@ -248,11 +247,6 @@ namespace TogglDesktop
         }
 
         private void cancelButtonClicked(object sender, RoutedEventArgs e)
-        {
-            this.Hide();
-        }
-
-        protected override void onCloseButtonClick(object sender, RoutedEventArgs e)
         {
             this.Hide();
         }


### PR DESCRIPTION
### 📒 Description
Relatively easy-to-do improvements to keyboard workflow for Windows app.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Right-Left keys to expand/collapse grouped entries
- [x] Delete key to delete a selected item in the list
- [x] Add Quit shortcut (Ctrl+Q)
- [x] Add Preferences shortcut (Ctrl+Comma - same as Slack, SourceTree)
- [x] Make Close button in Edit view non-focusable (because Esc can be used)

### 👫 Relationships
Closes #3147 