### PR TITLE
Fix Private/Public project when creating new one

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -215,6 +215,7 @@ extension ProjectCreationView {
         // Default value
         selectedColor = ProjectColor.default
         displayMode = .normal
+        publicProjectCheckBox.state = .off
 
         // Delegate
         projectTextField.delegate = self

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -229,7 +229,7 @@
                 </stackView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Vy-Nq-8Ub">
                     <rect key="frame" x="8" y="18" width="112" height="18"/>
-                    <buttonCell key="cell" type="check" title="Public Project" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="m2f-QZ-VmO">
+                    <buttonCell key="cell" type="check" title="Public Project" bezelStyle="regularSquare" imagePosition="left" inset="2" id="m2f-QZ-VmO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system" size="14"/>
                     </buttonCell>


### PR DESCRIPTION
### 📒 Description
There is a report that new project creating as a private when setting a public.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] There was a mismatch between the value in model (private project) and the UI of Project View. -> Fix the layout and set the default view

### 👫 Relationships
Close #3236

### 🔎 Review hints
- Create new project in desktop app in a WS you are an admin in
- Mark project as public or private by hitting the Check box, or just leave it as it is
- Open webapp projects page to view project (it will show as private)
=> The project status must be matched private/public during creation 

