### PR TITLE
Show Load More button if latest entry was more than 10 days ago

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/TimeEntryList.xaml.cs
@@ -61,7 +61,7 @@ namespace TogglDesktop
 
         public void FinishedFillingList()
         {
-            this.emptyListText.ShowOnlyIf(this.panel.Children.Count == 0);
+            this.emptyListText.ShowOnlyIf(this.panel.Children.Count == 0 && !loadMoreButton.IsVisible);
         }
 
         private void onEmptyListTextClick(object sender, RoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/TimerEntryListView.xaml.cs
@@ -49,6 +49,7 @@ namespace TogglDesktop
             if (this.TryBeginInvoke(this.onTimeEntryList, open, list, showLoadMoreButton))
                 return;
 
+            this.Entries.SetLoadMoreButtonVisibility(showLoadMoreButton);
             this.fillTimeEntryList(list);
 
             if (open)
@@ -56,8 +57,6 @@ namespace TogglDesktop
                 this.Entries.Focus(false);
                 this.DisableHighlight();
             }
-
-            this.Entries.SetLoadMoreButtonVisibility(showLoadMoreButton);
         }
 
         private void onTimeEntryEditor(bool open, Toggl.TogglTimeEntryView te, string focusedFieldName)


### PR DESCRIPTION
### 📒 Description
Correctly use library logic, so that when `showLoadMoreButton` is `true`, the Load More button is actually shown.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3035.

### 🔎 Review hints
STR in #3035.
