### PR TITLE
Fix crash on Google Login when using proxy

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -140,6 +140,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
### 📒 Description
Applies user proxy settings which are set in Preferences to Google authentication requests.
Previously, proxy settings were applied only to requests done by the Library.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #2276

### 🔎 Review hints
1. Use a proxy server by setting address and port in Windows settings (e.g. for Win10: Settings->Network&Internet->Proxy or just press Start and search for Proxy).
Proxy settings should require login and password.
If you need some proxy server credentials you can ask me.
2. Try logging in with Google with different proxy settings in Preferences. It should work if settings are correct, or fail (in the case of "Use system proxy settings"), but not crash.
3. In addition, please try signing up with Google when the proxy is on, try logging in with Google when the proxy is off and try normal login.