### PR TITLE
Close Editor when pressing ESC on Tag Textfield (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AddTagButton.swift
@@ -9,6 +9,8 @@
 import Cocoa
 
 protocol AddTagButtonDelegate: class {
+
+    func shouldCloseEditorPopover()
     func shouldOpenTagAutoComplete(with text: String)
 }
 
@@ -59,10 +61,16 @@ extension AddTagButton: NSTextFieldDelegate {
     }
 
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-        if (commandSelector == #selector(NSResponder.insertNewline(_:))) {
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
             keyboardDelegate?.shouldOpenTagAutoComplete(with: "")
             return true
         }
+
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            keyboardDelegate?.shouldCloseEditorPopover()
+            return true
+        }
+
         return false
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -672,4 +672,8 @@ extension EditorViewController: AddTagButtonDelegate {
         // because stringValue doesn't notify the delegate
         tagTextField.handleTextDidChange()
     }
+
+    func shouldCloseEditorPopover() {
+        closeBtnOnTap(self)
+    }
 }


### PR DESCRIPTION
### 📒 Description
Like the title 😅

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add an additional delegate func to notify the Editor to close when hitting ESC on Tag Text Field 

### 👫 Relationships
Close #3228

### 🔎 Review hints
1. Open Editor
2. Tab to focus on Empty Tag Text Field
3. Hit ESC
4. If the Popover closes -> 💯 

