### PR TITLE
Fix crash when opening browser link

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1417,6 +1417,17 @@ public static partial class Toggl
         OnError(errmsg, user_error);
     }
 
+    public static void OpenInBrowser(string url)
+    {
+        OnURL(url);
+    }
+
+    public static void ShowErrorAndNotify(string errmsg, Exception ex)
+    {
+        NewError(errmsg, true);
+        Program.NotifyBugsnag(ex);
+    }
+
     public static bool AskToDeleteEntry(string guid)
     {
         var result = MessageBox.Show(mainWindow, "Deleted time entries cannot be restored.", "Delete time entry?",

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/LoginView.xaml.cs
@@ -364,7 +364,7 @@ namespace TogglDesktop
 
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            System.Diagnostics.Process.Start(e.Uri.ToString());
+            Toggl.OpenInBrowser(e.Uri.ToString());
         }
 
         private void countrySelect_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/AboutWindow.xaml.cs
@@ -80,12 +80,12 @@ namespace TogglDesktop
 
         private void onGithubLinkClick(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/toggl/toggldesktop");
+            Toggl.OpenInBrowser("https://github.com/toggl/toggldesktop");
         }
 
         private void onChangelogLinkClick(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://toggl.github.io/toggldesktop");
+            Toggl.OpenInBrowser("http://toggl.github.io/toggldesktop");
         }
 
         private void onRestartButtonClick(object sender, RoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -358,7 +358,17 @@ namespace TogglDesktop
 
         private void onURL(string url)
         {
-            Process.Start(url);
+            try
+            {
+                Process.Start(url);
+            }
+            catch (Exception e)
+            {
+                if (!Utils.TryOpenInDefaultBrowser(url))
+                {
+                    Toggl.ShowErrorAndNotify("Wasn't able to open the browser", e);
+                }
+            }
         }
 
         private void onReminder(string title, string informativeText)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/LinqExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/LinqExtensions.cs
@@ -60,5 +60,14 @@ static class LinqExtensions
         }
         return current;
     }
+
+    public static string[] SplitByWhiteSpaceUnlessEnclosedInQuotes(this string str)
+    {
+        return str.Split('"')
+            .Select((element, index) => index % 2 == 0  // If even index
+                ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)  // Split the item
+                : new[] { element })  // Keep the entire item
+            .SelectMany(element => element).ToArray();
+    }
 }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -335,6 +336,35 @@ public static class Utils
                 {
                     subKey.DeleteValue("TogglDesktop");
                 }
+            }
+        }
+
+        public static bool TryOpenInDefaultBrowser(string url)
+        {
+            try
+            {
+                using (var browserKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice", false))
+                {
+                    if (browserKey == null) return false;
+                    var browserKeyName = browserKey.GetValue("ProgId") as string;
+                    if (string.IsNullOrEmpty(browserKeyName)) return false;
+                    using (var openBrowserCmdKey = Registry.ClassesRoot.OpenSubKey(browserKeyName + @"\shell\open\command"))
+                    {
+                        if (openBrowserCmdKey == null) return false;
+                        var openBrowserCmdValue = openBrowserCmdKey.GetValue(null) as string;
+                        if (string.IsNullOrEmpty(openBrowserCmdValue)) return false;
+                        openBrowserCmdValue = openBrowserCmdValue.Replace("%1", url);
+                        var splitResult = openBrowserCmdValue.SplitByWhiteSpaceUnlessEnclosedInQuotes();
+                        var fileName = splitResult.First(); // take the file name
+                        var args = string.Join(" ", splitResult.Skip(1)); // merge the rest of args back
+                        Process.Start(fileName, args);
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -341,6 +341,12 @@ public static class Utils
 
         public static bool TryOpenInDefaultBrowser(string url)
         {
+            return tryOpenInDefaultBrowserFromRegistry(url)
+                   || tryOpenInBuiltInBrowser(url);
+        }
+
+        private static bool tryOpenInDefaultBrowserFromRegistry(string url)
+        {
             try
             {
                 using (var browserKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice", false))
@@ -361,6 +367,27 @@ public static class Utils
                         return true;
                     }
                 }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool tryOpenInBuiltInBrowser(string url)
+        {
+            try
+            {
+                if (Environment.OSVersion.Version.Major >= 10)
+                {
+                    Process.Start(@"C:\WINDOWS\system32\LaunchWinApp.exe", url);
+                }
+                else
+                {
+                    Process.Start("iexplore.exe", url);
+                }
+
+                return true;
             }
             catch
             {


### PR DESCRIPTION
### 📒 Description
Fallback to opening a default browser specified in the registry.
The following registry paths worked for me and googling confirms it should work for Windows 7+ https://stackoverflow.com/a/12444963 https://gallery.technet.microsoft.com/scriptcenter/Show-default-browser-b1f10e33.
The registry hack is used only as a fallback, in case `Process.Start` fails.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- If `Process.Start` fails, try to find a default browser in the registry and open it.
- Instead of crashing the application just show an error to the user and send Bugsnag notification.

### 👫 Relationships
Closes #3267.

### 🔎 Review hints
I couldn't reproduce it so I suggest:
- In `MainWindow.xaml.cs` in `onURL` method replace `Process.Start(url)` with `throw new Exception()`.
- Try opening Reports from the cogwheel menu, Changelog and Github links from About window.