### PR TITLE
Fix Crash due to window position being saved with Int64.MinValue

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -31,7 +31,8 @@ public static class Utils
         }
 
         long x = 0, y = 0, h = 0, w = 0;
-        if (Toggl.WindowSettings(ref x, ref y, ref h, ref w))
+        if (Toggl.WindowSettings(ref x, ref y, ref h, ref w)
+            && ValidateWindowSettings(x, y, h, w))
         {
             mainWindow.Left = x;
             mainWindow.Top = y;
@@ -64,6 +65,11 @@ public static class Utils
 
             checkMinitimerVisibility(miniTimer);
         }
+    }
+
+    private static bool ValidateWindowSettings(params long[] valuesToValidate)
+    {
+        return valuesToValidate.All(v => v >= int.MinValue && v <= int.MaxValue);
     }
 
     public static void checkMinitimerVisibility(MiniTimerWindow miniTimer) {
@@ -107,7 +113,8 @@ public static class Utils
             h = (long)mainWindow.Height;
         }
 
-        var success = Toggl.SetWindowSettings(x, y, h, w);
+        var success = ValidateWindowSettings(x, y, h, w)
+                      && Toggl.SetWindowSettings(x, y, h, w);
 
         Toggl.Debug(success
                     ? "Saved window location and size ({0}x{1} by {2}x{3})"


### PR DESCRIPTION
### 📒 Description
Adds validation before saving and before restoring the window position.

The range to validate was taken from here https://github.com/dotnet/wpf/blob/master/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs#L5534, the exact place where the application crashed.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3171

### 🔎 Review hints
Unknown steps to reproduce.
Just review the code.