### PR TITLE
Use UIModifiedAt and UpdatedAt comparison to detect unsynced items

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -1969,7 +1969,7 @@ error Database::loadTimeEntriesFromSQLStatement(
                 } else {
                     model->SetValidationError(rs[19].convert<std::string>());
                 }
-                if (model->UIModifiedAt() != model->UpdatedAt()) {
+                if (model->UIModifiedAt() > model->UpdatedAt()) {
                     model->SetUnsynced();
                     model->SetDirty();
                 } else {

--- a/src/database.cc
+++ b/src/database.cc
@@ -1969,7 +1969,13 @@ error Database::loadTimeEntriesFromSQLStatement(
                 } else {
                     model->SetValidationError(rs[19].convert<std::string>());
                 }
-                model->ClearDirty();
+                if (model->UIModifiedAt() != model->UpdatedAt()) {
+                    model->SetUnsynced();
+                    model->SetDirty();
+                } else {
+                    model->ClearDirty();
+                }
+
                 list->push_back(model);
                 more = rs.moveNext();
             }

--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -457,8 +457,8 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
     SetBillable(data["billable"].asBool());
     SetDurOnly(data["duronly"].asBool());
     SetUpdatedAtString(data["at"].asString());
+    SetUIModifiedAt(Formatter::Parse8601(data["at"].asString()));
 
-    SetUIModifiedAt(0);
     ClearUnsynced();
 }
 


### PR DESCRIPTION
### 📒 Description
We use `UIModifiedAt` and `UpdatedAt` to detect if time entry has been synced.

We currently use `UIModifiedAt` to keep the timestamp of the last UI changes made locally

We currently use `UpdatedAt` to keep the timestamp of the moment data was saved to the server. 

If sync was success these should be same as we update the `UIModifiedAt` to be same as the `UpdatedAt`. If they are different this means that UI has been changed later and the changes have not been synced to the servers.

Marking the time entry `Dirty` means that it needs to be synced. Doing this right after loading the data from the database will make it sync faster

### 🕶️ Types of changes

**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships
Alternative solution to #3258 

Closes #3128

### 🔎 Review hints
- Go offline
- Create time entries
- See that they are marked unsynced
- Stay offline and restart app
- Unsynced items are marked as unsynced right away after app start

