### PR TITLE
DnD for notification and Idle popup 

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1430,7 +1430,6 @@ const NSString *appName = @"osx_native_app";
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
 	[self.idleNotificationWindowController displayIdleEvent:idleEvent];
-	[NSApp activateIgnoringOtherApps:YES];
 }
 
 - (PLCrashReporter *)configuredCrashReporter

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -10,6 +10,7 @@
 #import "DisplayCommand.h"
 #import "TogglDesktop-Swift.h"
 #import "IdleEvent.h"
+#import "UserNotificationCenter.h"
 
 @interface IdleNotificationWindowController ()
 
@@ -20,6 +21,7 @@
 @property (weak) IBOutlet NSButton *cancelButton;
 @property (weak) IBOutlet FlatButton *discardAndContinueButton;
 @property (weak) IBOutlet FlatButton *keepIdleTimeButton;
+@property (assign, nonatomic) BOOL isWaiting;
 
 - (IBAction)stopButtonClicked:(id)sender;
 - (IBAction)ignoreButtonClicked:(id)sender;
@@ -46,6 +48,24 @@ extern void *ctx;
 	[self styleTransparentButton:self.discardAndContinueButton];
 	[self styleTransparentButton:self.keepIdleTimeButton];
 	[self styleCancelButton];
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(windowDidBecomeActiveNotification)
+												 name:NSApplicationDidBecomeActiveNotification
+											   object:nil];
+}
+
+- (void)dealloc
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)windowDidBecomeActiveNotification
+{
+	if (self.isWaiting && ![UserNotificationCenter share].isDoNotDisturbEnabled)
+	{
+		[self.window makeKeyAndOrderFront:nil];
+        self.isWaiting = NO;
+	}
 }
 
 - (void)styleTransparentButton:(FlatButton *)button
@@ -94,8 +114,6 @@ extern void *ctx;
 
 	self.idleEvent = idleEvent;
 
-	[self.window makeKeyAndOrderFront:nil];
-
 	self.idleSinceTextField.stringValue = self.idleEvent.since;
 	[self.idleSinceTextField setHidden:NO];
 
@@ -103,6 +121,15 @@ extern void *ctx;
 	[self.idleAmountTextField setHidden:NO];
 
 	self.timeentryDescriptionTextField.stringValue = self.idleEvent.timeEntryDescription;
+
+	if ([[UserNotificationCenter share] isDoNotDisturbEnabled])
+	{
+		self.isWaiting = YES;
+	}
+	else
+	{
+		[self.window makeKeyAndOrderFront:nil];
+	}
 }
 
 - (IBAction)stopButtonClicked:(id)sender

--- a/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
+++ b/src/ui/osx/TogglDesktop/test2/IdleNotificationWindowController.m
@@ -50,7 +50,7 @@ extern void *ctx;
 	[self styleCancelButton];
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(windowDidBecomeActiveNotification)
-												 name:NSApplicationDidBecomeActiveNotification
+												 name:NSWindowDidBecomeKeyNotification
 											   object:nil];
 }
 
@@ -64,7 +64,8 @@ extern void *ctx;
 	if (self.isWaiting && ![UserNotificationCenter share].isDoNotDisturbEnabled)
 	{
 		[self.window makeKeyAndOrderFront:nil];
-        self.isWaiting = NO;
+		[NSApp activateIgnoringOtherApps:YES];
+		self.isWaiting = NO;
 	}
 }
 
@@ -129,6 +130,7 @@ extern void *ctx;
 	else
 	{
 		[self.window makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
 	}
 }
 

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)scheduleAutoTrackerWithProjectName:(NSString *)projectName projectID:(NSNumber *)projectID taskID:(NSNumber *)taskID;
 
+- (BOOL)isDoNotDisturbEnabled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
+++ b/src/ui/osx/TogglDesktop/test2/UserNotificationCenter.m
@@ -35,6 +35,13 @@
 	return self;
 }
 
+- (BOOL)isDoNotDisturbEnabled
+{
+	NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.apple.notificationcenterui"];
+
+	return [defaults boolForKey:@"doNotDisturb"];
+}
+
 - (NSUserNotification *)defaultUserNotificationWithTitle:(NSString *)title informativeText:(NSString *)informativeText
 {
 	NSUserNotification *notification = [[NSUserNotification alloc] init];


### PR DESCRIPTION
### 📒 Description
This PR will fix the bug that the idle popup doesn't respect the Do not Disturb setting.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Detect the status of DnD setting
- [x] Prevent the Idle Popup appears when DnD is on
- [x] Present it again if DnD is off

### 👫 Relationships
Closes #3268

### 🔎 Review hints
#### Notifications on DnD
1. Moving the mouse to top-right of screen -> Turn on DnD
2. Start any TE
3. Wait for Pomodoro or Reminder notification 
4. There is no one appear -> 💯 
#### Idle Popup on DnD
1. Turn on DnD
2. Start any TE, and set Idle time in Setting is 1 min
3. Leave the app after 1 mins
4. After 1 mins, there is no popup 
5. If we turn OFF DnD and come back to the app
6. Idle Dnd must come up -> 💯 
7. User can select those idle options as usual -> 💯 

#### Notification and idle when DnD is off
- Both notifications and idle should works as normal if the DnD is off.

