### PR TITLE
Track Edit size after resizing

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -58,8 +58,21 @@ void Analytics::TrackOSDetails(const std::string client_id) {
 void Analytics::TrackWindowSize(const std::string client_id,
                                 const std::string os,
                                 const toggl::Rectangle rect) {
+    TrackSize(client_id, os, "mainsize", rect);
+}
+
+void Analytics::TrackEditSize(const std::string client_id,
+                              const std::string os,
+                              const toggl::Rectangle rect) {
+    TrackSize(client_id, os, "editsize", rect);
+}
+
+void Analytics::TrackSize(const std::string client_id,
+                          const std::string os,
+                          const std::string name,
+                          const toggl::Rectangle rect) {
     std::stringstream ss;
-    ss << os << "/mainsize-" << rect.str();
+    ss << os << "/" << name << "-" << rect.str();
 
     Track(client_id, "stats", ss.str());
 }

--- a/src/analytics.h
+++ b/src/analytics.h
@@ -57,8 +57,17 @@ class Analytics : public Poco::TaskManager {
                          const std::string os,
                          const toggl::Rectangle rect);
 
+    void TrackEditSize(const std::string client_id,
+                       const std::string os,
+                       const toggl::Rectangle rect);
+
  private:
     Poco::LocalDateTime settings_sync_date;
+
+    void TrackSize(const std::string client_id,
+                   const std::string os,
+                   const std::string name,
+                   const toggl::Rectangle rect);
 };
 
 class GoogleAnalyticsEvent : public Poco::Task {

--- a/src/context.cc
+++ b/src/context.cc
@@ -5603,4 +5603,13 @@ void Context::TrackWindowSize(const Poco::Int64 width,
     }
 }
 
+void Context::TrackEditorSize(const Poco::Int64 width,
+                              const Poco::Int64 height) {
+    if ("production" == environment_) {
+        analytics_.TrackEditSize(db_->AnalyticsClientID(),
+                                 shortOSName(),
+                                 toggl::Rectangle(width, height));
+    }
+}
+
 }  // namespace toggl

--- a/src/context.cc
+++ b/src/context.cc
@@ -5603,8 +5603,8 @@ void Context::TrackWindowSize(const Poco::Int64 width,
     }
 }
 
-void Context::TrackEditorSize(const Poco::Int64 width,
-                              const Poco::Int64 height) {
+void Context::TrackEditSize(const Poco::Int64 width,
+                            const Poco::Int64 height) {
     if ("production" == environment_) {
         analytics_.TrackEditSize(db_->AnalyticsClientID(),
                                  shortOSName(),

--- a/src/context.h
+++ b/src/context.h
@@ -476,8 +476,8 @@ class Context : public TimelineDatasource {
     void TrackWindowSize(const Poco::Int64 width,
                          const Poco::Int64 height);
 
-    void TrackEditorSize(const Poco::Int64 width,
-                         const Poco::Int64 height);
+    void TrackEditSize(const Poco::Int64 width,
+                       const Poco::Int64 height);
 
  protected:
     void uiUpdaterActivity();

--- a/src/context.h
+++ b/src/context.h
@@ -476,6 +476,9 @@ class Context : public TimelineDatasource {
     void TrackWindowSize(const Poco::Int64 width,
                          const Poco::Int64 height);
 
+    void TrackEditorSize(const Poco::Int64 width,
+                         const Poco::Int64 height);
+
  protected:
     void uiUpdaterActivity();
     void checkReminders();

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1399,3 +1399,12 @@ void track_window_size(void *context,
     }
     app(context)->TrackWindowSize(width, height);
 }
+
+void track_edit_size(void *context,
+                     const uint64_t width,
+                     const uint64_t height) {
+    if (!context) {
+        return;
+    }
+    app(context)->TrackEditSize(width, height);
+}

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -1037,6 +1037,10 @@ extern "C" {
         const uint64_t width,
         const uint64_t height);
 
+    TOGGL_EXPORT void track_edit_size(
+        void *context,
+        const uint64_t width,
+        const uint64_t height);
 #undef TOGGL_EXPORT
 
 #ifdef __cplusplus

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -181,6 +181,7 @@ void *ctx;
 {
 	toggl_set_window_edit_size_width(ctx, size.width);
 	toggl_set_window_edit_size_height(ctx, size.height);
+	track_edit_size(ctx, size.width, size.height);
 }
 
 - (CGSize)getEditorWindowSize


### PR DESCRIPTION
### 📒 Description
This PR will track the size of the Editor after resizing by the user.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Bring the tracking size logic to separate method
- [x] Support Track Edit size after resizing.

### 👫 Relationships
Close #2659 

### 🔎 Review hints
1. Override 
```objc
toggl_set_environment(ctx, [@"production" UTF8String]);
```
in line 234, AppDelegate.m 
2. Start the app and resize the Editor
3.  Check the Metabase (https://metabase.toggl.space/question/261) if the data is record (it could take a bit delay)