### PR TITLE
Fix lose focus on Editor when TE is running

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -213,6 +213,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.descriptionLabel.editable = NO;
 	[self clear];
 	[self showDefaultTimer];
+	[self focusTimer];
 }
 
 - (void)displayTimerState:(TimeEntryViewItem *)te
@@ -274,8 +275,6 @@ NSString *kInactiveTimerColor = @"#999999";
 
 		self.durationTextField.toolTip = [NSString stringWithFormat:@"Started: %@", self.time_entry.startTimeString];
 		self.descriptionLabel.editable = NO;
-
-		[self focusTimer];
 	}
 	else
 	{


### PR DESCRIPTION
### 📒 Description
It's really annoying when we couldn't edit the Editor when the TE is running. The focus is alway losing at all. This PR definitely fixes it.

### Problem
It how the Library 📚 works. If the TE is running, this following notification keep pushing from the library, then we handle the timer data. By this time, we accidentally call `focusTimer`, and it results in the lose of focus on the Editor View.

https://github.com/toggl/toggldesktop/blob/4d662731dc10ccb91189e2a71918f141f8ae3009/src/ui/osx/TogglDesktop/TimerEditViewController.m#L76-L79

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Don't focus on Timer when the TE is running 
- [x] When it stops, focus on Timer

### 👫 Relationships
Close #3205 

### 🔎 Review hints
- Start the TE, try to edit the name or project in the Editor -> If there is no jump -> 💯 

### GIF
![2019-08-14 20 56 40](https://user-images.githubusercontent.com/5878421/63027288-de197580-bed6-11e9-8f1c-9f7ec2cc8f91.gif)

