### PR TITLE
Fix decimal durations not displaying correctly (lib)

### DIFF
--- a/src/formatter.cc
+++ b/src/formatter.cc
@@ -313,8 +313,8 @@ int Formatter::parseDurationStringHoursMinutesSeconds(
     take("sec", &seconds, whatsleft);
     take("s", &seconds, whatsleft);
 
-    long period = static_cast<long>(hours) * 3600 +
-                  static_cast<long>(minutes) * 60 +
+    long period = static_cast<long>(hours * 3600.0) +
+                  static_cast<long>(minutes * 60.0) +
                   static_cast<long>(seconds);
     return Poco::Timespan(period, 0).totalSeconds();
 }
@@ -438,7 +438,7 @@ std::string Formatter::FormatDuration(
         // Following rounding up is needed
         // to be compatible with Toggl web site.
         double a = hours * 100.0;
-        int b = static_cast<int>(hours) * 100;
+        int b = static_cast<int>(a);
         double d = a - std::floor(a);
         if (d > 0.5) {
             b++;


### PR DESCRIPTION
### 📒 Description
Fixes decimal durations not displaying correctly.
Fixes decimal duration parsing.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3225 

### 🔎 Review hints
See #3225.
Reproducible on all platforms.