### PR TITLE
Fix crash when locking or going to sleep while being logged out

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -3777,7 +3777,9 @@ void Context::SetSleep() {
     if (!isHandled) {
         logger().debug("SetSleep");
         idle_.SetSleep();
-        window_change_recorder_->SetIsSleeping(true);
+        if (window_change_recorder_) {
+            window_change_recorder_->SetIsSleeping(true);
+        }
     }
 }
 
@@ -3984,7 +3986,9 @@ void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
         }
 
         idle_.SetWake(user_);
-        window_change_recorder_->SetIsSleeping(false);
+        if (window_change_recorder_) {
+            window_change_recorder_->SetIsSleeping(false);
+        }
 
         Sync();
     }
@@ -4001,12 +4005,16 @@ void Context::onWake(Poco::Util::TimerTask&) {  // NOLINT
 
 void Context::SetLocked() {
     logger().debug("SetLocked");
-    window_change_recorder_->SetIsLocked(true);
+    if (window_change_recorder_) {
+        window_change_recorder_->SetIsLocked(true);
+    }
 }
 
 void Context::SetUnlocked() {
     logger().debug("SetUnlocked");
-    window_change_recorder_->SetIsLocked(false);
+    if (window_change_recorder_) {
+        window_change_recorder_->SetIsLocked(false);
+    }
 }
 
 void Context::SetOnline() {


### PR DESCRIPTION
### 📒 Description
Check window_change_recorder_ for nullptr before accessing it (lib).
Fixes crash when locking or going to sleep while being logged out.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3221.

### 🔎 Review hints
See #3221.
