### PR TITLE
AutoCompleteView is behind the Dock Bar

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -109,12 +109,15 @@ final class AutoCompleteView: NSView {
     }
 
     func update(height: CGFloat) {
-        guard let window = self.window else { return }
+        guard let window = self.window,
+            let screen = NSScreen.main else { return }
+
         var height = height
         let screenFrame = window.convertToScreen(frame)
         let topLeftY = screenFrame.origin.y + screenFrame.size.height
+        let dockBarHeight = abs(screen.frame.height - screen.visibleFrame.height)
         var offset: CGFloat = createNewItemContainerView.isHidden ? 0 : Constants.CreateButtonHeight
-        offset += 10 // No collision with edge of the screen
+        offset += dockBarHeight // Exclude the bar height
 
         // Reduce the size if the height is greater than screen
         if (height + offset) > topLeftY {


### PR DESCRIPTION
### 📒 Description
Continue on this #3176, we discover that if the Dock Bar is visible, the AutoComplete Menu could be presented underneath.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Use [visibleFrame](https://developer.apple.com/documentation/appkit/nsscreen/1388369-visibleframe?preferredLanguage=occ) to get the suitable size to draw in window

### 👫 Relationships
Close #3176 

### 🔎 Review hints
- Set the Dock bar Visible (System Preference -> Dock)
- Open AutoComplete View, and check whereas or not the "Auto Complete View" is not behind the Dock.
