### PR TITLE
Disable return key in AutoCompleteTextField (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Calendar/CalendarViewController.swift
@@ -159,7 +159,7 @@ extension CalendarViewController: CalendarCollectionViewDelegate {
         switch key {
         case .enter, .space:
             dataSource.selectSelectedDate()
-        case .escape:
+        case .escape, .tab:
             break
         }
     }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/AutoCompleteView.swift
@@ -68,6 +68,7 @@ final class AutoCompleteViewWindow: NSWindow {
 protocol AutoCompleteViewDelegate: class {
 
     func didTapOnCreateButton()
+    func shouldClose()
 }
 
 final class AutoCompleteView: NSView {
@@ -183,6 +184,12 @@ extension AutoCompleteView {
         }
         tableView.clickedOnRow = {[weak self] clickedRow in
             self?.dataSource?.selectRow(at: clickedRow)
+        }
+
+        createNewItemBtn.didPressKey = { key in
+            if key == .tab {
+                self.delegate?.shouldClose()
+            }
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -189,6 +189,10 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         autoCompleteDelegate?.autoCompleteDidTapOnCreateButton(self)
     }
 
+    func shouldClose() {
+        closeSuggestion()
+    }
+
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         // Prevent beep sound
         if currentEditor() != nil {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -188,6 +188,19 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
     func didTapOnCreateButton() {
         autoCompleteDelegate?.autoCompleteDidTapOnCreateButton(self)
     }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Prevent beep sound on return key
+        if let key = Key(rawValue: Int(event.keyCode)) {
+            switch key {
+                case .enter:
+                return true
+            default:
+                break
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -190,13 +190,15 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        // Prevent beep sound on return key
-        if let key = Key(rawValue: Int(event.keyCode)) {
-            switch key {
-                case .enter:
-                return true
-            default:
-                break
+        // Prevent beep sound
+        if currentEditor() != nil {
+            if let key = Key(rawValue: Int(event.keyCode)) {
+                switch key {
+                case .enter, .tab:
+                    return true
+                default:
+                    break
+                }
             }
         }
         return super.performKeyEquivalent(with: event)

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/CursorButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/CursorButton.swift
@@ -11,7 +11,7 @@ import Foundation
 class CursorButton: NSButton {
 
     // MARK: - Variable
-
+    var didPressKey: ((Key) -> Void)?
     var cursor: NSCursor? {
         didSet {
             resetCursorRects()
@@ -23,6 +23,13 @@ class CursorButton: NSButton {
             addCursorRect(bounds, cursor: cursor)
         } else {
             super.resetCursorRects()
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        super.keyDown(with: event)
+        if let key = Key(rawValue: Int(event.keyCode)) {
+            didPressKey?(key)
         }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Key.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Key.swift
@@ -13,6 +13,7 @@ enum Key {
     case escape
     case space
     case enter
+    case tab
 
     init?(rawValue: Int) {
         switch rawValue {
@@ -22,6 +23,8 @@ enum Key {
             self = .space
         case kVK_Return:
             self = .enter
+        case kVK_Tab:
+            self = .tab
         default:
             return nil
         }

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -145,6 +145,10 @@ extern void *ctx;
 											 selector:@selector(deselectAllTimeEntryNotification)
 												 name:kDeselectAllTimeEntryList
 											   object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(windowDidBecomeKeyNotification:)
+												 name:NSWindowDidBecomeKeyNotification
+											   object:nil];
 }
 
 - (void)initCollectionView
@@ -708,6 +712,23 @@ extern void *ctx;
 - (void)deselectAllTimeEntryNotification
 {
 	[self.collectionView deselectAll:self];
+}
+
+- (void)windowDidBecomeKeyNotification:(NSNotification *)notification
+{
+	// Don't focus on Timer Bar if the Editor is presented
+	if (self.timeEntrypopover.isShown)
+	{
+		return;
+	}
+
+	// Only focus if the window is main
+	// Otherwise, shouldn't override the firstResponder
+	if (notification.object != self.view.window)
+	{
+		return;
+	}
+	[self.timerEditViewController focusTimer];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.h
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.h
@@ -18,5 +18,6 @@
 
 - (void)timerFired:(NSTimer *)timer;
 - (void)fillEntryFromAutoComplete:(AutocompleteItem *)item;
+- (void)focusTimer;
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -102,10 +102,6 @@ NSString *kInactiveTimerColor = @"#999999";
 													 name:kCommandStop
 												   object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(windowDidBecomeKeyNotification:)
-													 name:NSWindowDidBecomeKeyNotification
-												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
 												 selector:@selector(startNewShortcut:)
 													 name:kCommandNewShortcut
 												   object:nil];
@@ -190,19 +186,6 @@ NSString *kInactiveTimerColor = @"#999999";
 			}
 			break;
 	}
-}
-
-- (void)windowDidBecomeKeyNotification:(NSNotification *)notification
-{
-	return;
-
-	// Only focus if the window is main
-	// Otherwise, shouldn't override the firstResponder
-	if (notification.object != self.view.window)
-	{
-		return;
-	}
-	[self focusTimer];
 }
 
 - (void)startDisplayTimerState:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -194,6 +194,8 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)windowDidBecomeKeyNotification:(NSNotification *)notification
 {
+	return;
+
 	// Only focus if the window is main
 	// Otherwise, shouldn't override the firstResponder
 	if (notification.object != self.view.window)


### PR DESCRIPTION
### 📒 Description
Disable the beep sound when returning the string in Editor view

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Disable the beep sound of return key

### 👫 Relationships
Close #3222

### 🔎 Review hints
Like #3222

