### PR TITLE
Show/hide console menu item in Debug or Prod (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -93,6 +93,7 @@
 
 // System Service
 @property (strong, nonatomic) SystemService *systemService;
+@property (weak) IBOutlet NSMenuItem *consoleMenuItem;
 
 @end
 
@@ -313,6 +314,8 @@ BOOL onTop = NO;
 		[self performSelectorInBackground:@selector(runScript:)
 							   withObject:self.scriptPath];
 	}
+
+	[self hideConsoleMenuIfNeed];
 }
 
 - (void)systemWillPowerOff:(NSNotification *)aNotification
@@ -1838,6 +1841,15 @@ void on_countries(TogglCountryView *first)
 {
 	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kDisplayCountries
 																object:[CountryViewItem loadAll:first]];
+}
+
+- (void)hideConsoleMenuIfNeed
+{
+#if DEBUG
+	[self.consoleMenuItem setHidden:NO];
+#else
+	[self.consoleMenuItem setHidden:YES];
+#endif
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
+++ b/src/ui/osx/TogglDesktop/test2/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -269,7 +269,11 @@
                 </menuItem>
             </items>
         </menu>
-        <customObject id="494" customClass="AppDelegate"/>
+        <customObject id="494" customClass="AppDelegate">
+            <connections>
+                <outlet property="consoleMenuItem" destination="ibF-Ws-y2e" id="6SE-Id-sqd"/>
+            </connections>
+        </customObject>
         <customObject id="420" customClass="NSFontManager"/>
         <segmentedControl verticalHuggingPriority="750" id="1458">
             <rect key="frame" x="0.0" y="0.0" width="164" height="23"/>


### PR DESCRIPTION
### 📒 Description
This PR introduce tiny improvement to show/hide Console Menu Item in Debug or Production Build.

### 🕶️ Types of changes
**Small change** (fix or feature that would cause existing functionality to change)

### 🤯 List of changes
- [x] Check Debug or Prod env in compile time to show/hide Console Menu

### 👫 Relationships
Close #3125 

### 🔎 Review hints
- Run the project in Xcode in Debug mode -> The Console menu is presented -> 💯 
- Archive the project -> Open -> The Console menu is vanished -> 💯 

