### PR TITLE
Random Project Color 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectColor.swift
@@ -27,4 +27,8 @@ struct ProjectColor: Equatable {
                                                 ProjectColor(colorHex: "#000000")]
 
     let colorHex: String
+
+    static func random() -> ProjectColor {
+        return defaultColors.randomElement() ?? .default
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.swift
@@ -50,6 +50,7 @@ final class ProjectCreationView: NSView {
 
     var selectedTimeEntry: TimeEntryViewItem! {
         didSet {
+            getRandomColor()
             resetViews()
         }
     }
@@ -119,6 +120,7 @@ final class ProjectCreationView: NSView {
         super.awakeFromNib()
 
         initCommon()
+        getRandomColor()
         selecteFirstWorkspace()
         updateLayoutState()
     }
@@ -239,6 +241,12 @@ extension ProjectCreationView {
         isPremiumWorkspace = false
     }
 
+    fileprivate func getRandomColor() {
+        let color = ProjectColor.random()
+        originalColor = color
+        selectedColor = color
+    }
+
     fileprivate func updateLayout() {
         let height = displayMode.height
         switch displayMode {
@@ -306,7 +314,7 @@ extension ProjectCreationView {
         selecteFirstWorkspace()
         clientAutoComplete.stringValue = ""
         selectedClient = nil
-        selectedColor = ProjectColor.default
+        selectedColor = originalColor
         updateLayoutState()
     }
 


### PR DESCRIPTION
### 📒 Description
This PR will introduce the random color when opening the Project Creation View.

There are 3 behaviors:
- If it's same TE -> Open the Project Creation View -> Only randomize 1 time, but don't do random for next open, until they close or select different TE
- If it's different TE -> Open Project Creation View -> Random
- "Reset" btn will reset to the random color (The original)

### 🕶️ Types of changes
**Improvement** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Get color random from the Project Color List
- [x] Assign color as a selected and original color (for reset)

### 👫 Relationships
Closes #3263 

### 🔎 Review hints
#### Select one TE
- Select any TE
- Open Project Creation
- Color should be randomized -> 💯 
- Close Project creation view
- Open again
- Color should not be randomized.

### Select different TE
The color should be changed randomly when we open TE for different TE

### Reset 
- Should reset to the Random color at the first place.

![2019-09-06 12 04 55](https://user-images.githubusercontent.com/5878421/64402449-37706100-d09f-11e9-90ce-65ef76f5aba5.gif)

