### PR TITLE
Fix window showing up outside screen

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -652,7 +652,7 @@ namespace TogglDesktop
             if (visible)
             {
                 // Make sure minitimer is not off screen
-                Utils.checkMinitimerVisibility(this.miniTimer);
+                Utils.CheckMinitimerVisibility(this.miniTimer);
             }
 
             if (!fromApi)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -53,6 +53,11 @@ public static class Utils
             Toggl.Debug("Force moved window to primary screen");
         }
 
+        if (shiftWindowOntoVisibleArea(mainWindow))
+        {
+            Toggl.Debug("Shifted main window onto visible area");
+        }
+
         if (miniTimer != null)
         {
             x = Toggl.GetMiniTimerX();
@@ -80,6 +85,41 @@ public static class Utils
             miniTimer.Top = location.Y;
             Toggl.Debug("Force moved mini timer to primary screen");
         }
+
+        if (shiftWindowOntoVisibleArea(miniTimer))
+        {
+            Toggl.Debug("Shifted mini timer onto visible area");
+        }
+    }
+
+    private static bool shiftWindowOntoVisibleArea(Window window)
+    {
+        var shifted = false;
+        if (window.Top < SystemParameters.VirtualScreenTop)
+        {
+            window.Top = SystemParameters.VirtualScreenTop;
+            shifted = true;
+        }
+
+        if (window.Left < SystemParameters.VirtualScreenLeft)
+        {
+            window.Left = SystemParameters.VirtualScreenLeft;
+            shifted = true;
+        }
+
+        if (window.Left + window.Width > SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth)
+        {
+            window.Left = SystemParameters.VirtualScreenWidth + SystemParameters.VirtualScreenLeft - window.Width;
+            shifted = true;
+        }
+
+        if (window.Top + window.Height > SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight)
+        {
+            window.Top = SystemParameters.VirtualScreenHeight + SystemParameters.VirtualScreenTop - window.Height;
+            shifted = true;
+        }
+
+        return shifted;
     }
 
     private static bool visibleOnAnyScreen(Window f)


### PR DESCRIPTION
### 📒 Description
Fixes the issues when the window was outside the visible screens after its position was restored.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Fixed the `VisibleOnAnyScreen` method to account for the scaling.
- [x] Shift the window into the visible area instead of resetting its position when the saved position is outside the bounding box of the monitor screens (better UX for most use cases when going from multi-monitor to single monitor)

### 👫 Relationships
Closes #2403
Closes #2681 

### 🔎 Review hints
Steps to reproduce that I've found (there might be easier steps than these, e.g. if using 4K monitor)
1. Have 1 connected screen (1920x1080 or 1920x1200) with 100% scaling.
2. Launch Toggl Desktop, move the window to the bottom right of the screen, close the app.
3. Connect a second screen (1920x1080 or 1920x1200) with 200% scaling, make it primary display (the first screen should still have 100% scaling).
4. Launch Toggl Desktop.

On master -> window is not visible.
On this branch -> window is being restored on the top left of the primary screen.
