### PR TITLE
Missing Tag in AutoComplete

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -166,6 +166,8 @@ void *ctx;
 	toggl_set_time_entry_description(ctx,
 									 [timeEntry.GUID UTF8String],
 									 [autocomplete.Description UTF8String]);
+	[self updateTimeEntryWithTags:autocomplete.tags guid:timeEntry.GUID];
+
 }
 
 - (NSString *)convertDuratonInSecond:(int64_t)durationInSecond


### PR DESCRIPTION
### 📒 Description
This PR will fix the missing of tag when selecting from AutoComplete in Editor.

### Problem
As soon as we select TE in AutoComplete in Editor, we update it in this method
https://github.com/toggl/toggldesktop/blob/c0e7870da78abe19e33bfb4e5050a41ffec7d397/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m#L159-L169

As we can see, we only update the Description and Project, but forgot to update the `TAG`.

### Solution
- Explicitly update the tag

### Library Issues
As soon as we execute the `toogl_time_entry....` in the Library, it will update the UI in same thread. It results in the number of library notification to update the Editor.
Currently, it's 3 times:
1. from Project Update
2. from Tag Update
3. From Syncer

=> It's unnecessary 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Explicitly update the tag from AutoCompleteItem

### 👫 Relationships
Close #3204 

### 🔎 Review hints
1. Create new TE with tag
2. Start and stop the TE
3. Select any tag in the List -> Open Editor -> Type the name again in Description text field
4. Select it
5. If the selected TE is updated with Description, Project, Tag -> It's correct ✅

### GIF
![2019-08-22 16 23 08](https://user-images.githubusercontent.com/5878421/63503743-3d404100-c4fa-11e9-90a4-ed74aee33d71.gif)
