### PR TITLE
Added WID to time entry hash generation (lib), closes #3255

### DIFF
--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -381,6 +381,7 @@ const std::string TimeEntry::GroupHash() const {
     std::stringstream ss;
     ss << toggl::Formatter::FormatDateHeader(Start())
        << Description()
+       << WID()
        << PID()
        << TID()
        << ProjectGUID()


### PR DESCRIPTION
### 📒 Description
Adds WID to time entry hash generation so that different identical time entries without projects that are not in they same workspace do not get grouped together.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
Added WID to time entry hash generation method

### 👫 Relationships

Closes #3255 

### 🔎 Review hints
- Create 2 time entries that have the same description and no project attached.
- They are grouped together
- Move one time entry to another workspace (select project from another workspace and then remove project)
- Two similar time entries should not be grouped together anymore
