### PR TITLE
Limited the maximum height of Activity Timeline 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineActivity.swift
+++ b/src/ui/osx/TogglDesktop/Feature/Timeline/Models/TimelineActivity.swift
@@ -64,7 +64,8 @@ final class TimelineActivity {
     // MARK: Public
 
     func timechunk() -> TimeChunk? {
-        return TimeChunk(start: started, end: ended)
+        let newEnded = min(started + 900, ended) // Draw at max 15 mins 
+        return TimeChunk(start: started, end: newEnded)
     }
 
     private static func getColor(from lightest: NSColor, darkest: NSColor, ratio: CGFloat) -> NSColor {


### PR DESCRIPTION
### 📒 Description
This PR introduces small fix to make sure that the Activity Timeline doesn't draw more than 15 chunk time.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Chunk time of each activity should be 15 min at max

### 👫 Relationships
Closes #3295

### 🔎 Review hints
1. Start Toggl and enable Timeline Recording 
2. Try play around Safari or certain app within more than 15 mins and try not to switch another app. (Another hack is that, open db at `/Users/<username>/Library/Application Support/Kopsik/development/kopsik.db`) and change the ended value
3. Back to Toggl and check, if the time is bigger than 15mins, but the Activity is drawing at 15 min -> 💯 

<img width="646" alt="Screen Shot 2019-09-10 at 14 41 23" src="https://user-images.githubusercontent.com/5878421/64594413-29417e00-d3da-11e9-82a1-fb6e19cfd7f3.png">
