### PR TITLE
Load More in Timeline

### DIFF
--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -647,13 +647,11 @@ void toggl_view_timeline_data(void *context) {
 
 void toggl_view_timeline_prev_day(
     void *context) {
-    app(context)->LoadMore();
     app(context)->ViewTimelinePrevDay();
 }
 
 void toggl_view_timeline_next_day(
     void *context) {
-    app(context)->LoadMore();
     app(context)->ViewTimelineNextDay();
 }
 
@@ -663,7 +661,6 @@ void toggl_view_timeline_current_day(void *context) {
 
 void toggl_view_timeline_set_day(void *context,
                                  const int64_t unix_timestamp) {
-    app(context)->LoadMore();
     app(context)->ViewTimelineSetDate(unix_timestamp);
 }
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -647,11 +647,13 @@ void toggl_view_timeline_data(void *context) {
 
 void toggl_view_timeline_prev_day(
     void *context) {
+    app(context)->LoadMore();
     app(context)->ViewTimelinePrevDay();
 }
 
 void toggl_view_timeline_next_day(
     void *context) {
+    app(context)->LoadMore();
     app(context)->ViewTimelineNextDay();
 }
 
@@ -661,6 +663,7 @@ void toggl_view_timeline_current_day(void *context) {
 
 void toggl_view_timeline_set_day(void *context,
                                  const int64_t unix_timestamp) {
+    app(context)->LoadMore();
     app(context)->ViewTimelineSetDate(unix_timestamp);
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
@@ -98,6 +98,17 @@ class TimeEntryDatasource: NSObject {
     
     // MARK: Public
 
+    @objc func loadMoreTimeEntryIfNeed(at date: Date) {
+        guard isShowLoadMore,
+            let lastDate = lastDateInSections() else { return }
+
+        // If the date of timeline is before the last day and the Load More btn is showing
+        // We should load more item
+        if date < lastDate {
+            DesktopLibraryBridge.shared().loadMoreTimeEntry()
+        }
+    }
+
     func selectFirstItem() {
         // Check if there is a least 1 item
         guard sections.first?.entries.first != nil else { return }
@@ -271,6 +282,11 @@ extension TimeEntryDatasource {
         collectionView.register(NSNib(nibNamed: Constants.TimeHeaderNibName, bundle: nil),
                                 forSupplementaryViewOfKind:NSCollectionView.elementKindSectionHeader,
                                 withIdentifier: Constants.TimeHeaderID)
+    }
+
+    fileprivate func lastDateInSections() -> Date? {
+        let lastSection = sections.reversed().first { !$0.isLoadMore }
+        return lastSection?.entries.last?.ended
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
@@ -286,7 +286,7 @@ extension TimeEntryDatasource {
 
     fileprivate func lastDateInSections() -> Date? {
         let lastSection = sections.reversed().first { !$0.isLoadMore }
-        return lastSection?.entries.last?.ended
+        return lastSection?.entries.last?.started
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.h
@@ -91,6 +91,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGSize)getEditorWindowSize;
 
+#pragma mark - Editor
+
+- (void)loadMoreTimeEntry;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -271,4 +271,9 @@ void *ctx;
 	return CGSizeMake(width, height);
 }
 
+- (void)loadMoreTimeEntry
+{
+	toggl_load_more(ctx);
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/MainDashboardViewController.swift
@@ -84,6 +84,7 @@ extension MainDashboardViewController {
         listBtn.isSelected = true
         timeEntryController.delegate = self
         headerContainerView.applyShadow(color: .black, opacity: 0.1, radius: 6.0)
+        timelineController.delegate = self
     }
 
     fileprivate func initNotification() {
@@ -161,5 +162,14 @@ extension MainDashboardViewController: TimeEntryListViewControllerDelegate {
 
     func containerViewForTimer() -> NSView! {
         return timerContainerView
+    }
+}
+
+// MARK: TimelineDashboardViewControllerDelegate
+
+extension MainDashboardViewController: TimelineDashboardViewControllerDelegate {
+
+    func timelineDidChangeDate(_ date: Date) {
+        timeEntryController.loadMoreIfNeed(at: date)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -8,6 +8,11 @@
 
 import Cocoa
 
+protocol TimelineDashboardViewControllerDelegate: class {
+
+    func timelineDidChangeDate(_ date: Date)
+}
+
 final class TimelineDashboardViewController: NSViewController {
 
     // MARK: OUTLET
@@ -19,6 +24,7 @@ final class TimelineDashboardViewController: NSViewController {
     
     // MARK: Variables
 
+    weak var delegate: TimelineDashboardViewControllerDelegate?
     private var selectedGUID: String?
     private var isFirstTime = true
     lazy var datePickerView: DatePickerView = DatePickerView.xibView()
@@ -177,6 +183,7 @@ extension TimelineDashboardViewController: DatePickerViewDelegate {
     func datePickerOnChanged(_ sender: DatePickerView, date: Date) {
         editorPopover.close()
         DesktopLibraryBridge.shared().timelineSetDate(date)
+        delegate?.timelineDidChangeDate(date)
     }
 
     func datePickerShouldClose(_ sender: DatePickerView) {

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
@@ -18,4 +18,7 @@
 @interface TimeEntryListViewController : NSViewController
 @property (weak, nonatomic) id<TimeEntryListViewControllerDelegate> delegate;
 @property (nonatomic, assign, readonly) BOOL isEditorOpen;
+
+- (void)loadMoreIfNeedAtDate:(NSDate *)date;
+
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -700,4 +700,8 @@ extern void *ctx;
 	[self.collectionView deselectAll:self];
 }
 
+- (void)loadMoreIfNeedAtDate:(NSDate *)date;
+{
+	[self.dataSource loadMoreTimeEntryIfNeedAt:date];
+}
 @end


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix to load "Load More" when navigating around in Timeline

### 🕶️ Types of changes
 **Improve** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Call LoadMore in Library when changing date in Timeline.

### 👫 Relationships
Close #3190 

### 🔎 Review hints
1. Start the app with account has bunch of old TE
2. Make sure the TE List has Load More button
3. Switch to Timeline and change to the day has LoadMore
4. The Timeline could get old TimeEntry -> 💯 
5. Back to TE List -> The Load More btn is disappear -> 💯 

