### PR TITLE
Focus on Editor when clicking on Timer Bar

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -22,6 +22,7 @@
 #import "AutoCompleteTable.h"
 #import <Carbon/Carbon.h>
 #import "Utils.h"
+#import "ClickableImageView.h"
 
 typedef enum : NSUInteger
 {
@@ -30,7 +31,7 @@ typedef enum : NSUInteger
 	DisplayModeInput,
 } DisplayMode;
 
-@interface TimerEditViewController ()
+@interface TimerEditViewController () <ClickableImageViewDelegate>
 @property (weak) IBOutlet NSBoxClickable *manualBox;
 @property (weak) IBOutlet NSBoxClickable *mainBox;
 @property (weak) IBOutlet NSTextFieldDuration *durationTextField;
@@ -38,7 +39,7 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet ProjectTextField *projectTextField;
 @property (weak) IBOutlet AutoCompleteInput *descriptionLabel;
 @property (weak) IBOutlet NSImageView *billableFlag;
-@property (weak) IBOutlet NSImageView *tagFlag;
+@property (weak) IBOutlet ClickableImageView *tagFlag;
 @property (weak) IBOutlet NSButton *addEntryBtn;
 @property (weak) IBOutlet NSView *contentContainerView;
 @property (weak) IBOutlet TimerContainerBox *autocompleteContainerView;
@@ -146,6 +147,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.autoCompleteInput.responderDelegate = self.autocompleteContainerView;
 
 	self.descriptionLabel.delegate = self;
+	self.tagFlag.delegate = self;
 }
 
 - (void)viewDidAppear
@@ -338,6 +340,10 @@ NSString *kInactiveTimerColor = @"#999999";
 	else if (sender == self.durationTextField)
 	{
 		focusField = kFocusedFieldNameDuration;
+	}
+	else if (sender == self.tagFlag)
+	{
+		focusField = kFocusedFieldNameTag;
 	}
 
 	toggl_edit(ctx, [self.time_entry.GUID UTF8String], false, focusField);
@@ -733,31 +739,9 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 }
 
-- (void)mouseUp:(NSEvent *)event
+- (void)imageViewOnClick:(id)sender
 {
-    [super mouseUp:event];
-	if (!self.time_entry.isRunning && self.displayMode != DisplayModeTimer)
-	{
-		return;
-	}
-
-	NSPoint globalLocation = [NSEvent mouseLocation];
-	NSRect rect = [self.view.window convertRectFromScreen:NSMakeRect(globalLocation.x, globalLocation.y, 0, 0)];
-	NSPoint windowLocation = rect.origin;
-	NSPoint mouseLocation = [self.contentContainerView convertPoint:windowLocation fromView:nil];
-	NSString *GUID = self.time_entry.GUID;
-
-	if (NSPointInRect(mouseLocation, self.projectTextField.frame) || NSPointInRect(mouseLocation, self.dotImageView.frame))
-	{
-		toggl_edit(ctx, [GUID UTF8String], false, kFocusedFieldNameProject);
-		return;
-	}
-
-	if (NSPointInRect(mouseLocation, self.descriptionLabel.frame))
-	{
-		toggl_edit(ctx, [GUID UTF8String], false, kFocusedFieldNameDescription);
-		return;
-	}
+	[self textFieldClicked:sender];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -733,4 +733,31 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 }
 
+- (void)mouseUp:(NSEvent *)event
+{
+    [super mouseUp:event];
+	if (!self.time_entry.isRunning && self.displayMode != DisplayModeTimer)
+	{
+		return;
+	}
+
+	NSPoint globalLocation = [NSEvent mouseLocation];
+	NSRect rect = [self.view.window convertRectFromScreen:NSMakeRect(globalLocation.x, globalLocation.y, 0, 0)];
+	NSPoint windowLocation = rect.origin;
+	NSPoint mouseLocation = [self.contentContainerView convertPoint:windowLocation fromView:nil];
+	NSString *GUID = self.time_entry.GUID;
+
+	if (NSPointInRect(mouseLocation, self.projectTextField.frame) || NSPointInRect(mouseLocation, self.dotImageView.frame))
+	{
+		toggl_edit(ctx, [GUID UTF8String], false, kFocusedFieldNameProject);
+		return;
+	}
+
+	if (NSPointInRect(mouseLocation, self.descriptionLabel.frame))
+	{
+		toggl_edit(ctx, [GUID UTF8String], false, kFocusedFieldNameDescription);
+		return;
+	}
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.xib
@@ -168,7 +168,7 @@
                                     <stackView distribution="equalSpacing" orientation="horizontal" alignment="centerY" spacing="5" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IPz-wJ-rvs">
                                         <rect key="frame" x="235" y="23" width="39" height="17"/>
                                         <subviews>
-                                            <imageView translatesAutoresizingMaskIntoConstraints="NO" id="5nL-Cd-iWe">
+                                            <imageView translatesAutoresizingMaskIntoConstraints="NO" id="5nL-Cd-iWe" customClass="ClickableImageView">
                                                 <rect key="frame" x="0.0" y="0.0" width="17" height="17"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="17" id="MC3-bx-7fi"/>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		BA014050225710FD000E5B91 /* TagAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA01404F225710FD000E5B91 /* TagAutoCompleteTextField.swift */; };
 		BA01405222571199000E5B91 /* TagTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA01405122571199000E5B91 /* TagTokenView.swift */; };
 		BA014054225711A3000E5B91 /* TagTokenView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA014053225711A3000E5B91 /* TagTokenView.xib */; };
