### PR TITLE
Remove recursion from clearing generic view items

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -466,7 +466,7 @@ void GUI::DisplayTags(const std::vector<view::Generic> list) {
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_tags_(first);
-    view_item_clear(first);
+    view_list_clear(first);
 }
 
 void GUI::DisplayAutotrackerRules(
@@ -508,7 +508,7 @@ void GUI::DisplayClientSelect(
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_client_select_(first);
-    view_item_clear(first);
+    view_list_clear(first);
 }
 
 void GUI::DisplayWorkspaceSelect(
@@ -517,7 +517,7 @@ void GUI::DisplayWorkspaceSelect(
 
     TogglGenericView *first = generic_to_view_item_list(list);
     on_display_workspace_select_(first);
-    view_item_clear(first);
+    view_list_clear(first);
 }
 
 void GUI::DisplayTimeEntryEditor(

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -158,13 +158,15 @@ void view_item_clear(TogglGenericView *item) {
     free(item->WorkspaceName);
     item->WorkspaceName = nullptr;
 
-    if (item->Next) {
-        TogglGenericView *next =
-            reinterpret_cast<TogglGenericView *>(item->Next);
-        view_item_clear(next);
-    }
-
     delete item;
+}
+
+void view_list_clear(TogglGenericView *first) {
+    while (first) {
+        TogglGenericView *next = reinterpret_cast<TogglGenericView*>(first->Next);
+        view_item_clear(first);
+        first = next;
+    }
 }
 
 void country_item_clear(TogglCountryView *item) {

--- a/src/toggl_api_private.h
+++ b/src/toggl_api_private.h
@@ -60,6 +60,8 @@ TogglAutocompleteView *autocomplete_item_init(
 
 void view_item_clear(TogglGenericView *item);
 
+void view_list_clear(TogglGenericView *first);
+
 void autocomplete_item_clear(TogglAutocompleteView *item);
 
 TogglCountryView *country_list_init(


### PR DESCRIPTION
### 📒 Description
Fixes a crash with a large number of tags when we reached the end of the stack and the app crashed. We could probably consider doing the same for all views but this should also be fixed by the library overhaul

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Large tag lists no longer make the app crash

### 👫 Relationships
Fixes #2787

### 🔎 Review hints
Check if the workspace with a large number of tags crashes or not. Also check if Displaying of clients and workspaces works right, too.

