### PR TITLE
Actually destroy TogglApi context when quitting the app

### DIFF
--- a/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
+++ b/src/ui/linux/TogglDesktop/mainwindowcontroller.cpp
@@ -457,6 +457,7 @@ void MainWindowController::onActionQuit() {
 
 void MainWindowController::quitApp() {
     TogglApi::instance->shutdown = true;
+    TogglApi::instance->clear();
     qApp->exit(0);
 }
 

--- a/src/ui/linux/TogglDesktop/toggl.cpp
+++ b/src/ui/linux/TogglDesktop/toggl.cpp
@@ -307,9 +307,6 @@ TogglApi::TogglApi(
 }
 
 TogglApi::~TogglApi() {
-    toggl_context_clear(ctx);
-    ctx = nullptr;
-
     instance = nullptr;
 }
 
@@ -326,6 +323,13 @@ bool TogglApi::notifyBugsnag(
 
 bool TogglApi::startEvents() {
     return toggl_ui_start(ctx);
+}
+
+void TogglApi::clear() {
+    toggl_context_clear(ctx);
+    ctx = nullptr;
+
+    instance = nullptr;
 }
 
 void TogglApi::login(const QString email, const QString password) {


### PR DESCRIPTION
### 📒 Description
The `clear` call in the `TogglApi` class was never actually used (or implemented, for that matter). This PR moves the `TogglApi` destructor to where it belongs - the `clear` method. This is necessary because the singleton pointer was never actually destroyed properly.
This call is then used in the Quit action in the menu of the application, fixing the crash.
This crash resulted from how the threads are tangled in the app and some threads (like the websocket client) kept running in the background, even though a sockets were long closed. With this fix, the websocket client is destroyed before all threads are forced to stop by the poco thread pool.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- linux - The app no longer crashes on exit

### 👫 Relationships
Closes #3136

### 🔎 Review hints
Start and quit the app. Observe if you get a SIGABRT or not.

