### PR TITLE
Treat "This entry can't be saved - please add..." errors as user errors

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -86,6 +86,7 @@
 #define kDatabaseDiskMalformed "The database disk image is malformed"
 #define kMissingWS "You no longer have access to your last workspace"
 #define kOutOfDatePleaseUpgrade "Your version of Toggl Desktop is out of date, please upgrade!"
+#define kThisEntryCantBeSavedPleaseAdd "This entry can't be saved - please add"
 
 #define kModelAutotrackerRule "autotracker_rule"
 #define kModelClient "client"

--- a/src/error.cc
+++ b/src/error.cc
@@ -203,7 +203,7 @@ bool IsUserError(const error err) {
     if (err.find(kProjectNameAlreadyExists) != std::string::npos) {
         return true;
     }
-    if (err.find("This entry can't be saved - please add") != std::string::npos) {
+    if (err.find(kThisEntryCantBeSavedPleaseAdd) != std::string::npos) {
         return true;
     }
     return false;

--- a/src/error.cc
+++ b/src/error.cc
@@ -203,6 +203,9 @@ bool IsUserError(const error err) {
     if (err.find(kProjectNameAlreadyExists) != std::string::npos) {
         return true;
     }
+    if (err.find("This entry can't be saved - please add") != std::string::npos) {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
### 📒 Description
Treats errors which contain the text "This entry can't be saved - please add..." as user errors.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3233.

### 🔎 Review hints
Can be tested only if you have a workspace with some required fields defined, but the code is super-straightforward. The error text was just copied from Bugsnag.