+		BA01E8A1232F77B3006B93EC /* ClickableImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = BA01E8A0232F77B3006B93EC /* ClickableImageView.m */; };
 		BA03725521FE9FD400FC277B /* FlatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA03725421FE9FD400FC277B /* FlatButton.swift */; };
 		BA03729D21FED85700FC277B /* NSView+Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA03729C21FED85700FC277B /* NSView+Xib.swift */; };
 		BA053659225DDDBB00C26E1F /* CustomFocusRingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA053658225DDDBB00C26E1F /* CustomFocusRingButton.swift */; };
@@ -690,6 +691,8 @@
 		BA01404F225710FD000E5B91 /* TagAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BA01405122571199000E5B91 /* TagTokenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTokenView.swift; sourceTree = "<group>"; };
 		BA014053225711A3000E5B91 /* TagTokenView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TagTokenView.xib; sourceTree = "<group>"; };
+		BA01E89F232F77B3006B93EC /* ClickableImageView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ClickableImageView.h; sourceTree = "<group>"; };
+		BA01E8A0232F77B3006B93EC /* ClickableImageView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClickableImageView.m; sourceTree = "<group>"; };
 		BA03725421FE9FD400FC277B /* FlatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatButton.swift; sourceTree = "<group>"; };
 		BA03729C21FED85700FC277B /* NSView+Xib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Xib.swift"; sourceTree = "<group>"; };
 		BA053658225DDDBB00C26E1F /* CustomFocusRingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFocusRingButton.swift; sourceTree = "<group>"; };
@@ -1082,6 +1085,8 @@
 				BA08E086222E709C0075F68E /* ProjectTextField.m */,
 				745126B419A28AA500390F47 /* Reachability.h */,
 				745126B519A28AA600390F47 /* Reachability.m */,
+				BA01E89F232F77B3006B93EC /* ClickableImageView.h */,
+				BA01E8A0232F77B3006B93EC /* ClickableImageView.m */,
 			);
 			name = ui;
 			path = test2;
@@ -1988,6 +1993,7 @@
 				7424949E17F1E3D20030121C /* UIEvents.m in Sources */,
 				BA13D2152269C01500EB3833 /* Date+Utils.swift in Sources */,
 				BAAF56A02223DF9A003D0D73 /* VertificalTimeEntryFlowLayout.swift in Sources */,
+				BA01E8A1232F77B3006B93EC /* ClickableImageView.m in Sources */,
 				C5CB7F0417F43EE100A2AEB1 /* TimeEntryCell.m in Sources */,
 				C5DA1FBF17F1B08A001C4565 /* MainWindowController.m in Sources */,
 				BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/test2/ClickableImageView.h
+++ b/src/ui/osx/TogglDesktop/test2/ClickableImageView.h
@@ -1,0 +1,25 @@
+//
+//  ClickableImageView.h
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 9/16/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ClickableImageViewDelegate <NSObject>
+
+- (void)imageViewOnClick:(id)sender;
+
+@end
+
+@interface ClickableImageView : NSImageView
+
+@property (weak, nonatomic) id<ClickableImageViewDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ui/osx/TogglDesktop/test2/ClickableImageView.m
+++ b/src/ui/osx/TogglDesktop/test2/ClickableImageView.m
@@ -1,0 +1,18 @@
+//
+//  ClickableImageView.m
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 9/16/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+#import "ClickableImageView.h"
+
+@implementation ClickableImageView
+
+- (void)mouseDown:(NSEvent *)theEvent
+{
+	[self.delegate imageViewOnClick:self];
+}
+
+@end

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -31,6 +31,11 @@
 	self.renderClient = YES;
 }
 
+- (void)mouseDown:(NSEvent *)theEvent
+{
+	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
+}
+
 - (void)setAttributedStringValue:(NSAttributedString *)attributedStringValue
 {
 	[super setAttributedStringValue:attributedStringValue];
@@ -127,6 +132,7 @@
 - (void)setTextColor:(NSColor *)textColor
 {
 	NSColor *visibleColor = [textColor visibleColor];
+
 	[super setTextColor:visibleColor];
 }
 


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix that we can click on Timer Bar to open Editor and focus on specific fields.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Introduce ClickableImageView 
- [x] Logic for detect mouse down (same old approach) and open Editor with specific focus fields. 

### 👫 Relationships
Closes #3245

### 🔎 Review hints
1. Start any TE
2. Click on Description, Project label and Tag icon on Timer bar -> Editor opens and focus on Description, Project Textfield or Tag view -> 💯 
