### PR TITLE
[Need Help][WIP] Locally store Unsynced in database

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -1853,7 +1853,7 @@ error Database::loadTimeEntries(
                "SELECT local_id, id, uid, description, wid, guid, pid, "
                "tid, billable, duronly, ui_modified_at, start, stop, "
                "duration, tags, created_with, deleted_at, updated_at, "
-               "project_guid, validation_error "
+               "project_guid, validation_error, unsynced "
                "FROM time_entries "
                "WHERE uid = :uid "
                "ORDER BY start DESC",
@@ -1969,6 +1969,12 @@ error Database::loadTimeEntriesFromSQLStatement(
                 } else {
                     model->SetValidationError(rs[19].convert<std::string>());
                 }
+                if (rs[20].convert<bool>()) {
+                    model->SetUnsynced();
+                } else {
+                    model->ClearUnsynced();
+                }
+
                 model->ClearDirty();
                 list->push_back(model);
                 more = rs.moveNext();

--- a/src/database.cc
+++ b/src/database.cc
@@ -2085,7 +2085,8 @@ error Database::saveModel(
                           "deleted_at = :deleted_at, "
                           "updated_at = :updated_at, "
                           "project_guid = :project_guid, "
-                          "validation_error = :validation_error "
+                          "validation_error = :validation_error, "
+                          "unsynced = :unsynced "
                           "where local_id = :local_id",
                           useRef(model->ID()),
                           useRef(model->UID()),
@@ -2106,6 +2107,7 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->Unsynced()),
                           useRef(model->LocalID()),
                           now;
             } else {
@@ -2121,7 +2123,8 @@ error Database::saveModel(
                           "deleted_at = :deleted_at, "
                           "updated_at = :updated_at, "
                           "project_guid = :project_guid, "
-                          "validation_error = :validation_error "
+                          "validation_error = :validation_error, "
+                          "unsynced = :unsynced "
                           "where local_id = :local_id",
                           useRef(model->UID()),
                           useRef(model->Description()),
@@ -2141,6 +2144,7 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->Unsynced()),
                           useRef(model->LocalID()),
                           now;
             }
@@ -2173,13 +2177,13 @@ error Database::saveModel(
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "
                           "tags, created_with, deleted_at, updated_at, "
-                          "project_guid, validation_error) "
+                          "project_guid, validation_error, unsynced) "
                           "values(:id, :uid, :description, :wid, "
                           ":guid, :pid, :tid, :billable, "
                           ":duronly, :ui_modified_at, "
                           ":start, :stop, :duration, "
                           ":tags, :created_with, :deleted_at, :updated_at, "
-                          ":project_guid, :validation_error)",
+                          ":project_guid, :validation_error, :unsynced)",
                           useRef(model->ID()),
                           useRef(model->UID()),
                           useRef(model->Description()),
@@ -2199,6 +2203,7 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->Unsynced()),
                           now;
             } else {
                 *session_ <<
@@ -2207,14 +2212,14 @@ error Database::saveModel(
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "
                           "tags, created_with, deleted_at, updated_at, "
-                          "project_guid, validation_error "
+                          "project_guid, validation_error, unsynced"
                           ") values ("
                           ":uid, :description, :wid, "
                           ":guid, :pid, :tid, :billable, "
                           ":duronly, :ui_modified_at, "
                           ":start, :stop, :duration, "
                           ":tags, :created_with, :deleted_at, :updated_at, "
-                          ":project_guid, :validation_error)",
+                          ":project_guid, :validation_error, :unsynced)",
                           useRef(model->UID()),
                           useRef(model->Description()),
                           useRef(model->WID()),
@@ -2233,6 +2238,7 @@ error Database::saveModel(
                           useRef(model->UpdatedAt()),
                           useRef(model->ProjectGUID()),
                           useRef(model->ValidationError()),
+                          useRef(model->Unsynced()),
                           now;
             }
             error err = last_error("saveTimeEntry");

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -816,6 +816,14 @@ error Migrations::migrateTimeEntries() {
         return err;
     }
 
+    err = db_->Migrate(
+        "time_entries.unsynced",
+        "ALTER TABLE time_entries "
+        "ADD COLUMN unsynced INTEGER NOT NULL DEFAULT 0;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 


### PR DESCRIPTION
### 📒 Description
According the proposal in https://github.com/toggl/toggldesktop/issues/3128#issuecomment-525168994.

This PR tries to store unsynced state of TimeEntry in database whenever the TE is set "Unsynced" from the Syncer in Library.

It could resolve the case that when launching the app, the Unsynced state is remained and fulfill the requirement on https://github.com/toggl/toggldesktop/issues/3128#issuecomment-525180989 

### Need help
@IndrekV I couldn't find suitable way to force the TE save in database when `BaseModel::SetUnsynced()` is trigger from the Syncer. 

I need some help 🙌

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Add unsynced to database (migration)
- [x] Receive and save in database when the TE is saved.
- [ ] When TE is set as "Unsynced" -> Store to database

### 👫 Relationships
Close #3128

### 🔎 Review hints
- Steps in #3128

