### PR TITLE
Resolve conflicted TimeEntry in Timeline

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -2994,6 +2994,33 @@ error Context::SetTimeEntryDate(
     return displayError(save(true));
 }
 
+error Context::SetTimeEntryStart(const std::string GUID,
+                                 const Poco::Int64 startAt) {
+    TimeEntry *te = nullptr;
+
+    {
+        Poco::Mutex::ScopedLock lock(user_m_);
+        if (!user_) {
+            logger().warning("Cannot change stop time, user logged out");
+            return noError;
+        }
+        te = user_->related.TimeEntryByGUID(GUID);
+
+        if (!te) {
+            logger().warning("Time entry not found: " + GUID);
+            return noError;
+        }
+
+        if (isTimeEntryLocked(te)) {
+            return logAndDisplayUserTriedEditingLockedEntry();
+        }
+    }
+
+    Poco::LocalDateTime start(Poco::Timestamp::fromEpochTime(startAt));
+    std::string s = Poco::DateTimeFormatter::format(start, Poco::DateTimeFormat::ISO8601_FORMAT);
+    te->SetStartUserInput(s, GetKeepEndTimeFixed());
+    return displayError(save(true));
+}
 
 error Context::SetTimeEntryStart(
     const std::string GUID,
@@ -3051,6 +3078,34 @@ error Context::SetTimeEntryStart(
 
     te->SetStartUserInput(s, GetKeepEndTimeFixed());
 
+    return displayError(save(true));
+}
+
+error Context::SetTimeEntryStop(const std::string GUID,
+                                const Poco::Int64 endAt) {
+    TimeEntry *te = nullptr;
+
+    {
+        Poco::Mutex::ScopedLock lock(user_m_);
+        if (!user_) {
+            logger().warning("Cannot change stop time, user logged out");
+            return noError;
+        }
+        te = user_->related.TimeEntryByGUID(GUID);
+
+        if (!te) {
+            logger().warning("Time entry not found: " + GUID);
+            return noError;
+        }
+
+        if (isTimeEntryLocked(te)) {
+            return logAndDisplayUserTriedEditingLockedEntry();
+        }
+    }
+
+    Poco::LocalDateTime stop(Poco::Timestamp::fromEpochTime(endAt));
+    std::string s = Poco::DateTimeFormatter::format(stop, Poco::DateTimeFormat::ISO8601_FORMAT);
+    te->SetStopUserInput(s);
     return displayError(save(true));
 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -2841,7 +2841,7 @@ error Context::SetTimeEntryDuration(
     const std::string duration) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -2863,7 +2863,7 @@ error Context::SetTimeEntryProject(
     try {
         TimeEntry *te = nullptr;
         error findError = GetTimeEntryFromGUID(GUID, &te);
-        if (findError != noError && !te) {
+        if (findError != noError || !te) {
             return findError;
         }
 
@@ -2941,7 +2941,7 @@ error Context::SetTimeEntryDate(
     const Poco::Int64 unix_timestamp) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -2982,7 +2982,7 @@ error Context::SetTimeEntryStart(const std::string GUID,
                                  const Poco::Int64 startAt) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -2997,7 +2997,7 @@ error Context::SetTimeEntryStart(
     const std::string value) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -3037,7 +3037,7 @@ error Context::SetTimeEntryStop(const std::string GUID,
                                 const Poco::Int64 endAt) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -3052,7 +3052,7 @@ error Context::SetTimeEntryStop(
     const std::string value) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -3097,7 +3097,7 @@ error Context::SetTimeEntryTags(
     const std::string value) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -3116,7 +3116,7 @@ error Context::SetTimeEntryBillable(
     const bool value) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 
@@ -3135,7 +3135,7 @@ error Context::SetTimeEntryDescription(
     const std::string value) {
     TimeEntry *te = nullptr;
     error findError = GetTimeEntryFromGUID(GUID, &te);
-    if (findError != noError && !te) {
+    if (findError != noError || !te) {
         return findError;
     }
 

--- a/src/context.h
+++ b/src/context.h
@@ -353,6 +353,8 @@ class Context : public TimelineDatasource {
         const Poco::UInt64 project_id,
         const std::string project_guid);
 
+    error GetTimeEntryFromGUID(const std::string GUID, TimeEntry** timeEntry);
+
     error SetTimeEntryDate(
         const std::string GUID,
         const Poco::Int64 unix_timestamp);

--- a/src/context.h
+++ b/src/context.h
@@ -353,8 +353,6 @@ class Context : public TimelineDatasource {
         const Poco::UInt64 project_id,
         const std::string project_guid);
 
-    error GetTimeEntryFromGUID(const std::string GUID, TimeEntry** timeEntry);
-
     error SetTimeEntryDate(
         const std::string GUID,
         const Poco::Int64 unix_timestamp);

--- a/src/context.h
+++ b/src/context.h
@@ -361,9 +361,15 @@ class Context : public TimelineDatasource {
         const std::string GUID,
         const std::string value);
 
+    error SetTimeEntryStart(const std::string GUID,
+                            const Poco::Int64 startAt);
+
     error SetTimeEntryStop(
         const std::string GUID,
         const std::string value);
+
+    error SetTimeEntryStop(const std::string GUID,
+                           const Poco::Int64 endAt);
 
     error SetTimeEntryTags(
         const std::string GUID,

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -755,12 +755,28 @@ bool_t toggl_set_time_entry_start(
            SetTimeEntryStart(to_string(guid), to_string(value));
 }
 
+bool_t toggl_set_time_entry_start_timestamp(
+    void *context,
+    const char_t *guid,
+    const int64_t start) {
+    return toggl::noError == app(context)->
+           SetTimeEntryStart(to_string(guid), start);
+}
+
 bool_t toggl_set_time_entry_end(
     void *context,
     const char_t *guid,
     const char_t *value) {
     return toggl::noError == app(context)->
            SetTimeEntryStop(to_string(guid), to_string(value));
+}
+
+bool_t toggl_set_time_entry_end_timestamp(
+    void *context,
+    const char_t *guid,
+    const int64_t end) {
+    return toggl::noError == app(context)->
+           SetTimeEntryStop(to_string(guid), end);
 }
 
 bool_t toggl_set_time_entry_tags(

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -645,10 +645,20 @@ extern "C" {
         const char_t *guid,
         const char_t *value);
 
+    TOGGL_EXPORT bool_t toggl_set_time_entry_start_timestamp(
+        void *context,
+        const char_t *guid,
+        const int64_t start);
+
     TOGGL_EXPORT bool_t toggl_set_time_entry_end(
         void *context,
         const char_t *guid,
         const char_t *value);
+
+    TOGGL_EXPORT bool_t toggl_set_time_entry_end_timestamp(
+        void *context,
+        const char_t *guid,
+        const int64_t end);
 
     // value is '\t' separated tag list
     TOGGL_EXPORT bool_t toggl_set_time_entry_tags(

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -55,8 +55,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateTimeEntryWithStartTime:(NSString *)startTime
 								guid:(NSString *)guid;
 
+- (void)updateTimeEntryWithStartAtTimestamp:(NSTimeInterval)timestamp
+									   guid:(NSString *)guid;
+
 - (void)updateTimeEntryWithEndTime:(NSString *)endTime
 							  guid:(NSString *)guid;
+
+- (void)updateTimeEntryWithEndAtTimestamp:(NSTimeInterval)timestamp
+									 guid:(NSString *)guid;
 
 - (void)deleteTimeEntryImte:(TimeEntryViewItem *)item;
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -125,12 +125,28 @@ void *ctx;
 							   [startTime UTF8String]);
 }
 
+- (void)updateTimeEntryWithStartAtTimestamp:(NSTimeInterval)timestamp
+									   guid:(NSString *)guid
+{
+	toggl_set_time_entry_start_timestamp(ctx,
+										 [guid UTF8String],
+										 timestamp);
+}
+
 - (void)updateTimeEntryWithEndTime:(NSString *)endTime
 							  guid:(NSString *)guid
 {
 	toggl_set_time_entry_end(ctx,
 							 [guid UTF8String],
 							 [endTime UTF8String]);
+}
+
+- (void)updateTimeEntryWithEndAtTimestamp:(NSTimeInterval)timestamp
+									 guid:(NSString *)guid
+{
+	toggl_set_time_entry_end_timestamp(ctx,
+									   [guid UTF8String],
+									   timestamp);
 }
 
 - (void)deleteTimeEntryImte:(TimeEntryViewItem *)item

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -87,6 +87,28 @@ class TimelineData {
             return activities[safe: indexPath.item]?.timechunk()
         }
     }
+
+    func changeFirstEntryStopTime(at entry: TimelineTimeEntry) {
+
+        // Get all conflicted entry in same group
+        let sameGroupEntries = timeEntries
+            .filter { $0 is TimelineTimeEntry && $0.group == entry.group }
+            .sorted { (lhs, rhs) -> Bool in
+                return lhs.col <= rhs.col
+            }
+
+        // If there is only 1 -> Skip
+        guard sameGroupEntries.count > 1,
+            let firstEntry = sameGroupEntries.first as? TimelineTimeEntry,
+            let stopAt = entry.timeEntry.startTimeString else { return }
+
+        DesktopLibraryBridge.shared().updateTimeEntry(withEndTime: stopAt,
+                                                      guid: firstEntry.timeEntry.guid)
+    }
+
+    func changeLastEntryStartTime(at entry: TimelineTimeEntry) {
+        
+    }
 }
 
 // MARK: Private
@@ -108,7 +130,7 @@ extension TimelineData {
 
     fileprivate func calculateColumnsPositionForTimeline() {
         var calculatedEntries: [TimelineBaseTimeEntry] = []
-        var group = 0
+        var group = -1
         for entry in timeEntries {
 
             // Check if this time entry intersect with previous one

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -94,11 +94,11 @@ class TimelineData {
         // If there is only 1 -> Skip
         guard group.count > 1,
             let firstEntry = group.first,
-            let startAt = entry.timeEntry.startTimeString else { return }
+            let started = entry.timeEntry.started else { return }
 
         // Set the end time as a start time of selected entry
-        DesktopLibraryBridge.shared().updateTimeEntry(withEndTime: startAt,
-                                                      guid: firstEntry.timeEntry.guid)
+        DesktopLibraryBridge.shared().updateTimeEntryWithEnd(atTimestamp: started.timeIntervalSince1970 - 1,
+                                                             guid: firstEntry.timeEntry.guid)
     }
 
     func changeLastEntryStartTime(at entry: TimelineTimeEntry) {
@@ -107,11 +107,11 @@ class TimelineData {
         // If there is only 1 -> Skip
         guard group.count > 1,
             let firstEntry = group.first,
-            let endAt = firstEntry.timeEntry.endTimeString else { return }
+            let endAt = firstEntry.timeEntry.ended else { return }
 
         // Set the start time as a stop time of First entry
-        DesktopLibraryBridge.shared().updateTimeEntry(withStartTime: endAt,
-                                                      guid: entry.timeEntry.guid)
+        DesktopLibraryBridge.shared().updateTimeEntryWithStart(atTimestamp: endAt.timeIntervalSince1970 + 1,
+                                                               guid: entry.timeEntry.guid)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -89,20 +89,15 @@ class TimelineData {
     }
 
     func changeFirstEntryStopTime(at entry: TimelineTimeEntry) {
-
-        // Get all conflicted entry in same group
-        let sameGroupEntries = timeEntries
-            .filter { $0 is TimelineTimeEntry && $0.group == entry.group }
-            .sorted { (lhs, rhs) -> Bool in
-                return lhs.col <= rhs.col
-            }
+        let group = getAllConflictedTimeEntries(at: entry)
 
         // If there is only 1 -> Skip
-        guard sameGroupEntries.count > 1,
-            let firstEntry = sameGroupEntries.first as? TimelineTimeEntry,
-            let stopAt = entry.timeEntry.startTimeString else { return }
+        guard group.count > 1,
+            let firstEntry = group.first,
+            let startAt = entry.timeEntry.startTimeString else { return }
 
-        DesktopLibraryBridge.shared().updateTimeEntry(withEndTime: stopAt,
+        // Set the start time as a stop time of First entry
+        DesktopLibraryBridge.shared().updateTimeEntry(withEndTime: startAt,
                                                       guid: firstEntry.timeEntry.guid)
     }
 
@@ -181,5 +176,17 @@ extension TimelineData {
             // Add
             timeEntries.append(contentsOf: emptyTimeEntries)
         }
+    }
+
+    fileprivate func getAllConflictedTimeEntries(at entry: TimelineTimeEntry) -> [TimelineTimeEntry] {
+        // Get all conflicted entry in same group
+        return timeEntries
+            .filter { $0 is TimelineTimeEntry && $0.group == entry.group }
+            .sorted { (lhs, rhs) -> Bool in
+                return lhs.col <= rhs.col
+            }
+            .compactMap { (entry) -> TimelineTimeEntry? in
+                return entry as? TimelineTimeEntry
+            }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineData.swift
@@ -108,6 +108,7 @@ extension TimelineData {
 
     fileprivate func calculateColumnsPositionForTimeline() {
         var calculatedEntries: [TimelineBaseTimeEntry] = []
+        var group = 0
         for entry in timeEntries {
 
             // Check if this time entry intersect with previous one
@@ -130,8 +131,15 @@ extension TimelineData {
                 }
             } while isOverlap
 
+            // Group of entry
+            // All overlap entries are same group
+            if col == 0 {
+                group += 1
+            }
+
             // Exit the loop
-            entry.update(col)
+            entry.col = col
+            entry.group = group
             calculatedEntries.append(entry)
         }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -12,7 +12,7 @@ class TimelineBaseTimeEntry {
 
     let start: TimeInterval
     let end: TimeInterval
-    var group: Int = 0 // Group of overlap entries -> Help to resolve the overlap later
+    var group: Int = -1 // Group of overlap entries -> Help to resolve the overlap later
     var col: Int = 0
     var isOverlap: Bool {
         return col > 0

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineTimeEntry.swift
@@ -12,7 +12,8 @@ class TimelineBaseTimeEntry {
 
     let start: TimeInterval
     let end: TimeInterval
-    private(set) var col: Int = 0
+    var group: Int = 0 // Group of overlap entries -> Help to resolve the overlap later
+    var col: Int = 0
     var isOverlap: Bool {
         return col > 0
     }
@@ -24,10 +25,6 @@ class TimelineBaseTimeEntry {
 
     func timechunk() -> TimeChunk {
         return TimeChunk(start: start, end: end)
-    }
-
-    func update(_ col: Int) {
-        self.col = col
     }
 
     func isIntersected(with entry: TimelineBaseTimeEntry) -> Bool {

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -212,4 +212,12 @@ extension TimelineDatasource: TimelineTimeEntryCellDelegate {
     func timeEntryCellMouseDidExited(_ sender: TimelineTimeEntryCell) {
         delegate?.shouldDismissTimeEntryHover()
     }
+
+    func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
+        timeline?.changeFirstEntryStopTime(at: entry)
+    }
+
+    func timeEntryCellShouldChangeLastEntryStartTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell) {
+        timeline?.changeLastEntryStartTime(at: entry)
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryCell.swift
@@ -12,6 +12,8 @@ protocol TimelineTimeEntryCellDelegate: class {
 
     func timeEntryCellMouseDidEntered(_ sender: TimelineTimeEntryCell)
     func timeEntryCellMouseDidExited(_ sender: TimelineTimeEntryCell)
+    func timeEntryCellShouldChangeFirstEntryStopTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
+    func timeEntryCellShouldChangeLastEntryStartTime(for entry: TimelineTimeEntry, sender: TimelineTimeEntryCell)
 }
 
 final class CursorView: NSView {
@@ -105,9 +107,12 @@ final class TimelineTimeEntryCell: NSCollectionViewItem {
     }
 }
 
+// MARK: Private
+
 extension TimelineTimeEntryCell {
 
     fileprivate func initCommon() {
+        timeEntryMenu.menuDelegate = self
         if let cursorView = view as? CursorView {
             cursorView.cursor = NSCursor.pointingHand
         }
@@ -118,5 +123,20 @@ extension TimelineTimeEntryCell {
         self.trackingArea = tracking
         backgroundView.addTrackingArea(tracking)
         backgroundView.updateTrackingAreas()
+    }
+}
+
+// MARK: TimelineTimeEntryMenuDelegate
+
+extension TimelineTimeEntryCell: TimelineTimeEntryMenuDelegate {
+
+    func shouldChangeFirstEntryStopTime() {
+        guard let timeEntry = timeEntry else { return }
+        delegate?.timeEntryCellShouldChangeFirstEntryStopTime(for: timeEntry, sender: self)
+    }
+
+    func shouldChangeLastEntryStartTime() {
+        guard let timeEntry = timeEntry else { return }
+        delegate?.timeEntryCellShouldChangeLastEntryStartTime(for: timeEntry, sender: self)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -8,7 +8,15 @@
 
 import Cocoa
 
+protocol TimelineTimeEntryMenuDelegate: class {
+
+    func shouldChangeFirstEntryStopTime()
+    func shouldChangeLastEntryStartTime()
+}
+
 final class TimelineTimeEntryMenu: NSMenu {
+
+    weak var menuDelegate: TimelineTimeEntryMenuDelegate?
 
     init() {
         super.init(title: "Menu")
@@ -35,10 +43,10 @@ extension TimelineTimeEntryMenu {
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
-        
+        menuDelegate?.shouldChangeFirstEntryStopTime()
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {
-
+        menuDelegate?.shouldChangeLastEntryStartTime()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineTimeEntryMenu.swift
@@ -35,7 +35,7 @@ extension TimelineTimeEntryMenu {
     }
 
     @objc private func changeFirstEntryStopTimeOnTap() {
-
+        
     }
 
     @objc private func changeLastEntryStartTimeOnTap() {

--- a/src/ui/osx/TogglDesktop/test2/Reachability.m
+++ b/src/ui/osx/TogglDesktop/test2/Reachability.m
@@ -101,7 +101,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 
 @implementation Reachability
 {
-	BOOL _alwaysReturnLocalWiFiStatus;                                                                                                                                                                                                                 // default is NO
+	BOOL _alwaysReturnLocalWiFiStatus;                                                                                                                                                                                                                                     // default is NO
 	SCNetworkReachabilityRef _reachabilityRef;
 }
 

--- a/src/ui/osx/TogglDesktop/test2/Reachability.m
+++ b/src/ui/osx/TogglDesktop/test2/Reachability.m
@@ -101,7 +101,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 
 @implementation Reachability
 {
-	BOOL _alwaysReturnLocalWiFiStatus;                                                                                                                                                                                                     // default is NO
+	BOOL _alwaysReturnLocalWiFiStatus;                                                                                                                                                                                                                 // default is NO
 	SCNetworkReachabilityRef _reachabilityRef;
 }
 


### PR DESCRIPTION
### 📒 Description
This PR will introduce the logic the resolve the conflict of Timeline entry.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce new methods in library to override exact Start/End time (unix timestamp) of given GUID. The `Context::SetTimeEntryStop` and `Context::SetTimeEntryStart` doesn't work well since it only overrides the hour and minute (The second remains) 
- [x] Logic to resolve the conflicts 

### 👫 Relationships
Close #3187 

### 🔎 Review hints
Reproduce from https://github.com/toggl/toggldesktop/issues/3187#issuecomment-519121568

