### PR TITLE
Fix for the main window staying in the tray

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/BugsnagService.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/BugsnagService.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Windows.Forms;
+using Bugsnag;
+using Bugsnag.Payload;
+using Exception = System.Exception;
+
+namespace TogglDesktop
+{
+    public static class BugsnagService
+    {
+        private static Client bugsnag;
+
+        public static void Init()
+        {
+            Toggl.InitialiseLog();
+
+            var configuration = new Configuration("aa13053a88d5133b688db0f25ec103b7");
+            configuration.AppVersion = Program.Version();
+
+#if TOGGL_PRODUCTION_BUILD
+            configuration.ReleaseStage = "production";
+#else
+            configuration.ReleaseStage = "development";
+#endif
+
+            bugsnag = new Client(configuration);
+            bugsnag.BeforeNotify(report =>
+            {
+                report.Event.User = new User
+                {
+                    Id = Program.UserId.ToString()
+                };
+                report.Event.Metadata.Add("Details", new Dictionary<string, string>
+                {
+                    {
+                        "Channel", Toggl.UpdateChannel()
+                    },
+                    {"Bitness", Utils.Bitness()}
+                });
+            });
+
+            Toggl.OnError += delegate(string errmsg, bool user_error)
+            {
+                Toggl.Debug(errmsg);
+                try
+                {
+                    if (!user_error && bugsnag.Configuration.ReleaseStage != "development")
+                        NotifyBugsnag(new Exception(errmsg));
+                }
+                catch (Exception ex)
+                {
+                    Toggl.Debug("Could not check if can notify bugsnag: " + ex);
+                }
+            };
+
+            Application.ThreadException += Application_ThreadException;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            NotifyBugsnag(e.ExceptionObject as Exception);
+        }
+
+        private static void Application_ThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            NotifyBugsnag(e.Exception);
+        }
+
+        public static void NotifyBugsnag(Exception e)
+        {
+            Toggl.Debug("Notifying bugsnag: " + e);
+            try
+            {
+                bugsnag.Notify(e);
+            }
+            catch (Exception ex)
+            {
+                Toggl.Debug("Could not notify bugsnag: " + ex);
+            }
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using System.Threading;
 using System.Windows.Interop;
 using System.Windows.Media;
 using Application = System.Windows.Forms.Application;
@@ -11,151 +9,39 @@ namespace TogglDesktop
 {
 static class Program
 {
-    private const string appGUID = "29067F3B-F706-46CB-92D2-1EA1E72A4CE3";
-    private static Bugsnag.Client bugsnag;
-    private static UInt64 uid;
+    private static SingleInstanceManager<App> singleInstanceManager;
+    public static ulong UserId { get; private set; }
+    public static bool IsLoggedIn => UserId > 0;
 
-    public static bool IsLoggedIn
-    {
-        get
-        {
-            return uid > 0;
-        }
-    }
-
-    /// <summary>
-    /// The main entry point for the application.
-    /// </summary>
     [STAThread]
-    static void Main()
+    static void Main(string[] args)
     {
-        Win32.AttachConsole(Win32.ATTACH_PARENT_PROCESS);
-
-        using (Mutex mutex = new Mutex(false, "Global\\" + Environment.UserName + "_" + appGUID))
-        {
-            if (!mutex.WaitOne(0, false))
-            {
-                // See if we get hold of the other process.
-                // If we do, activate it's window and exit.
-                Process current = Process.GetCurrentProcess();
-                Process[] instances = Process.GetProcessesByName(current.ProcessName);
-                foreach (Process p in instances)
-                {
-                    if (p.Id != current.Id)
-                    {
-                        // gotcha
-                        IntPtr hWnd = p.MainWindowHandle;
-                        if (hWnd == IntPtr.Zero)
-                        {
-                            hWnd = Win32.SearchForWindow(current.ProcessName, "Toggl Desktop");
-                        }
-
-                        Win32.ShowWindow(hWnd, Win32.SW_RESTORE);
-                        Win32.SetForegroundWindow(hWnd);
-
-                        return;
-                    }
-                }
-
-                // If not, print an error message and exit.
-                System.Windows.MessageBox.Show("Another copy of Toggl Desktop is already running." +
-                                               Environment.NewLine + "This copy will now quit.");
-                return;
-            }
-
-            Toggl.InitialiseLog();
-
-            var configuration = new Bugsnag.Configuration("aa13053a88d5133b688db0f25ec103b7");
-            configuration.AppVersion = Version();
-
-#if TOGGL_PRODUCTION_BUILD
-            configuration.ReleaseStage = "production";
-#else
-            configuration.ReleaseStage = "development";
-#endif
-
-            bugsnag = new Bugsnag.Client(configuration);
-            bugsnag.BeforeNotify(report =>
-            {
-                report.Event.User = new Bugsnag.Payload.User { Id = uid.ToString() };
-                report.Event.Metadata.Add("Details", new Dictionary<string, string>
-                {
-                    { "Channel", Toggl.UpdateChannel() },
-                    { "Bitness", Utils.Bitness() }
-                });
-            });
-
-            Toggl.OnLogin += delegate(bool open, UInt64 user_id)
-            {
-                uid = user_id;
-            };
-
-            Toggl.OnError += delegate(string errmsg, bool user_error)
-            {
-                Toggl.Debug(errmsg);
-                try
-                {
-                    if (!user_error && bugsnag.Configuration.ReleaseStage != "development")
-                    {
-                        NotifyBugsnag(new Exception(errmsg));
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Toggl.Debug("Could not check if can notify bugsnag: " + ex);
-                }
-            };
-
-            Application.ThreadException += Application_ThreadException;
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-
-            RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
-
-            new App().Run();
-        }
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
+        singleInstanceManager = new SingleInstanceManager<App>();
+        singleInstanceManager.BeforeStartup += OnBeforeStartup;
+        singleInstanceManager.Run(args);
     }
 
-    public static void NotifyBugsnag(Exception e)
+    private static void OnBeforeStartup()
     {
-        Toggl.Debug("Notifying bugsnag: " + e);
-        try
-        {
-            bugsnag.Notify(e);
-        }
-        catch (Exception ex)
-        {
-            Toggl.Debug("Could not notify bugsnag: " + ex);
-        }
-    }
-
-    static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-    {
-        NotifyBugsnag(e.ExceptionObject as Exception);
-    }
-
-    static void Application_ThreadException(object sender, System.Threading.ThreadExceptionEventArgs e)
-    {
-        NotifyBugsnag(e.Exception);
+        Toggl.OnLogin += delegate (bool open, ulong user_id) { UserId = user_id; };
+        BugsnagService.Init();
+        singleInstanceManager.BeforeStartup -= OnBeforeStartup;
     }
 
     public static void Shutdown(int exitCode)
     {
         Toggl.Clear();
-
         Environment.Exit(exitCode);
     }
 
     public static string Version()
     {
-        Assembly assembly = Assembly.GetExecutingAssembly();
-        FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-        return string.Format("{0}.{1}.{2}",
-                             versionInfo.ProductMajorPart,
-                             versionInfo.ProductMinorPart,
-                             versionInfo.ProductBuildPart);
+        var assembly = Assembly.GetExecutingAssembly();
+        var versionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+        return $"{versionInfo.ProductMajorPart}.{versionInfo.ProductMinorPart}.{versionInfo.ProductBuildPart}";
     }
 }
 }

--- a/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace TogglDesktop
+{
+    public class SingleInstanceManager<T> : Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase
+        where T : System.Windows.Application, new()
+    {
+        T app;
+        public SingleInstanceManager()
+        {
+            base.IsSingleInstance = true;
+        }
+
+        public event Action BeforeStartup;
+
+        protected override bool OnStartup(Microsoft.VisualBasic.ApplicationServices.StartupEventArgs e)
+        {
+            BeforeStartup?.Invoke();
+            app = new T();
+            app.Run();
+            return false;
+        }
+
+        protected override void OnStartupNextInstance(Microsoft.VisualBasic.ApplicationServices.StartupNextInstanceEventArgs e)
+        {
+            app.MainWindow.ShowOnTop();
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -1142,7 +1142,7 @@ public static partial class Toggl
                 }
                 catch (Exception e)
                 {
-                    Program.NotifyBugsnag(e);
+                    BugsnagService.NotifyBugsnag(e);
                     Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
                 }
             }
@@ -1178,7 +1178,7 @@ public static partial class Toggl
                 }
                 catch (Exception e)
                 {
-                    Program.NotifyBugsnag(e);
+                    BugsnagService.NotifyBugsnag(e);
                     Toggl.OnError?.Invoke($"Unable to delete the file: {file.FullName}. Delete this file manually.", false);
                 }
             }
@@ -1201,7 +1201,7 @@ public static partial class Toggl
             }
             catch (Win32Exception e)
             {
-                Program.NotifyBugsnag(e);
+                BugsnagService.NotifyBugsnag(e);
                 Toggl.OnError?.Invoke("Unable to run the installer. Please update manually.", false);
                 return;
             }
@@ -1425,7 +1425,7 @@ public static partial class Toggl
     public static void ShowErrorAndNotify(string errmsg, Exception ex)
     {
         NewError(errmsg, true);
-        Program.NotifyBugsnag(ex);
+        BugsnagService.NotifyBugsnag(ex);
     }
 
     public static bool AskToDeleteEntry(string guid)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -135,6 +135,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -174,8 +175,10 @@
     <Compile Include="AutoCompletion\Implementation\TimerItem.cs" />
     <Compile Include="AutoCompletion\Implementation\WorkspaceCategory.cs" />
     <Compile Include="AutoCompletion\ListBoxItem.cs" />
+    <Compile Include="BugsnagService.cs" />
     <Compile Include="Diagnostics\IPerformanceToken.cs" />
     <Compile Include="Diagnostics\Performance.cs" />
+    <Compile Include="SingleInstanceManager.cs" />
     <Compile Include="ui\AutoCompleteControls\ProjectCategory.xaml.cs">
       <DependentUpon>ProjectCategory.xaml</DependentUpon>
     </Compile>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/KeyboardShortcuts.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/KeyboardShortcuts.cs
@@ -146,7 +146,7 @@ namespace TogglDesktop
 
         private static void canExecuteHide(object sender, CanExecuteRoutedEventArgs e)
         {
-            e.CanExecute = !mainWindow.CanBeShown;
+            e.CanExecute = mainWindow.CanBeHidden;
         }
 
         private static void onHide(object sender, ExecutedRoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/UIExtensions.cs
@@ -95,6 +95,16 @@ static class UIExtensions
         window.Dispatcher.BeginInvoke(DispatcherPriority.Background, hideAction);
     }
 
+    public static void ShowOnTop(this Window window)
+    {
+        window.Show();
+        if (window.WindowState == WindowState.Minimized)
+        {
+            window.WindowState = WindowState.Normal;
+        }
+        window.Activate();
+    }
+
     public static void ClearUndoHistory(this TextBoxBase textBox)
     {
         textBox.IsUndoEnabled = false;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -88,7 +88,9 @@ namespace TogglDesktop
 
         public TutorialManager TutorialManager { get; private set; }
 
-        public bool CanBeShown => !this.IsVisible || this.WindowState == WindowState.Minimized;
+        public bool CanBeShown => !this.IsVisible || !this.IsActive;
+
+        public bool CanBeHidden => this.IsVisible && this.WindowState != WindowState.Minimized;
 
         #endregion
 
@@ -521,7 +523,14 @@ namespace TogglDesktop
 
         private void onGlobalShowKeyPressed(object sender, KeyPressedEventArgs e)
         {
-            this.togglVisibility();
+            if (this.CanBeShown)
+            {
+                this.ShowOnTop();
+            }
+            else
+            {
+                this.MinimizeToTray();
+            }
         }
 
         private void onGlobalStartKeyPressed(object sender, KeyPressedEventArgs e)
@@ -550,7 +559,14 @@ namespace TogglDesktop
 
         private void onTaskbarLeftMouseUp(object sender, RoutedEventArgs e)
         {
-            this.togglVisibility();
+            if (this.CanBeHidden)
+            {
+                this.MinimizeToTray();
+            }
+            else
+            {
+                this.ShowOnTop();
+            }
         }
 
         private void onTrayBalloonTipClicked(object sender, RoutedEventArgs e)
@@ -659,18 +675,6 @@ namespace TogglDesktop
             if (!fromApi)
             {
                 Toggl.SetManualMode(manualMode);
-            }
-        }
-
-        private void togglVisibility()
-        {
-            if (this.CanBeShown)
-            {
-                this.ShowOnTop();
-            }
-            else
-            {
-                this.MinimizeToTray();
             }
         }
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -42,13 +42,9 @@ namespace TogglDesktop
         private MiniTimerWindow miniTimer;
 
         private IMainView activeView;
-        private bool isInManualMode;
-        private bool isMiniTimerVisible;
-        private bool isTracking;
         private bool isResizingWithHandle;
         private bool closing;
         private string trackingTitle;
-        private WindowState previousWindowState;
         private string todaysDuration = "0 h 00 min";
 
         #endregion
@@ -86,16 +82,13 @@ namespace TogglDesktop
 
         #region properties
 
-        public bool IsTracking { get { return this.isTracking; } }
-        public bool IsInManualMode { get { return this.isInManualMode; } }
-        public bool IsMiniTimerVisible { get { return this.isMiniTimerVisible; } }
+        public bool IsTracking { get; private set; }
+        public bool IsInManualMode { get; private set; }
+        public bool IsMiniTimerVisible { get; private set; }
 
         public TutorialManager TutorialManager { get; private set; }
 
-        public bool CanBeShown
-        {
-            get { return !this.IsVisible || this.WindowState == WindowState.Minimized; }
-        }
+        public bool CanBeShown => !this.IsVisible || this.WindowState == WindowState.Minimized;
 
         #endregion
 
@@ -512,24 +505,7 @@ namespace TogglDesktop
         protected override void OnStateChanged(EventArgs e)
         {
             this.resizeHandle.ShowOnlyIf(this.WindowState != WindowState.Maximized);
-
-            // fix for when maximised window is activated from a different process using ShowWindow()
-            if (this.fixWindowStateOnShowWindow())
-                return;
-
-            this.previousWindowState = this.WindowState;
-
             base.OnStateChanged(e);
-        }
-
-        protected override void OnActivated(EventArgs e)
-        {
-            // fix for when the window is activated from a different process using ShowWindow()
-            this.fixVisibilityOnShowWindow();
-
-            //Toggl.SetWake();
-
-            base.OnActivated(e);
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -550,16 +526,16 @@ namespace TogglDesktop
 
         private void onGlobalStartKeyPressed(object sender, KeyPressedEventArgs e)
         {
-            if (this.isTracking)
+            if (this.IsTracking)
             {
-                using (Performance.Measure("stopping time entry from global short cut", this.isInManualMode))
+                using (Performance.Measure("stopping time entry from global short cut", this.IsInManualMode))
                 {
                     Toggl.Stop();
                 }
             }
             else
             {
-                using (Performance.Measure("starting time entry from global short cut, manual mode: {0}", this.isInManualMode))
+                using (Performance.Measure("starting time entry from global short cut, manual mode: {0}", this.IsInManualMode))
                 {
                     KeyboardShortcuts.StartTimeEntry(true);
                 }
@@ -653,7 +629,7 @@ namespace TogglDesktop
 
         public void SetMiniTimerVisible(bool visible, bool fromApi = false)
         {
-            this.isMiniTimerVisible = visible;
+            this.IsMiniTimerVisible = visible;
 
             this.togglMiniTimerVisibilityMenuItem.IsChecked = visible;
 
@@ -673,12 +649,12 @@ namespace TogglDesktop
 
         public void SetManualMode(bool manualMode, bool fromApi = false)
         {
-            this.isInManualMode = manualMode;
+            this.IsInManualMode = manualMode;
 
             this.togglManualModeMenuItem.IsChecked = manualMode;
 
-            this.timerEntryListView.SetManualMode(this.isInManualMode);
-            this.miniTimer.SetManualMode(this.isInManualMode);
+            this.timerEntryListView.SetManualMode(this.IsInManualMode);
+            this.miniTimer.SetManualMode(this.IsInManualMode);
 
             if (!fromApi)
             {
@@ -728,16 +704,6 @@ namespace TogglDesktop
             {
                 Toggl.Debug("Could not register show hotkey: " + e);
             }
-        }
-
-        public void ShowOnTop()
-        {
-            this.Show();
-            if (this.WindowState == WindowState.Minimized)
-            {
-                this.WindowState = WindowState.Normal;
-            }
-            this.Activate();
         }
 
         public void shutdown(int exitCode)
@@ -797,7 +763,7 @@ namespace TogglDesktop
         {
             Icon icon;
 
-            if (this.isTracking)
+            if (this.IsTracking)
             {
                 icon = isOnline
                     ? Properties.Resources.toggltray
@@ -817,7 +783,7 @@ namespace TogglDesktop
         {
             var tracking = timeEntry != null;
 
-            this.isTracking = tracking;
+            this.IsTracking = tracking;
 
             if (tracking)
             {
@@ -842,7 +808,7 @@ namespace TogglDesktop
                 }
 
 
-                if (this.isInManualMode)
+                if (this.IsInManualMode)
                     this.SetManualMode(false);
             }
             else
@@ -959,29 +925,6 @@ namespace TogglDesktop
             this.MinHeight = this.WindowHeaderHeight + activeView.MinHeight;
             this.MinWidth = activeView.MinWidth;
         }
-
-        private bool fixWindowStateOnShowWindow()
-        {
-            if (this.Visibility != Visibility.Visible)
-            {
-                if (this.previousWindowState == WindowState.Maximized && this.WindowState != WindowState.Maximized)
-                {
-                    this.WindowState = WindowState.Maximized;
-                    this.Visibility = Visibility.Visible;
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void fixVisibilityOnShowWindow()
-        {
-            if (this.Visibility != Visibility.Visible)
-            {
-                this.Visibility = Visibility.Visible;
-            }
-        }
-
 
         #endregion
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Win32.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Win32.cs
@@ -1,60 +1,11 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Text;
 // ReSharper disable InconsistentNaming
 
 namespace TogglDesktop
 {
 static class Win32
 {
-    [DllImport("user32.dll")]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, ref SearchData data);
-
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-    private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
-
-    [DllImport("User32")]
-    public static extern int SetForegroundWindow(IntPtr hwnd);
-
-    [DllImport("User32")]
-    public static extern bool ShowWindow(IntPtr hwnd, int cmdshow);
-
-    public const int SW_RESTORE = 9;
-
-    private delegate bool EnumWindowsProc(IntPtr hWnd, ref SearchData data);
-
-    private static bool EnumProc(IntPtr hWnd, ref SearchData data)
-    {
-        var sb = new StringBuilder(1024);
-        GetWindowText(hWnd, sb, sb.Capacity);
-        if (sb.ToString().Contains(data.Title))
-        {
-            data.hWnd = hWnd;
-            return false;    // Found the window
-        }
-        return true;
-    }
-
-    [DllImport("kernel32.dll")]
-    public static extern bool AttachConsole(int dwProcessId);
-
-    public const int ATTACH_PARENT_PROCESS = -1;
-
-    public static IntPtr SearchForWindow(string wndclass, string title)
-    {
-        var sd = new SearchData { Wndclass = wndclass, Title = title };
-        EnumWindows(EnumProc, ref sd);
-        return sd.hWnd;
-    }
-
-    private class SearchData
-    {
-        public string Wndclass;
-        public string Title;
-        public IntPtr hWnd;
-    }
-
     [DllImport("user32.dll")]
     public static extern int SendMessage(IntPtr hwnd, int msg, int wparam, int lparam);
 


### PR DESCRIPTION
### 📒 Description
Fix for the main window staying in the tray after restarting PC.
Removed some old code for securing a single instance of the application and replaced it with more concise and standard code.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fix for the main window staying in the tray after restarting PC
- Make "Show/Hide Toggl" bring the window to the front if it has no focus
- Removed the old mutex-based code for securing a single instance of the application in favor of a more standard implementation.

### 👫 Relationships
Closes #3285
Closes #3274
First point from #3148

### 🔎 Review hints
**Scenario 1**
- Run the app with argument "--minimize" (in Visual Studio you can specify it in Properties->Debug)
- While the app is in the tray, try to start the app once more (e.g. from Explorer)

Expected result:
- The app window should become focused

**Scenarios 2-5**
- Maximize/minimize/hide/set non-maximum size for the main window
- Try to start the app once more

Expected result:
- The app window should become focused

**Scenarios 6-8**
- Set up the global shortcut `Show/Hide Toggl` in Preferences
- Open the window but focus some other window / Hide the window / Minimize the window
- Press the shortcut `Show/Hide Toggl` that you've set up earlier

Expected result:
- The app window should become focused

**Try some other related scenarios that I could've forgotten**

