### PR TITLE
Project is clear after creating 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/ProjectAutoCompleteTextField.swift
@@ -94,10 +94,10 @@ extension ProjectAutoCompleteTextField: ProjectCreationViewDelegate {
 
     func projectCreationDidAdd(with name: String, color: String, projectGUID: String) {
         lastProjectGUID = projectGUID
-        closeSuggestion()
         stringValue = name
         layoutProject(with: name)
         applyColor(with: color)
+        closeSuggestion()
     }
 
     func projectCreationDidCancel() {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -544,11 +544,14 @@ extension EditorViewController: AutoCompleteTextFieldDelegate {
             projectTextField.projectItem = nil
             projectTextField.closeSuggestion()
 
-            // Update
-            DesktopLibraryBridge.shared().setProjectForTimeEntryWithGUID(timeEntry.guid,
-                                                                         taskID: 0,
-                                                                         projectID: 0,
-                                                                         projectGUID: "")
+            // Clear project selection if leave the project text field empty
+            if let projectLabel = timeEntry.projectLabel,
+                !projectLabel.isEmpty, projectTextField.stringValue.isEmpty {
+                DesktopLibraryBridge.shared().setProjectForTimeEntryWithGUID(timeEntry.guid,
+                                                                             taskID: 0,
+                                                                             projectID: 0,
+                                                                             projectGUID: "")
+            }
         }
     }
 


### PR DESCRIPTION
### 📒 Description
This PR will fix the bug when the project is cleared after creating from the running TimeEntry

### Problem
Basically, after we press the Create new Project, the Main Window will become key window -> Notify to focus on Timer Bar -> Thus, the Project Text Field is resigned and execute the code the clear the project again (mistake) -> Lead to the empty project

<img width="392" alt="Screen Shot 2019-08-15 at 21 27 11" src="https://user-images.githubusercontent.com/5878421/63102886-2bb0e380-bfa6-11e9-9cce-0607f11dcc0b.png">



### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Fix code when resetting the project label
- [x] Should close the Project Creator View after setting the name

### 👫 Relationships
Close #3180 

### 🔎 Review hints
1. Start new TE
2. Open the Editor, and go straight to Project creation 
3. Create new project
4. If the Project Label fills with new projects without disappearing -> 💯 


![2019-08-15 21 36 21](https://user-images.githubusercontent.com/5878421/63103015-6e72bb80-bfa6-11e9-88ef-05bb1fc2beea.gif)
