### PR TITLE
Fix crash when adding idle time as new entry

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/MainWindow.xaml.cs
@@ -870,6 +870,12 @@ namespace TogglDesktop
             if (this.editPopup == null || (!forceUpdate && !this.editPopup.IsVisible))
                 return;
 
+            if (this.ActualHeight.DoubleEquals(0.0))
+            {
+                // make sure the window was shown at least once to be able to use ActualHeight and ActualWidth properties
+                this.Show();
+            }
+
             if (this.WindowState == WindowState.Maximized)
             {
                 Win32.Rectangle bounds;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/utilities/Utils.cs
@@ -412,5 +412,14 @@ public static class Utils
         public static string Bitness() => Environment.Is64BitProcess ? "(64-bit)" : "(32-bit)";
 
         #endregion environment
-}
+
+        #region numeric
+
+        public static bool DoubleEquals(this double d1, double d2, double epsilon = 1e-6)
+        {
+            return Math.Abs(d1 - d2) < epsilon;
+        }
+
+        #endregion
+    }
 }


### PR DESCRIPTION
### 📒 Description
Fix crash when adding idle time as new entry.
The issue was due to the usage of `ActualHeight` and `ActualWidth` properties before the window was shown even once.

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Closes #3305.

### 🔎 Review hints
STR in #3305.

