### PR TITLE
Fix CMake REGEX path variable from PR #3179

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ if ("${TOGGL_VERSION}" STREQUAL "7.0.0")
             RESULT_VARIABLE RESULT_GIT
             OUTPUT_VARIABLE OUTPUT_GIT
             ERROR_VARIABLE ERROR_GIT)
-        string (REGEX REPLACE "^v" "" OUTPUT_GIT ${OUTPUT_GIT})
-        string (REGEX REPLACE "-([0-9]+)-.*" ".\\1" OUTPUT_GIT ${OUTPUT_GIT})
-        string (REGEX REPLACE "\n" ""  TOGGL_VERSION ${OUTPUT_GIT})
+        string (REGEX REPLACE "^v" "" OUTPUT_GIT "${OUTPUT_GIT}")
+        string (REGEX REPLACE "-([0-9]+)-.*" ".\\1" OUTPUT_GIT "${OUTPUT_GIT}")
+        string (REGEX REPLACE "\n" ""  TOGGL_VERSION "${OUTPUT_GIT}")
     else(GIT_FOUND)
         message(WARNING "Version was not set by the user and it could not be retrieved from git - it will default to 7.0.0.")
     endif (GIT_FOUND)


### PR DESCRIPTION
### 📒 Description
<!-- Describe your changes in detail -->
Fix CMake error `Error:string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command` when building. It happens probably at some environments like archlinux AUR makepkg fakeroot. Add quotes to CMakeLists.txt to not lost the path argument.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->
**Bug fix** (non-breaking change which fixes an issue)
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->
`CMakeLists.txt`

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->
PR #3179
<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->

