### PR TITLE
Tab to focus on "Add tag"

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
@@ -13,14 +13,33 @@ protocol AddTagButtonDelegate: class {
     func shouldOpenTagAutoComplete(with text: String)
 }
 
-final class AddTagButton: NSButton {
+final class AddTagButton: NSTextField {
 
     // MARK: Variables
 
-    weak var delegate: AddTagButtonDelegate?
+    weak var keyboardDelegate: AddTagButtonDelegate?
     private let ignoreKeys = [kVK_Tab,kVK_Space] // Tab and space
 
+    var cursor: NSCursor? {
+        didSet {
+            resetCursorRects()
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        cursor = .pointingHand
+    }
+
     // MARK: Override
+
+    override func resetCursorRects() {
+        if let cursor = cursor {
+            addCursorRect(bounds, cursor: cursor)
+        } else {
+            super.resetCursorRects()
+        }
+    }
 
     override func keyDown(with event: NSEvent) {
         super.keyDown(with: event)
@@ -32,6 +51,11 @@ final class AddTagButton: NSButton {
         let text = characters == "\r" ? "" : characters
 
         // Notify
-        delegate?.shouldOpenTagAutoComplete(with: text)
+        keyboardDelegate?.shouldOpenTagAutoComplete(with: text)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        super.mouseDown(with: event)
+        keyboardDelegate?.shouldOpenTagAutoComplete(with: "")
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -14,7 +14,6 @@ final class EditorViewController: NSViewController {
     private struct Constans {
 
         static let TokenViewSpacing: CGFloat = 5.0
-        static let MaximumTokenWidth: CGFloat = 260.0
         static let TimerNotification = NSNotification.Name("TimerForRunningTimeEntryOnTicket")
     }
 
@@ -290,6 +289,7 @@ extension EditorViewController {
             tagDatasource.updateSelectedTags(tags)
 
             // Render tag token
+            var visibleTokens: [TagTokenView] = []
             let tokens = tags.map { tag -> TagTokenView in
                 let view = TagTokenView.xibView() as TagTokenView
                 view.delegate = self
@@ -298,16 +298,19 @@ extension EditorViewController {
             }
 
             var width: CGFloat = 0
+            let maximunWidth = view.frame.size.width - 20
             for token in tokens {
                 let size = token.fittingSize
                 width += size.width + Constans.TokenViewSpacing
-                if width <= Constans.MaximumTokenWidth {
+                if width <= maximunWidth {
                     tagStackView.addArrangedSubview(token)
+                    visibleTokens.append(token)
                 } else {
                     let moreToken = TagTokenView.xibView() as TagTokenView
                     moreToken.delegate = self
                     moreToken.render(Tag.moreTag)
                     tagStackView.addArrangedSubview(moreToken)
+                    visibleTokens.append(moreToken)
                     break
                 }
             }
@@ -317,18 +320,18 @@ extension EditorViewController {
             tagInputContainerView.borderColor = .clear
 
             // Tab to move to each Token View
-            projectTextField.nextKeyView = tokens.first?.actionButton
+            projectTextField.nextKeyView = visibleTokens.first?.actionButton
 
             // Connection
-            var currentToken = tokens.first?.actionButton
-            for i in 1..<tokens.count {
-                let token = tokens[i]
+            var currentToken = visibleTokens.first?.actionButton
+            for i in 1..<visibleTokens.count {
+                let token = visibleTokens[i]
                 currentToken?.nextKeyView = token.actionButton
                 currentToken = token.actionButton
             }
 
             // Last to duration
-            tokens.last?.actionButton.nextKeyView = durationTextField
+            visibleTokens.last?.actionButton.nextKeyView = durationTextField
         }
         else {
             tagDatasource.updateSelectedTags([])

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -31,6 +31,7 @@ final class EditorViewController: NSViewController {
     @IBOutlet weak var tagAutoCompleteContainerView: NSBox!
     @IBOutlet weak var tagStackView: NSStackView!
     @IBOutlet weak var tagAddButton: AddTagButton!
+    @IBOutlet weak var tagAddContainerView: NSBox!
     @IBOutlet weak var tagInputContainerView: NSBox!
     @IBOutlet weak var datePickerView: KeyboardDatePicker!
     @IBOutlet weak var dayNameButton: CursorButton!
@@ -109,15 +110,6 @@ final class EditorViewController: NSViewController {
 
     @IBAction func closeBtnOnTap(_ sender: Any) {
         DesktopLibraryBridge.shared().togglEditor()
-    }
-
-    @IBAction func tagAddButtonOnTap(_ sender: Any) {
-
-        // Reset
-        tagTextField.resetText()
-
-        // Expand the view
-        openTagAutoCompleteView()
     }
 
     @IBAction func nextDateBtnOnTap(_ sender: Any) {
@@ -235,7 +227,7 @@ extension EditorViewController {
         }
 
         // Tags
-        tagAddButton.delegate = self
+        tagAddButton.keyboardDelegate = self
     }
 
     fileprivate func initDatasource() {
@@ -287,7 +279,7 @@ extension EditorViewController {
         // Remove all
         tagStackView.subviews.forEach { $0.removeFromSuperview() }
         tagStackView.isHidden = true
-        tagAddButton.isHidden = false
+        tagAddContainerView.isHidden = false
         tagInputContainerView.borderColor = borderColor
 
         // Add tag token if need
@@ -321,7 +313,7 @@ extension EditorViewController {
             }
 
             tagStackView.isHidden = false
-            tagAddButton.isHidden = true
+            tagAddContainerView.isHidden = true
             tagInputContainerView.borderColor = .clear
 
             // Tab to move to each Token View

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +24,8 @@
                 <outlet property="projectDotImageView" destination="gFc-aw-iMX" id="BEl-Tj-c8T"/>
                 <outlet property="projectTextField" destination="Doe-dQ-82A" id="cgo-cM-Mbh"/>
                 <outlet property="startAtTextField" destination="bCC-ON-SgR" id="cIO-X2-PfF"/>
-                <outlet property="tagAddButton" destination="fzH-q2-m3a" id="Z2u-zq-e9e"/>
+                <outlet property="tagAddButton" destination="TEs-AY-h6J" id="1vQ-mB-CXa"/>
+                <outlet property="tagAddContainerView" destination="ybL-Oh-zfH" id="8YX-uR-u51"/>
                 <outlet property="tagAutoCompleteContainerView" destination="mUe-Xn-xvP" id="cvg-Ii-7IT"/>
                 <outlet property="tagInputContainerView" destination="sts-eu-78s" id="Xu1-2S-B1m"/>
                 <outlet property="tagStackView" destination="qgG-HS-MvE" id="aDQ-6D-KtU"/>
@@ -130,61 +131,60 @@
                                 <color key="borderColor" name="upload-border-color"/>
                                 <color key="fillColor" name="editor-background-color"/>
                             </box>
-                            <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="sts-eu-78s">
+                            <box boxType="custom" borderType="none" borderWidth="0.0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="sts-eu-78s">
                                 <rect key="frame" x="10" y="227" width="254" height="30"/>
                                 <view key="contentView" id="GjA-gG-Fhy">
-                                    <rect key="frame" x="1" y="1" width="252" height="28"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="254" height="30"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <stackView hidden="YES" distribution="equalSpacing" orientation="horizontal" alignment="centerY" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qgG-HS-MvE">
-                                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="28"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="30"/>
                                         </stackView>
-                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Scx-li-Ewv">
-                                            <rect key="frame" x="0.0" y="0.0" width="252" height="28"/>
-                                            <subviews>
-                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fzH-q2-m3a" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="252" height="28"/>
-                                                    <buttonCell key="cell" type="bevel" title="Add tags" bezelStyle="rounded" alignment="left" imageScaling="proportionallyDown" inset="2" id="FrN-5J-6rF" customClass="VerticallyCenteredButtonCell" customModule="TogglDesktop" customModuleProvider="target">
-                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="system" size="14"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="number" keyPath="focusRingCornerRadius">
-                                                                <real key="value" value="8"/>
-                                                            </userDefinedRuntimeAttribute>
-                                                            <userDefinedRuntimeAttribute type="number" keyPath="leftPadding">
-                                                                <real key="value" value="10"/>
-                                                            </userDefinedRuntimeAttribute>
-                                                        </userDefinedRuntimeAttributes>
-                                                    </buttonCell>
-                                                    <connections>
-                                                        <action selector="tagAddButtonOnTap:" target="-2" id="Bfd-bb-wxi"/>
-                                                    </connections>
-                                                </button>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="fzH-q2-m3a" firstAttribute="leading" secondItem="Scx-li-Ewv" secondAttribute="leading" id="2Ap-96-clS"/>
-                                                <constraint firstAttribute="bottom" secondItem="fzH-q2-m3a" secondAttribute="bottom" id="7uf-bd-HJg"/>
-                                                <constraint firstItem="fzH-q2-m3a" firstAttribute="top" secondItem="Scx-li-Ewv" secondAttribute="top" id="Z9s-pO-4Gv"/>
-                                                <constraint firstAttribute="trailing" secondItem="fzH-q2-m3a" secondAttribute="trailing" id="vNW-Jk-62b"/>
-                                            </constraints>
-                                        </customView>
+                                        <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="ybL-Oh-zfH">
+                                            <rect key="frame" x="0.0" y="0.0" width="254" height="30"/>
+                                            <view key="contentView" id="MVO-M3-O5k">
+                                                <rect key="frame" x="1" y="1" width="252" height="28"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TEs-AY-h6J" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
+                                                        <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Add tags" usesSingleLineMode="YES" id="yAk-86-67A" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
+                                                            <font key="font" metaFont="system" size="14"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="focusRingCornerRadius">
+                                                                    <real key="value" value="8"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </textFieldCell>
+                                                    </textField>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="TEs-AY-h6J" firstAttribute="top" secondItem="MVO-M3-O5k" secondAttribute="top" id="Jt7-e4-xh1"/>
+                                                    <constraint firstAttribute="bottom" secondItem="TEs-AY-h6J" secondAttribute="bottom" id="KnR-k3-bmx"/>
+                                                    <constraint firstAttribute="trailing" secondItem="TEs-AY-h6J" secondAttribute="trailing" id="Wx5-3Z-uD7"/>
+                                                    <constraint firstItem="TEs-AY-h6J" firstAttribute="leading" secondItem="MVO-M3-O5k" secondAttribute="leading" id="wxw-CB-9h9"/>
+                                                </constraints>
+                                            </view>
+                                            <color key="borderColor" name="upload-border-color"/>
+                                            <color key="fillColor" name="editor-background-color"/>
+                                        </box>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="Scx-li-Ewv" secondAttribute="trailing" id="7uN-c2-g31"/>
+                                        <constraint firstAttribute="bottom" secondItem="ybL-Oh-zfH" secondAttribute="bottom" id="Buq-XW-8VL"/>
                                         <constraint firstAttribute="bottom" secondItem="qgG-HS-MvE" secondAttribute="bottom" id="JCc-fX-syf"/>
+                                        <constraint firstItem="ybL-Oh-zfH" firstAttribute="top" secondItem="GjA-gG-Fhy" secondAttribute="top" id="LsE-we-qs1"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qgG-HS-MvE" secondAttribute="trailing" id="N5a-Q5-H8g"/>
-                                        <constraint firstAttribute="bottom" secondItem="Scx-li-Ewv" secondAttribute="bottom" id="W8T-By-CMT"/>
-                                        <constraint firstItem="Scx-li-Ewv" firstAttribute="top" secondItem="GjA-gG-Fhy" secondAttribute="top" id="d78-9b-S6x"/>
                                         <constraint firstItem="qgG-HS-MvE" firstAttribute="leading" secondItem="GjA-gG-Fhy" secondAttribute="leading" id="f5V-sW-lys"/>
-                                        <constraint firstItem="Scx-li-Ewv" firstAttribute="leading" secondItem="GjA-gG-Fhy" secondAttribute="leading" id="fVD-Dt-0Bg"/>
+                                        <constraint firstItem="ybL-Oh-zfH" firstAttribute="leading" secondItem="GjA-gG-Fhy" secondAttribute="leading" id="gWH-oa-hvY"/>
+                                        <constraint firstAttribute="trailing" secondItem="ybL-Oh-zfH" secondAttribute="trailing" id="oQl-7M-T9h"/>
                                         <constraint firstItem="qgG-HS-MvE" firstAttribute="top" secondItem="GjA-gG-Fhy" secondAttribute="top" id="yEs-m5-WeO"/>
                                     </constraints>
                                 </view>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="AnT-nB-TSC"/>
                                 </constraints>
-                                <color key="borderColor" name="upload-border-color"/>
-                                <color key="fillColor" name="editor-background-color"/>
                             </box>
                             <box boxType="custom" cornerRadius="8" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Qo9-rw-PRz">
                                 <rect key="frame" x="10" y="153" width="80" height="30"/>


### PR DESCRIPTION
### 📒 Description
The current design of "Add tag" looks like the TextField, but we couldn't tab to focus on it by default Keyboard's focus option. (Keyboard Preference -> Shortcut -> Text boxes and List only)

This PR will fix it, by replacing the NSButton by NSTextField, which works by default.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Replace Add tag button with TextField
- [x] Improve to remain the current logic

### 👫 Relationships
Close #3212 
Close #3210 

### 🔎 Review hints
#### Text boxs and List only
1. Select "Text-boxes and List only" in Keyboard Preference 
2. Able to tab to "Add button" and navigate around those text field
3. Old logic remains 

#### All controls
1. Select "All controls" in Keyboard Preference 
2. Able to tab to "Add button" and navigate around those text field
3. Old logic remains 

![2019-08-15 13 51 10](https://user-images.githubusercontent.com/5878421/63078892-2ed8af00-bf67-11e9-9a6e-5a9b371e817a.gif)

### Limitation
If we select "Text-boxes and List only", it's impossible to focus to Tag Token View (which is a NSButton) unless we select "All controls". It's the default behavior of macOS.

I tried to use TextField as a Tag Token View, but it has a problem that we couldn't hide the blind cursor when it's focused (see GIF)
![2019-08-15 14 05 44](https://user-images.githubusercontent.com/5878421/63078811-e7522300-bf66-11e9-8105-a419b42936d6.gif)
