### PR TITLE
Clean up Idle Notifications code and fix hiding of the widget

### DIFF
--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.h
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.h
@@ -58,7 +58,7 @@ private:
 
     void on_discardTimeAndContinueButton_clicked();
 
-    void on_pushButton_clicked();
+    void on_addIdleTimeAsNewEntryButton_clicked();
 
  private:
     Ui::IdleNotificationWidget *ui;

--- a/src/ui/linux/TogglDesktop/idlenotificationwidget.ui
+++ b/src/ui/linux/TogglDesktop/idlenotificationwidget.ui
@@ -89,7 +89,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="pushButton">
+    <widget class="QPushButton" name="addIdleTimeAsNewEntryButton">
      <property name="text">
       <string>Add idle time as a new time entry</string>
      </property>


### PR DESCRIPTION
### 📒 Description
There were some relicts of the old notification dialog (button called pushButton, signal connecting with the `SIGNAL` and `SLOT` macros instead of method pointers) so I cleaned them up so it's more obvious what's what.
I also changed how the previous top widget is stored in case the idle notification is shown twice in a row (so it hides properly after user interaction).

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Idle notification hides right after being displayed twice in a row (linux)

### 👫 Relationships
Closes #3238

### 🔎 Review hints
See the attached issue for reproduction steps.

