### PR TITLE
Autocomplete should be inside the Screen

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -74,6 +74,7 @@ final class AutoCompleteView: NSView {
 
     private struct Constants {
         static let CreateButtonHeight: CGFloat = 40
+        static let MinimumHeight: CGFloat = 44
     }
 
     // MARK: OUTLET
@@ -113,12 +114,15 @@ final class AutoCompleteView: NSView {
         let screenFrame = self.window!.convertToScreen(frame)
         let topLeftY = screenFrame.origin.y + screenFrame.size.height
         var offset: CGFloat = createNewItemContainerView.isHidden ? 0 : Constants.CreateButtonHeight
-        offset -= 2 // No collision with screen
+        offset += 10 // No collision with edge of the screen
 
         // Reduce the size if the height is greater than screen
         if (height + offset) > topLeftY {
             height = topLeftY - offset
         }
+
+        // Make sure >= minimum size
+        height = CGFloat.maximum(height, Constants.MinimumHeight + offset)
 
         // Overriden
         tableViewHeight.constant = height

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -74,7 +74,6 @@ final class AutoCompleteView: NSView {
 
     private struct Constants {
         static let CreateButtonHeight: CGFloat = 40
-        static let MinimumHeight: CGFloat = 44
     }
 
     // MARK: OUTLET
@@ -121,8 +120,8 @@ final class AutoCompleteView: NSView {
             height = topLeftY - offset
         }
 
-        // Make sure >= minimum size
-        height = CGFloat.maximum(height, Constants.MinimumHeight + offset)
+        // Make sure >= 0
+        height = CGFloat.maximum(height, 0)
 
         // Overriden
         tableViewHeight.constant = height

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -72,6 +72,10 @@ protocol AutoCompleteViewDelegate: class {
 
 final class AutoCompleteView: NSView {
 
+    private struct Constants {
+        static let CreateButtonHeight: CGFloat = 40
+    }
+
     // MARK: OUTLET
 
     @IBOutlet weak var tableView: KeyboardTableView!
@@ -105,6 +109,18 @@ final class AutoCompleteView: NSView {
     }
 
     func update(height: CGFloat) {
+        var height = height
+        let screenFrame = self.window!.convertToScreen(frame)
+        let topLeftY = screenFrame.origin.y + screenFrame.size.height
+        var offset: CGFloat = createNewItemContainerView.isHidden ? 0 : Constants.CreateButtonHeight
+        offset -= 2 // No collision with screen
+
+        // Reduce the size if the height is greater than screen
+        if (height + offset) > topLeftY {
+            height = topLeftY - offset
+        }
+
+        // Overriden
         tableViewHeight.constant = height
     }
 


### PR DESCRIPTION
### 📒 Description
For some situation, the number of items in AutoComplete is huge, then the view is out of screen. This PR will calculate the suitable size and make sure that the content is always visible. Therefore, the Create button is always visible too.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Calculate suitable size for autocomplete

### 👫 Relationships
Close #3176 

### 🔎 Review hints
- Setup long entry in AutoCompleteView -> Select the TE at the end of list (Easy testing) -> Search AutoComplete in Project, Desciption, Tag,  Workspace and Client -> if the list is always inside the Main Screen -> 💯 

![2019-08-02 16 09 20](https://user-images.githubusercontent.com/5878421/62359361-dbb33500-b540-11e9-8917-5df498e1578f.gif)


