### PR TITLE
Fix crash when showing notification

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -228,6 +228,7 @@
     <Compile Include="ui\Experiments\ExperimentParameters.cs" />
     <Compile Include="ui\KeyboardShortcuts.cs" />
     <Compile Include="ui\Experiments\implementations\ExperimentHacks.cs" />
+    <Compile Include="ui\NotificationExtensions.cs" />
     <Compile Include="ui\Theme.cs" />
     <Compile Include="ui\ThemeResourceDictionary.cs" />
     <Compile Include="ui\ThemeTypes.cs" />

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/NotificationExtensions.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/NotificationExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using Hardcodet.Wpf.TaskbarNotification;
+
+namespace TogglDesktop
+{
+    public static class NotificationExtensions
+    {
+        public static bool ShowNotification(this TaskbarIcon icon, UIElement element, PopupAnimation animation,
+            TimeSpan? timeout = null)
+        {
+            try
+            {
+                icon.ShowCustomBalloon(element, animation, (int?)timeout?.TotalMilliseconds);
+            }
+            catch (Exception e)
+            {
+                BugsnagService.NotifyBugsnag(new Exception("Failed to show a custom notification", e));
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerNotification.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/AutotrackerNotification.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using Hardcodet.Wpf.TaskbarNotification;
@@ -26,13 +27,13 @@ namespace TogglDesktop
             if (this.TryBeginInvoke(this.onAutotrackerNotification, projectName, projectId, taskId))
                 return;
 
-            this.Message = string.Format("Track {0}?", projectName);
+            this.Message = $"Track {projectName}?";
             this.projectId = projectId;
             this.taskId = taskId;
 
             this.RemoveFromParent();
 
-            this.icon.ShowCustomBalloon(this, PopupAnimation.Slide, 6000);
+            this.icon.ShowNotification(this, PopupAnimation.Slide, TimeSpan.FromSeconds(6));
         }
 
         private void onStartButtonClick(object sender, RoutedEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/PomodoroNotification.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/PomodoroNotification.xaml.cs
@@ -30,9 +30,14 @@ namespace TogglDesktop
 
             this.RemoveFromParent();
 
-            this.icon.ShowCustomBalloon(this, PopupAnimation.Slide, null);
-
-            System.Media.SystemSounds.Asterisk.Play();
+            if (!icon.ShowNotification(this, PopupAnimation.Slide, null))
+            {
+                icon.ShowBalloonTip(title, informativetext, Properties.Resources.toggl, largeIcon: true);
+            }
+            else
+            {
+                System.Media.SystemSounds.Asterisk.Play();
+            }
         }
 
         private void onDisplayPomodoroBreak(string title, string informativetext)
@@ -45,9 +50,14 @@ namespace TogglDesktop
 
             this.RemoveFromParent();
 
-            this.icon.ShowCustomBalloon(this, PopupAnimation.Slide, null);
-
-            System.Media.SystemSounds.Asterisk.Play();
+            if (!icon.ShowNotification(this, PopupAnimation.Slide, null))
+            {
+                icon.ShowBalloonTip(title, informativetext, Properties.Resources.toggl, largeIcon: true);
+            }
+            else
+            {
+                System.Media.SystemSounds.Asterisk.Play();
+            }
         }
 
         private void onNotificationMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ReminderNotification.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/ReminderNotification.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using Hardcodet.Wpf.TaskbarNotification;
@@ -28,7 +29,10 @@ namespace TogglDesktop
 
             this.RemoveFromParent();
 
-            icon.ShowCustomBalloon(this, PopupAnimation.Slide, 6000);
+            if (!icon.ShowNotification(this, PopupAnimation.Slide, TimeSpan.FromSeconds(10)))
+            {
+                icon.ShowBalloonTip(title, informative_text, Properties.Resources.toggl, largeIcon: true);
+            }
         }
 
         private void onNotificationMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -230,7 +230,6 @@ namespace TogglDesktop
             Toggl.OnTimeEntryEditor += this.onTimeEntryEditor;
             Toggl.OnTimeEntryList += this.onTimeEntryList;
             Toggl.OnOnlineState += this.onOnlineState;
-            //Toggl.OnReminder += this.onReminder;
             Toggl.OnURL += this.onURL;
             Toggl.OnUserTimeEntryStart += this.onUserTimeEntryStart;
             Toggl.OnRunningTimerState += this.onRunningTimerState;
@@ -364,14 +363,6 @@ namespace TogglDesktop
                     Toggl.ShowErrorAndNotify("Wasn't able to open the browser", e);
                 }
             }
-        }
-
-        private void onReminder(string title, string informativeText)
-        {
-            if (this.TryBeginInvoke(this.onReminder, title, informativeText))
-                return;
-
-            this.taskbarIcon.ShowBalloonTip(title, informativeText, Properties.Resources.toggl, largeIcon: true);
         }
 
         private void onOnlineState(Toggl.OnlineState state)


### PR DESCRIPTION
### 📒 Description
Fix crash when showing notification

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Catch exceptions when showing notification
- Fallback to Windows native notification in case custom notification fails
- Increase reminder notification timeout from 6 sec to 10 sec (based on my subjective feeling that 6 seconds is not enough to click Start when you're caught off guard by the notification)

### 👫 Relationships
Closes #3303

### 🔎 Review hints
Steps to reproduce are unknown, so test that Reminder, Pomodoro/Pomodoro break, and Autotracker notifications still work as before.