### PR TITLE
Create TE on click in Timeline 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -53,7 +53,7 @@ final class TimelineDashboardViewController: NSViewController {
     private lazy var activityHoverPopover: NSPopover = {
         let popover = NSPopover()
         popover.animates = false
-        popover.behavior = .transient
+        popover.behavior = .semitransient
         popover.contentViewController = activityHoverController
         activityHoverController.popover = popover
         return popover
@@ -61,7 +61,7 @@ final class TimelineDashboardViewController: NSViewController {
     private lazy var editorPopover: EditorPopover = {
         let popover = EditorPopover()
         popover.animates = false
-        popover.behavior = .transient
+        popover.behavior = .semitransient
         popover.prepareViewController()
         return popover
     }()
@@ -321,6 +321,10 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
 extension TimelineDashboardViewController: TimelineCollectionViewDelegate {
 
     func timelineShouldCreateEmptyEntry(with startTime: TimeInterval) {
-        
+        // Don't create new TE if one of Popover is active
+        guard !editorPopover.isShown, !activityHoverPopover.isShown, !timeEntryHoverPopover.isShown else { return }
+
+        // Create
+        startNewTimeEntry(at: startTime, ended: startTime + 1)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.swift
@@ -19,7 +19,7 @@ final class TimelineDashboardViewController: NSViewController {
 
     @IBOutlet weak var datePickerContainerView: NSView!
     @IBOutlet weak var recordSwitcher: OGSwitch!
-    @IBOutlet weak var collectionView: NSCollectionView!
+    @IBOutlet weak var collectionView: TimelineCollectionView!
     @IBOutlet weak var emptyLbl: NSTextField!
     @IBOutlet weak var emptyActivityLbl: NSTextField!
     @IBOutlet weak var emptyActivityLblPadding: NSLayoutConstraint!
@@ -157,7 +157,7 @@ extension TimelineDashboardViewController {
     }
 
     fileprivate func initCollectionView() {
-
+        collectionView.timelineDelegate = self
     }
 
     @objc private func handleDisplaySettingNotification(_ noti: Notification) {
@@ -313,5 +313,14 @@ extension TimelineDashboardViewController: TimelineDatasourceDelegate {
 
         editorPopover.animates = false
         editorPopover.show(relativeTo: cell.view.bounds, of: cell.view, preferredEdge: .maxX)
+    }
+}
+
+// MARK: TimelineCollectionViewDelegate
+
+extension TimelineDashboardViewController: TimelineCollectionViewDelegate {
+
+    func timelineShouldCreateEmptyEntry(with startTime: TimeInterval) {
+        
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDashboardViewController.xib
@@ -119,7 +119,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="369" height="410"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <collectionView selectable="YES" id="hht-dC-mpO">
+                                    <collectionView selectable="YES" id="hht-dC-mpO" customClass="TimelineCollectionView" customModule="TogglDesktop" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="369" height="410"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="ZtE-Ms-OYm">

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineDatasource.swift
@@ -90,6 +90,7 @@ final class TimelineDatasource: NSObject {
 
     func render(_ timeline: TimelineData) {
         self.timeline = timeline
+        flow.currentDate = Date(timeIntervalSince1970: timeline.start)
         collectionView.reloadData()
     }
 

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -150,6 +150,10 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
 
 extension TimelineFlowLayout {
 
+    public func convertTimestamp(from location: CGPoint) -> TimeInterval {
+        return 0
+    }
+
     private func calculateBlockSize(at indexPath: IndexPath) -> (y: CGFloat, height: CGFloat)? {
         guard let timestamp = flowDelegate?.timechunkForItem(at: indexPath) else {
             print("Missing timestamp for at \(indexPath)")

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -44,6 +44,7 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
     // MARK: Variables
 
     weak var flowDelegate: TimelineFlowLayoutDelegate?
+    var currentDate = Date()
     private var zoomLevel: TimelineDatasource.ZoomLevel = .x1
     private var timeLablesAttributes: [NSCollectionViewLayoutAttributes] = []
     private var timeEntryAttributes: [NSCollectionViewLayoutAttributes] = []
@@ -150,8 +151,17 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
 
 extension TimelineFlowLayout {
 
+    private var ratio: CGFloat {
+        // The ratio
+        // From the design, the size of time label + padding prepresents 1 hours or 2 hours (depend on zoomLevel)
+        // Get the ratio for later calculations
+        return (Constants.TimeLabel.Size.height + verticalPaddingTimeLabel) / CGFloat(zoomLevel.span)
+    }
+
     public func convertTimestamp(from location: CGPoint) -> TimeInterval {
-        return 0
+        let beginDay = Date.startOfDay(from: currentDate.timeIntervalSince1970)
+        let start = TimeInterval((location.y / ratio)) + beginDay
+        return start
     }
 
     private func calculateBlockSize(at indexPath: IndexPath) -> (y: CGFloat, height: CGFloat)? {
@@ -163,11 +173,6 @@ extension TimelineFlowLayout {
 
         // Length of time entry
         let span = CGFloat(timestamp.end - timestamp.start)
-
-        // The ratio
-        // From the design, the size of time label + padding prepresents 1 hours or 2 hours (depend on zoomLevel)
-        // Get the ratio for later calculations
-        let ratio = (Constants.TimeLabel.Size.height + verticalPaddingTimeLabel) / CGFloat(zoomLevel.span)
 
         // Ex: To calculate the height of the entry with X timestamp
         // Height = X * ratio

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/TimelineFlowLayout.swift
@@ -145,6 +145,12 @@ final class TimelineFlowLayout: NSCollectionViewFlowLayout {
         let height = CGFloat(numberOfTimeLabels) * (verticalPaddingTimeLabel + Constants.TimeLabel.Size.height)
         return CGSize(width: width, height: height)
     }
+
+    func isInTimeEntrySection(at location: CGPoint) -> Bool {
+        guard let timeLabelDivider = dividerAttributes.first,
+            let activityDivider = dividerAttributes.last else { return false }
+        return timeLabelDivider.frame.origin.x < location.x && location.x < activityDivider.frame.origin.x
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
@@ -1,0 +1,49 @@
+//
+//  TimelineCollectionView.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 9/9/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+protocol TimelineCollectionViewDelegate: class {
+
+    func timelineShouldCreateEmptyEntry(with startTime: TimeInterval)
+}
+
+final class TimelineCollectionView: NSCollectionView {
+
+    // MARK: Variables
+
+    weak var timelineDelegate: TimelineCollectionViewDelegate?
+
+    // MARK: View
+
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+        handleMouseClick(with: event)
+    }
+
+}
+
+// MARK: Private
+
+extension TimelineCollectionView {
+
+    fileprivate func handleMouseClick(with event: NSEvent) {
+        guard let flowLayout = collectionViewLayout as? TimelineFlowLayout else { return }
+
+        // Convert to CollectionView coordinator
+        let clickedPoint = convert(event.locationInWindow, from: nil)
+
+        // Single click and on empty space
+        guard event.clickCount == 1,
+            indexPathForItem(at: clickedPoint) == nil else { return }
+
+        // Get timestamp from click point, depend on zoom level and position
+        let timestamp = flowLayout.convertTimestamp(from: clickedPoint)
+        timelineDelegate?.timelineShouldCreateEmptyEntry(with: timestamp)
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Views/TimelineCollectionView.swift
@@ -42,6 +42,9 @@ extension TimelineCollectionView {
         guard event.clickCount == 1,
             indexPathForItem(at: clickedPoint) == nil else { return }
 
+        // Skip if the click is in Time Label and Activity section
+        guard flowLayout.isInTimeEntrySection(at: clickedPoint) else { return }
+
         // Get timestamp from click point, depend on zoom level and position
         let timestamp = flowLayout.convertTimestamp(from: clickedPoint)
         timelineDelegate?.timelineShouldCreateEmptyEntry(with: timestamp)

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		BA49912E22C0BA14008149D9 /* TimelineDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49912D22C0BA14008149D9 /* TimelineDateFormatter.swift */; };
 		BA4AEB9C22C217A4001A898D /* ResizablePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */; };
 		BA50ED8522705F9E008323FA /* CalendarFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */; };
+		BA5AC61623264651007E6C91 /* TimelineCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5AC61523264651007E6C91 /* TimelineCollectionView.swift */; };
 		BA6572A6224DFA6F00BA4C60 /* RGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A0224DFA6E00BA4C60 /* RGB.swift */; };
 		BA6572A7224DFA6F00BA4C60 /* HSBGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A1224DFA6E00BA4C60 /* HSBGen.swift */; };
 		BA6572A8224DFA6F00BA4C60 /* CurrentColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6572A2224DFA6F00BA4C60 /* CurrentColorView.swift */; };
@@ -795,6 +796,7 @@
 		BA49912D22C0BA14008149D9 /* TimelineDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineDateFormatter.swift; sourceTree = "<group>"; };
 		BA4AEB9B22C217A4001A898D /* ResizablePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizablePopover.swift; sourceTree = "<group>"; };
 		BA50ED8422705F9E008323FA /* CalendarFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarFlowLayout.swift; sourceTree = "<group>"; };
+		BA5AC61523264651007E6C91 /* TimelineCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineCollectionView.swift; sourceTree = "<group>"; };
 		BA6572A0224DFA6E00BA4C60 /* RGB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RGB.swift; sourceTree = "<group>"; };
 		BA6572A1224DFA6E00BA4C60 /* HSBGen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HSBGen.swift; sourceTree = "<group>"; };
 		BA6572A2224DFA6F00BA4C60 /* CurrentColorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentColorView.swift; sourceTree = "<group>"; };
@@ -1570,6 +1572,7 @@
 				BA24E791230BE50600B1D4B2 /* TimelineActivityHoverController.swift */,
 				BA24E792230BE50600B1D4B2 /* TimelineActivityHoverController.xib */,
 				BA1FFE70231FB0F300EAD9DC /* PanelSwitcherButton.swift */,
+				BA5AC61523264651007E6C91 /* TimelineCollectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2178,6 +2181,7 @@
 				BAD0E0BD22C49BAC009F5A83 /* TimelineDividerView.swift in Sources */,
 				BAB818C3228D5847008C2367 /* DescriptionAutoCompleteTextField.swift in Sources */,
 				BA13D2112269BE2F00EB3833 /* DateInfo.swift in Sources */,
+				BA5AC61623264651007E6C91 /* TimelineCollectionView.swift in Sources */,
 				BA13D20E2269BAA600EB3833 /* DateCellViewItem.swift in Sources */,
 				BA47920122F0479200E24F79 /* TimerContainerBox.swift in Sources */,
 				BA712EC821BF9F1200A2D8DD /* UndoStack.swift in Sources */,


### PR DESCRIPTION
### 📒 Description
This PR introduces the ability to create TimeEntry by mouse when clicking on Empty space of Timeline view. 

Some behaviors: 
- [x] Able to click to create TE in empty space of Timeline Time Entry
- [x] Click on existing TE or Activity doesn't execute the feature
- [x] Only able to create TE when clicking on Time Entry section (Click on Time Label or Activity Section won't do)
- [x] If there is any Popover is appear, click on Empty space don't create TE -> It will close the current Popover.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce TimelineCollection view and handle the mouse click
- [x] Improve TimelineFlowLayout for converting the Location -> Timestamp 
- [x] Create TE with given timestamp_start

### 👫 Relationships
Closes #3288

### 🔎 Review hints
#### Create TE
- Able to create TE and the Editor open when clicking on Empty Space -> 💯 
- Click on Time Label section and Activity section won't do -> 💯 
- Don't create when clicking on Empty Space but there is any Popover, which is opening -> 💯 
- Zoom in/out and create TE -> The timestamp should match -> 💯 

![2019-09-09 16 31 20](https://user-images.githubusercontent.com/5878421/64521015-6c8be600-d321-11e9-8e67-e0522a91da47.gif)


