### PR TITLE
Fix the Description label doesn't update when selecting from AutoComplete

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -260,7 +260,7 @@ extension EditorViewController {
         calendarViewControler.prepareLayout(with: timeEntry.started)
 
         // Update description with condition to prevent lossing text
-        if !(oldValue?.guid == timeEntry.guid && descriptionTextField.currentEditor() != nil) {
+        if !(oldValue?.guid == timeEntry.guid && descriptionTextField.currentEditor() != nil) || !timeEntry.isRunning() {
             descriptionTextField.stringValue = timeEntry.descriptionName
         }
 
@@ -453,6 +453,7 @@ extension EditorViewController: AutoCompleteViewDataSourceDelegate {
                 DesktopLibraryBridge.shared().updateDescription(forTimeEntry: timeEntry,
                                                                 autocomplete: descriptionTimeEntry.item)
                 descriptionTextField.closeSuggestion()
+                descriptionTextField.stringValue = descriptionTimeEntry.item.descriptionTitle
             }
         }
     }


### PR DESCRIPTION
### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Update description label after selecting from Auto
- [x] Fix condition to determine whereas it should be updated

### 👫 Relationships
Close #3156 

### 🔎 Review hints
- Able to select the AutoComplete => 💯 
- Description label in Editor doesn't update when the TE is running 

