### PR TITLE
Added start/continue/stop menu items to dock menu

### DIFF
--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -907,6 +907,21 @@ void *ctx;
 	[self.runningTimeEntryMenuItem setTitle:@"Timer is not tracking"];
 }
 
+- (NSMenu *)applicationDockMenu:(NSApplication *)sender {
+	NSMenu *menu = [[NSMenu alloc] init];
+
+	[menu addItemWithTitle:@"Start New"
+					action:@selector(onNewMenuItem:)
+			 keyEquivalent:@"n"].tag = kMenuItemTagNew;
+	[menu addItemWithTitle:@"Continue Latest"
+					action:@selector(onContinueMenuItem:)
+			 keyEquivalent:@"o"].tag = kMenuItemTagContinue;
+	[menu addItemWithTitle:@"Stop Timer"
+					action:@selector(onStopMenuItem:)
+			 keyEquivalent:@"s"].tag = kMenuItemTagStop;
+	return menu;
+}
+
 - (void)createStatusItem
 {
 	NSAssert([NSThread isMainThread], @"Rendering stuff should happen on main thread");


### PR DESCRIPTION
### 📒 Description
Adds `Start New`, `Continue Latest`, `Stop Timer` items to Dock menu

![Screenshot 2019-09-17 at 13 20 50](https://user-images.githubusercontent.com/842229/65033674-34eaf280-d94e-11e9-946d-9883bef897a7.png)


### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3314

### 🔎 Review hints
- Start app and open dock menu

Test that if timer is not running `Stop timer` item is disabled

