### PR TITLE
Adapt color for light/dark mode

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/DotImageView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/Views/DotImageView.swift
@@ -17,7 +17,8 @@ final class DotImageView: NSImageView {
     // MARK: Public
 
     @objc func fill(with tintColor: NSColor) {
-        let iconWithColor = icon.image(withTintColor: tintColor)
+        let visibleColor = tintColor.visibleColor()
+        let iconWithColor = icon.image(withTintColor: visibleColor)
         image = iconWithColor
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -109,8 +109,9 @@ final class AutoCompleteView: NSView {
     }
 
     func update(height: CGFloat) {
+        guard let window = self.window else { return }
         var height = height
-        let screenFrame = self.window!.convertToScreen(frame)
+        let screenFrame = window.convertToScreen(frame)
         let topLeftY = screenFrame.origin.y + screenFrame.size.height
         var offset: CGFloat = createNewItemContainerView.isHidden ? 0 : Constants.CreateButtonHeight
         offset += 10 // No collision with edge of the screen

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
@@ -76,12 +76,13 @@ final class ProjectAutoCompleteTextField: AutoCompleteTextField {
 
     private func applyColor(with hex: String) {
         guard let color = ConvertHexColor.hexCode(toNSColor: hex) else { return }
-        dotImageView?.fill(with: color)
+        let visibleColor = color.visibleColor()
+        dotImageView?.fill(with: visibleColor)
         let font = self.font ?? NSFont.systemFont(ofSize: 14.0)
         let parap = NSMutableParagraphStyle()
         parap.lineBreakMode = .byTruncatingTail
         let att: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: font,
-                                                  NSAttributedString.Key.foregroundColor: color,
+                                                  NSAttributedString.Key.foregroundColor: visibleColor,
                                                   NSAttributedString.Key.paragraphStyle: parap]
         attributedStringValue = NSAttributedString(string: stringValue, attributes: att)
     }

--- a/src/ui/osx/TogglDesktop/Swift/Extensions/NSColor+VisibleColor.swift
+++ b/src/ui/osx/TogglDesktop/Swift/Extensions/NSColor+VisibleColor.swift
@@ -13,13 +13,13 @@ import Foundation
     @objc func visibleColor() -> NSColor {
         guard let window = NSApplication.shared.keyWindow else { return self }
         let darkMode = window.isDarkMode
-        let bottomThreshold: CGFloat = 30.0 / 255.0
-        let topThreshold: CGFloat = 225.0 / 255.0
+        let bottomThreshold: CGFloat = 75.0 / 255.0
+        let topThreshold: CGFloat = 180.0 / 255.0
 
         // If darkmode and color is black-based
         // or light mode and color is white-based
-        if (darkMode && redComponent <= bottomThreshold && blueComponent <= bottomThreshold && greenComponent <= bottomThreshold) ||
-            (!darkMode && redComponent >= topThreshold && blueComponent >= topThreshold && greenComponent >= topThreshold) {
+        if (darkMode && (redComponent + blueComponent + greenComponent) <= 3.0 * bottomThreshold) ||
+            (!darkMode && (redComponent + blueComponent + greenComponent) >= 3.0 * topThreshold) {
 
             // Revert color to make it visible
             let red = 1.0 - redComponent

--- a/src/ui/osx/TogglDesktop/Swift/Extensions/NSColor+VisibleColor.swift
+++ b/src/ui/osx/TogglDesktop/Swift/Extensions/NSColor+VisibleColor.swift
@@ -1,0 +1,32 @@
+//
+//  NSColor+VisibleColor.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 8/12/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+
+@objc extension NSColor {
+
+    @objc func visibleColor() -> NSColor {
+        guard let window = NSApplication.shared.keyWindow else { return self }
+        let darkMode = window.isDarkMode
+        let bottomThreshold: CGFloat = 30.0 / 255.0
+        let topThreshold: CGFloat = 225.0 / 255.0
+
+        // If darkmode and color is black-based
+        // or light mode and color is white-based
+        if (darkMode && redComponent <= bottomThreshold && blueComponent <= bottomThreshold && greenComponent <= bottomThreshold) ||
+            (!darkMode && redComponent >= topThreshold && blueComponent >= topThreshold && greenComponent >= topThreshold) {
+
+            // Revert color to make it visible
+            let red = 1.0 - redComponent
+            let green = 1.0 - greenComponent
+            let blue = 1.0 - blueComponent
+            return NSColor(calibratedRed: red, green: green, blue: blue, alpha: 1.0)
+        }
+        return self
+    }
+}

--- a/src/ui/osx/TogglDesktop/Swift/Extensions/NSView+Appearance.swift
+++ b/src/ui/osx/TogglDesktop/Swift/Extensions/NSView+Appearance.swift
@@ -20,30 +20,13 @@ extension NSView {
     }
 }
 
-/// Check or get notified about macOS Dark Mode status
-public final class DarkMode {
-    private static let notificationName = NSNotification.Name("AppleInterfaceThemeChangedNotification")
-
-    static var onChange: ((Bool) -> Void)? {
-        didSet {
-            if onChange == nil {
-                DistributedNotificationCenter.default().removeObserver(self, name: notificationName, object: nil)
-            } else {
-                DistributedNotificationCenter.default().addObserver(self, selector: #selector(selectorHandler), name: notificationName, object: nil)
+extension NSWindow {
+    @objc var isDarkMode: Bool {
+        if #available(OSX 10.14, *) {
+            if effectiveAppearance.name == .darkAqua {
+                return true
             }
         }
-    }
-
-    static var isEnabled: Bool {
-        return UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
-    }
-
-    static var blackColor: NSColor {
-        return isEnabled ? .white : .black
-    }
-
-    @objc
-    private static func selectorHandler() {
-        onChange?(isEnabled)
+        return false
     }
 }

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		BA7DB6E321F9C77A0059239B /* MASShortcut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA7DB6D221F9C7660059239B /* MASShortcut.framework */; };
 		BA7DB6E421F9C77A0059239B /* MASShortcut.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BA7DB6D221F9C7660059239B /* MASShortcut.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BA80BEB2221EAE6F00BDFD35 /* Array+ByGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA80BEB1221EAE6F00BDFD35 /* Array+ByGroup.swift */; };
+		BA81896A23016148000710EA /* NSColor+VisibleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA81896923016148000710EA /* NSColor+VisibleColor.swift */; };
 		BA84363B22533A6600EF5830 /* DesktopLibraryBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = BA84363A22533A6600EF5830 /* DesktopLibraryBridge.m */; };
 		BA89CB392265EA4400D21584 /* String+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA89CB382265EA4400D21584 /* String+Search.swift */; };
 		BA8B4C752251FAD500592BC7 /* WorkspaceCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8B4C742251FAD500592BC7 /* WorkspaceCellView.swift */; };
@@ -743,6 +744,7 @@
 		BA7D335D2248B48000B953A8 /* AutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BA7DB6BB21F9C7660059239B /* MASShortcut.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MASShortcut.xcodeproj; path = ../../../../third_party/MASShortcut/MASShortcut.xcodeproj; sourceTree = "<group>"; };
 		BA80BEB1221EAE6F00BDFD35 /* Array+ByGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ByGroup.swift"; sourceTree = "<group>"; };
+		BA81896923016148000710EA /* NSColor+VisibleColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+VisibleColor.swift"; sourceTree = "<group>"; };
 		BA84363922533A6600EF5830 /* DesktopLibraryBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DesktopLibraryBridge.h; sourceTree = "<group>"; };
 		BA84363A22533A6600EF5830 /* DesktopLibraryBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DesktopLibraryBridge.m; sourceTree = "<group>"; };
 		BA89CB382265EA4400D21584 /* String+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Search.swift"; sourceTree = "<group>"; };
@@ -1225,6 +1227,7 @@
 				BAA260D0222D1DC70094F4E4 /* NSView+Shadow+Border.swift */,
 				BA08E011222E32C90075F68E /* NSView+LayoutConstraint.swift */,
 				BA89CB382265EA4400D21584 /* String+Search.swift */,
+				BA81896923016148000710EA /* NSColor+VisibleColor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1995,6 +1998,7 @@
 				74098C331919899600CBDFB9 /* Utils.m in Sources */,
 				BA0F67B7224A32F700ED0F91 /* CursorButton.swift in Sources */,
 				BA9C2E0C224C8F58002AD2A1 /* KeyboardTableView.swift in Sources */,
+				BA81896A23016148000710EA /* NSColor+VisibleColor.swift in Sources */,
 				69FC180117E6534400B96425 /* main.m in Sources */,
 				74F1070118993FFE00E93BD5 /* FeedbackWindowController.m in Sources */,
 				BAB818E3228D594D008C2367 /* DescriptionTimeEntryStorage.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -10,6 +10,7 @@
 #import "TimeEntryViewItem.h"
 #import "ConvertHexColor.h"
 #import "AutocompleteItem.h"
+#import "TogglDesktop-Swift.h"
 
 @implementation ProjectTextField
 
@@ -121,6 +122,12 @@
 	{
 		return [ConvertHexColor hexCodeToNSColor:@"#555555"];
 	}
+}
+
+- (void)setTextColor:(NSColor *)textColor
+{
+	NSColor *visibleColor = [textColor visibleColor];
+	[super setTextColor:visibleColor];
 }
 
 @end


### PR DESCRIPTION
### 📒 Description
This PR will try to get the visible color from the current Appearance mode of the system and the color.

### How it converts
As we don't want to manipulate the original color of the project, so it;s better to recognize if it's too dark or too light.
For instance,
- If the color is too dark (RGB <= 30) and OS is Dark Mode => Get visible color
- If the color is too light (RGB >= 225) and OS is Light Mode => Get visible color

The Visible color is calculated by reverting the color.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce basic algorithm to get the visible color from given color.
- [x] Set visible color in Project Text Field (Autocomplete, Entry Cell, Editor)
- [x] Remove old code

### 👫 Relationships
Close #3182 

### 🔎 Review hints
### Prepare
- Set Black color for any project before testing and Set Darkmode OS => Make sure that it's difficult to recognize it

#### Test
- Check this PR, and the color is visible in Entry Cell, AutoComplete and Editor 

