### PR TITLE
Process Tag in background

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Storage/TagStorage.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Storage/TagStorage.swift
@@ -25,10 +25,11 @@ extension Notification.Name {
     // MARK: Public
 
     func update(with viewItems: [ViewItem]) {
-        self.tags = build(from: viewItems)
-        print("==== Tag data source \(self.tags.map {$0.name})")
-        NotificationCenter.default.post(name: .TagStorageChangedNotification,
-                                        object: tags)
+        build(from: viewItems) {[weak self] tags in
+            guard let strongSelf = self else { return }
+            strongSelf.tags = tags
+            NotificationCenter.default.post(name: .TagStorageChangedNotification, object: tags)
+        }
     }
 
     func filter(with text: String) -> [Tag] {
@@ -48,18 +49,23 @@ extension Notification.Name {
 
 extension TagStorage {
 
-    fileprivate func build(from viewItems: [ViewItem]) -> [Tag] {
-        var tags = viewItems.map { Tag(viewItem: $0) }
+    fileprivate func build(from viewItems: [ViewItem], complete: @escaping ([Tag]) -> Void) {
+        DispatchQueue.global(qos: .background).async {[weak self] in
+            guard let strongSelf = self else { return }
+            var tags = viewItems.map { Tag(viewItem: $0) }
 
-        // We have to add new tags manually
-        // It's a bug in Library
-        // There is no new tags, even it synced properly, until we open the TimeEntryEditor again
-        newTags.forEach { tag in
-            if !tags.contains(where: { $0.name == tag.name }) {
-                tags.append(tag)
+            // We have to add new tags manually
+            // It's a bug in Library
+            // There is no new tags, even it synced properly, until we open the TimeEntryEditor again
+            strongSelf.newTags.forEach { tag in
+                if !tags.contains(where: { $0.name == tag.name }) {
+                    tags.append(tag)
+                }
+            }
+            DispatchQueue.main.async {
+                complete(tags)
             }
         }
-        return tags
     }
 }
 


### PR DESCRIPTION
### 📒 Description
This PR will introduce the fix for the UI Freeze if there is a huge number of tags.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Process the tag in background

### 👫 Relationships
Close #2787

### 🔎 Review hints
Replace `void GUI::DisplayTags(const std::vector<view::Generic> list)` with the following code
```
void GUI::DisplayTags(const std::vector<view::Generic> list) {
    logger().debug("DisplayTags");

//    TogglGenericView *first = generic_to_view_item_list(list);
    TogglGenericView *first = nullptr;
    for (int i=0; i < 10000; i++) {
        for (std::vector<toggl::view::Generic>::const_iterator
                it = list.begin();
                it != list.end();
                it++) {
            TogglGenericView *item = generic_to_view_item(*it);
            item->Next = first;
            first = item;
        }
    }

    on_display_tags_(first);
    view_item_clear(first);
}
```
It will 10x your current tags. Make sure you have 5-6, so the result is 50k or 100k.

- Start the app, and search through the tag
- Observe if the app is freeze when opening the TE -> If it's smooth -> 💯 
- Searching could cause the freeze a bit but it's reasonable.
- Check RAM. If it's around 100-200Mb -> Good to go 💯 

<img width="527" alt="Screen Shot 2019-09-06 at 18 50 21" src="https://user-images.githubusercontent.com/5878421/64426882-fe091700-d0d9-11e9-96aa-6d273baea911.png">
<img width="938" alt="Screen Shot 2019-09-06 at 18 50 55" src="https://user-images.githubusercontent.com/5878421/64426883-fe091700-d0d9-11e9-8875-c8ee570d04b1.png">

