### PR TITLE
Start new TE depend on Timer or Manual Mode

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -103,6 +103,10 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(windowDidBecomeKeyNotification:)
 													 name:NSWindowDidBecomeKeyNotification
 												   object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(startNewShortcut:)
+													 name:kCommandNewShortcut
+												   object:nil];
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
 
@@ -693,6 +697,11 @@ NSString *kInactiveTimerColor = @"#999999";
 		self.projectTextField.placeholderString = @"+ Add project";
 		self.projectTextFieldLeading.constant = 0;
 	}
+}
+
+- (void)startNewShortcut:(NSNotification *)notification
+{
+	[self startButtonClicked:self];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -178,10 +178,6 @@ BOOL onTop = NO;
 												 name:kCommandNew
 											   object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(startNewShortcut:)
-												 name:kCommandNewShortcut
-											   object:nil];
-	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(startContinueTimeEntry:)
 												 name:kCommandContinue
 											   object:nil];
@@ -486,28 +482,6 @@ BOOL onTop = NO;
 		{
 			toggl_set_time_entry_billable(ctx, guid, new_time_entry.billable);
 		}
-		free(guid);
-	});
-}
-
-- (void)startNewShortcut:(NSNotification *)notification
-{
-	[self newShortcut:notification.object];
-}
-
-- (void)newShortcut:(TimeEntryViewItem *)new_time_entry
-{
-	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
-	NSAssert(new_time_entry != nil, @"new time entry details cannot be nil");
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-		char *guid = toggl_start(ctx,
-								 [new_time_entry.Description UTF8String],
-								 [new_time_entry.duration UTF8String],
-								 new_time_entry.TaskID,
-								 new_time_entry.ProjectID,
-								 0,
-								 0,
-								 false);
 		free(guid);
 	});
 }


### PR DESCRIPTION
### Description 
Cmd+N should start new running Timer in the Timer mode, or create new empty TimeEntry in Manual Mode.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Map Cmd+N to the click action of Start btn.

### 👫 Relationships
Close #3165 
Related to https://github.com/toggl/toggldesktop/pull/3141#issuecomment-516297086

### 🔎 Review hints
- On Timer mode -> Cmd+N -> New running Time Entry should be created -> 💯 
- On Manual Mode -> Cmd+N -> New empty Time Entry should be created -> 💯 
