### PR TITLE
Attempt to fix the Window size when it goes smaller than Timer Bar

### DIFF
--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -16,6 +16,7 @@
 #import "DisplayCommand.h"
 #import "TrackingService.h"
 #import "TogglDesktop-Swift.h"
+#import "TimerEditViewController.h"
 
 @interface MainWindowController ()
 @property (weak) IBOutlet NSView *contentView;
@@ -85,6 +86,7 @@ extern void *ctx;
 
 	// Error View
 	[self initErrorView];
+	[self setInitialWindowSizeIfNeed];
 }
 
 - (void)initErrorView {
@@ -267,6 +269,19 @@ extern void *ctx;
 		case WindowModeDefault :
 			[self.window setLevel:NSNormalWindowLevel];
 			break;
+	}
+}
+
+- (void)setInitialWindowSizeIfNeed
+{
+	if (self.contentView == nil || self.timeEntryListViewController.timerEditViewController == nil)
+	{
+		return;
+	}
+
+	if (self.contentView.frame.size.height - 2 <= self.timeEntryListViewController.timerEditViewController.view.frame.size.height)
+	{
+		[self.window setContentSize:CGSizeMake(400, 600)];
 	}
 }
 

--- a/src/ui/osx/TogglDesktop/MainWindowController.xib
+++ b/src/ui/osx/TogglDesktop/MainWindowController.xib
@@ -17,16 +17,16 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Toggl Desktop" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="MainWindow" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
-            <rect key="contentRect" x="196" y="240" width="300" height="398"/>
+            <rect key="contentRect" x="196" y="240" width="300" height="400"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="240" height="20"/>
             <value key="maxSize" type="size" width="2500" height="2500"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="300" height="398"/>
+                <rect key="frame" x="0.0" y="0.0" width="300" height="400"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="av5-A6-9S5" userLabel="ContentView">
-                        <rect key="frame" x="0.0" y="0.0" width="300" height="398"/>
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="400"/>
                     </customView>
                 </subviews>
                 <constraints>

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.h
@@ -8,6 +8,9 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TimerEditViewController;
+
 @interface TimeEntryListViewController : NSViewController
+@property (nonatomic, strong) TimerEditViewController *timerEditViewController;
 @property (nonatomic, assign, readonly) BOOL isEditorOpen;
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -26,7 +26,6 @@ static NSString *kFrameKey = @"frame";
 @property (weak) IBOutlet NSBox *emptyViewContainerView;
 
 @property (nonatomic, strong) TimeEntryDatasource *dataSource;
-@property (nonatomic, strong) TimerEditViewController *timerEditViewController;
 @property (nonatomic, assign) NSInteger defaultPopupHeight;
 @property (nonatomic, assign) NSInteger defaultPopupWidth;
 @property (nonatomic, assign) NSInteger addedHeight;


### PR DESCRIPTION
### 📒 Description
There is a user report that after upgrading the app, the entire window is collapsed and become small size. 

Since I couldn't reproduce this bug, so This PR will attempt to check and set the initial size if needed.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Check if the size of window is smaller than the TImer Bar -> Set initial size

### 👫 Relationships
Close #3253

### 🔎 Review hints
#### Resize if the size is small
- Open the app, resize to small size as possible
- Stop, and open -> If the size is become normal -> 💯 

#### Maintain previous size
- Open the app, resize to be bigger 
- Stop and open -> The size is remained -> 💯 
