### PR TITLE
Fix Editor couldn't update data from auto complete (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -33,6 +33,7 @@ static NSString *kFrameKey = @"frame";
 @property (nonatomic, copy) NSString *lastSelectedGUID;
 @property (nonatomic, strong) TimeEntryEmptyView *emptyView;
 @property (nonatomic, strong) EditorPopover *timeEntrypopover;
+@property (nonatomic, assign) BOOL isOpening;
 @end
 
 @implementation TimeEntryListViewController
@@ -68,10 +69,19 @@ extern void *ctx;
 - (void)viewDidAppear
 {
 	[super viewDidAppear];
+	self.isOpening = YES;
 	[self.collectionView reloadData];
 }
 
-- (void)initCommon {
+- (void)viewWillDisappear
+{
+	[super viewWillDisappear];
+	self.isOpening = NO;
+}
+
+- (void)initCommon
+{
+	self.isOpening = YES;
 	self.addedHeight = 0;
 	self.runningEdit = NO;
 }
@@ -281,6 +291,12 @@ extern void *ctx;
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");
 
 	NSLog(@"TimeEntryListViewController displayTimeEntryEditor, thread %@", [NSThread currentThread]);
+
+	// Skip render if need
+	if (!self.isOpening)
+	{
+		return;
+	}
 
 	TimeEntryViewItem *timeEntry = cmd.timeEntry;
 	if (cmd.open)


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix to make sure that the Editor in Timeline will get latest TE data.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue

### 🤯 List of changes
- [x] Add `isOpen` key in TimeEntryListViewController and TimelineViewController to update Editor if it's presenting
- [x] Observe the editor notification from library and update the content (Same approach how) 

### 👫 Relationships
Closes #3300

### 🔎 Review hints
1. Select any TE in Timeline to open Editor
2. Try select TE in description auto-complete item in Editor 
- If the TimeEntry Bar in Timeline update correctly -> 💯 
- If the Editor is updated correctly (Project, Description, Color, Tag) -> 💯 
- Switch back to TimeEntry List -> Double check this TE -> If the data is correct -> 💯


