### PR TITLE
Avoid overriding the TE in Timer when selecting from AutoComplete

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -133,8 +133,7 @@ NSString *kInactiveTimerColor = @"#999999";
 
 - (void)initCommon
 {
-	// Manual as default
-	self.displayMode = DisplayModeManual;
+	self.displayMode = DisplayModeInput;
 	self.projectTextField.isInTimerBar = YES;
 	self.autoCompleteInput.displayMode = AutoCompleteDisplayModeFullscreen;
 	self.liteAutocompleteDataSource.input = self.autoCompleteInput;
@@ -263,6 +262,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 	else
 	{
+		self.descriptionLabel.editable = YES;
 		[self showDefaultTimer];
 	}
 

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -441,7 +441,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.autoCompleteInput.stringValue = self.time_entry.Description;
 
 	// Make descriptionLabel is editable and focus
-	self.descriptionLabel.editable = (item.Type != 0);
+	self.descriptionLabel.editable = YES;
 	self.descriptionLabel.stringValue = self.time_entry.Description;
 	self.displayMode = DisplayModeTimer;
 	[self.view.window makeFirstResponder:self.descriptionLabel];


### PR DESCRIPTION
### 📒 Description
This PR will fix the issue, which describes in the following Problem section

### Problem
As soon as we stop the TE (The TimeEntry could be new or existed in the list), the 📚 Library will notify bunch of `kDisplayTimerState` notifications (4-5 times) to TimerEditViewController (https://github.com/toggl/toggldesktop/blob/c0e7870da78abe19e33bfb4e5050a41ffec7d397/src/ui/osx/TogglDesktop/TimerEditViewController.m#L204).

If we quickly click by mouse (enter not work) the TimeEntry in autocomplete in Timer. One of above notifications will clear it out => Result in the disappearance of the TE.

### Solution
- In order to prevent it, we make the Description label to become first responder, so the if-statement https://github.com/toggl/toggldesktop/blob/c0e7870da78abe19e33bfb4e5050a41ffec7d397/src/ui/osx/TogglDesktop/TimerEditViewController.m#L210-L213
will be true and return immediately.
- Secondly, we are able to edit on the selected TE as well (see the GIF)

### Library issue
By throwing bunch of notifications after stopping the TE, we have to find alternative solution to make sure:
- 1 Notifications

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Make Description Editable and become first responder -> Prevent the clear
- [x] Able to edit the selected TE

### 👫 Relationships
Close #3240 

### 🔎 Review hints
1. Start any TE
2. Stop
3. Quickly type something in Timer -> select any TE by mouse
4. If the TE is still there and we're able to edit it => 💯 

### GIF
![2019-08-22 14 53 48](https://user-images.githubusercontent.com/5878421/63497525-20057580-c4ee-11e9-9191-74ee2f26cc23.gif)

