### PR TITLE
Graceful error handling during auto-update

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -80,7 +80,8 @@ static class Program
                 report.Event.User = new Bugsnag.Payload.User { Id = uid.ToString() };
                 report.Event.Metadata.Add("Details", new Dictionary<string, string>
                 {
-                    { "Channel", Toggl.UpdateChannel() }
+                    { "Channel", Toggl.UpdateChannel() },
+                    { "Bitness", Utils.Bitness() }
                 });
             });
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -97,7 +97,7 @@ static class Program
                 {
                     if (!user_error && bugsnag.Configuration.ReleaseStage != "development")
                     {
-                        notifyBugsnag(new Exception(errmsg));
+                        NotifyBugsnag(new Exception(errmsg));
                     }
                 }
                 catch (Exception ex)
@@ -118,7 +118,7 @@ static class Program
         }
     }
 
-    static void notifyBugsnag(Exception e)
+    public static void NotifyBugsnag(Exception e)
     {
         Toggl.Debug("Notifying bugsnag: " + e);
         try
@@ -133,12 +133,12 @@ static class Program
 
     static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
     {
-        notifyBugsnag(e.ExceptionObject as Exception);
+        NotifyBugsnag(e.ExceptionObject as Exception);
     }
 
     static void Application_ThreadException(object sender, System.Threading.ThreadExceptionEventArgs e)
     {
-        notifyBugsnag(e.Exception);
+        NotifyBugsnag(e.Exception);
     }
 
     public static void Shutdown(int exitCode)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1136,7 +1136,7 @@ public static partial class Toggl
             var di = new DirectoryInfo(updatePath);
             foreach (var file in di.GetFiles("TogglDesktopInstaller*.exe", SearchOption.TopDirectoryOnly))
             {
-                file.Delete();
+                Utils.DeleteFile(file.FullName);
             }
 
             return;
@@ -1164,7 +1164,7 @@ public static partial class Toggl
             Debug("Multiple update installers found. Deleting.");
             foreach (var file in files)
             {
-                file.Delete();
+                Utils.DeleteFile(file.FullName);
             }
             return null;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1136,7 +1136,15 @@ public static partial class Toggl
             var di = new DirectoryInfo(updatePath);
             foreach (var file in di.GetFiles("TogglDesktopInstaller*.exe", SearchOption.TopDirectoryOnly))
             {
-                Utils.DeleteFile(file.FullName);
+                try
+                {
+                    Utils.DeleteFile(file.FullName);
+                }
+                catch (Exception e)
+                {
+                    Program.NotifyBugsnag(e);
+                    Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
+                }
             }
 
             return;
@@ -1164,7 +1172,15 @@ public static partial class Toggl
             Debug("Multiple update installers found. Deleting.");
             foreach (var file in files)
             {
-                Utils.DeleteFile(file.FullName);
+                try
+                {
+                    Utils.DeleteFile(file.FullName);
+                }
+                catch (Exception e)
+                {
+                    Program.NotifyBugsnag(e);
+                    Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
+                }
             }
             return null;
         }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -1177,14 +1178,27 @@ public static partial class Toggl
 
         return () =>
         {
-            var process = Process.Start(installerFullPath, "/S /U");
+            Process process;
+            try
+            {
+                process = Process.Start(installerFullPath, "/S /U");
+            }
+            catch (Win32Exception e)
+            {
+                Program.NotifyBugsnag(e);
+                Toggl.OnError?.Invoke("Unable to run the installer. Please update manually.", false);
+                return;
+            }
+
             if (process != null && !process.HasExited && process.Id != 0)
             {
                 // Update has started. Quit, installer will restart me.
                 Environment.Exit(0);
             }
-
-            Debug("Failed to start installer process");
+            else
+            {
+                Toggl.OnError?.Invoke("Unable to run the installer. Please update manually.", false);
+            }
         };
     }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace TogglDesktop
             this.updateText.Text = "";
             this.restartButton.Visibility = Visibility.Collapsed;
 
-            this.versionText.Text = Program.Version() + (Environment.Is64BitProcess ? " (64-bit)" : " (32-bit)");
+            this.versionText.Text = Program.Version() + " " + Utils.Bitness();
 
             var isUpdatCheckDisabled = Toggl.IsUpdateCheckDisabled();
             this.releaseChannelComboBox.ShowOnlyIf(!isUpdatCheckDisabled, true);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
@@ -336,10 +337,21 @@ public static class Utils
         }
 
         #endregion
-    }
+
+        #region file system
+
+        public static void DeleteFile(string fullPath)
+        {
+            File.SetAttributes(fullPath, FileAttributes.Normal);
+            File.Delete(fullPath);
+        }
+
+        #endregion file system
+
         #region environment
 
         public static string Bitness() => Environment.Is64BitProcess ? "(64-bit)" : "(32-bit)";
 
         #endregion environment
+}
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -337,4 +337,9 @@ public static class Utils
 
         #endregion
     }
+        #region environment
+
+        public static string Bitness() => Environment.Is64BitProcess ? "(64-bit)" : "(32-bit)";
+
+        #endregion environment
 }


### PR DESCRIPTION
### 📒 Description
Adds more graceful error handling during auto-update.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- Send bitness info to Bugsnag
- Do not crash the app when unable to start the installer
- Reset file attributes before attempting to delete the file
- Do not crash the app when still unable to delete the file

### 👫 Relationships
Closes #3220

### 🔎 Review hints
Fixes based on a few crashes from the latest beta:
https://app.bugsnag.com/toggldesktop/toggldesktop/timeline?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[release.seen_in][0][type]=eq&filters[release.seen_in][0][value]=7.4.519

Steps to reproduce the crashes are not fully clear. The files are either in use or have Read-only attribute.
I tested resetting file attributes by assigning a read-only attribute to the downloaded installer in `updates` folder and the running `TogglDesktop.exe --updated`.