### PR TITLE
Fix issues with database insert triggering instead of update

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -2162,7 +2162,7 @@ error Database::saveModel(
             logger().debug(ss.str());
             if (model->ID()) {
                 *session_ <<
-                          "insert into time_entries(id, uid, description, "
+                          "insert or replace into time_entries(id, uid, description, "
                           "wid, guid, pid, tid, billable, "
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "
@@ -2196,7 +2196,7 @@ error Database::saveModel(
                           now;
             } else {
                 *session_ <<
-                          "insert into time_entries(uid, description, wid, "
+                          "insert or replace into time_entries(uid, description, wid, "
                           "guid, pid, tid, billable, "
                           "duronly, ui_modified_at, "
                           "start, stop, duration, "


### PR DESCRIPTION
### 📒 Description
Changes database clause logic to handle insert conflict by just updating the data.

### 🕶️ Types of changes

**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships

Closes #2946

### 🔎 Review hints
Comment out `database.cc` line 2242
`model->SetLocalID(local_id);`

This creates a situation that makes it trigger insert when actually it should be update.

With this change there should not be any issues as when conflict occurs update is automatically triggered.



