### PR TITLE
Avoid using recursion to clear any View items 

### DIFF
--- a/src/gui.cc
+++ b/src/gui.cc
@@ -100,7 +100,7 @@ void GUI::DisplayCountries(
     }
     TogglCountryView *first = country_list_init(items);
     on_display_countries_(first);
-    country_item_clear(first);
+    country_list_clear(first);
 }
 
 void GUI::DisplaySyncState(const Poco::Int64 state) {
@@ -370,7 +370,7 @@ void GUI::DisplayTimeEntryAutocomplete(
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_time_entry_autocomplete_(first);
-    autocomplete_item_clear(first);
+    autocomplete_list_clear(first);
 }
 
 void GUI::DisplayHelpArticles(
@@ -383,7 +383,7 @@ void GUI::DisplayHelpArticles(
 
     TogglHelpArticleView *first = help_article_list_init(articles);
     on_display_help_articles_(first);
-    help_article_clear(first);
+    help_article_list_clear(first);
 }
 
 void GUI::DisplayMinitimerAutocomplete(
@@ -392,7 +392,7 @@ void GUI::DisplayMinitimerAutocomplete(
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_mini_timer_autocomplete_(first);
-    autocomplete_item_clear(first);
+    autocomplete_list_clear(first);
 }
 
 void GUI::DisplayProjectAutocomplete(
@@ -401,7 +401,7 @@ void GUI::DisplayProjectAutocomplete(
 
     TogglAutocompleteView *first = autocomplete_list_init(items);
     on_display_project_autocomplete_(first);
-    autocomplete_item_clear(first);
+    autocomplete_list_clear(first);
 }
 
 void GUI::DisplayTimeEntryList(const bool open,
@@ -450,7 +450,7 @@ void GUI::DisplayTimeEntryList(const bool open,
 
     on_display_time_entry_list_(open, first, show_load_more_button);
 
-    time_entry_view_item_clear(first);
+    time_entry_view_list_clear(first);
 
     stopwatch.stop();
     {
@@ -499,7 +499,7 @@ void GUI::DisplayAutotrackerRules(
     }
     delete[] title_list;
 
-    autotracker_view_item_clear(first);
+    autotracker_view_list_clear(first);
 }
 
 void GUI::DisplayClientSelect(
@@ -534,7 +534,7 @@ void GUI::DisplayTimeEntryEditor(
     on_display_time_entry_editor_(open, view, field_s);
     free(field_s);
 
-    time_entry_view_item_clear(view);
+    time_entry_view_list_clear(view);
 }
 
 void GUI::DisplayURL(const std::string URL) {
@@ -595,7 +595,7 @@ void GUI::DisplayTimerState(
 
     TogglTimeEntryView *view = time_entry_view_item_init(te);
     on_display_timer_state_(view);
-    time_entry_view_item_clear(view);
+    time_entry_view_list_clear(view);
 
     logger().debug("DisplayTimerState");
 }

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -74,15 +74,15 @@ void autocomplete_item_clear(TogglAutocompleteView *item) {
     free(item->WorkspaceName);
     item->WorkspaceName = nullptr;
 
-    if (item->Next) {
-        TogglAutocompleteView *next =
-            reinterpret_cast<TogglAutocompleteView *>(item->Next);
-        poco_check_ptr(next);
-        autocomplete_item_clear(next);
-        item->Next = nullptr;
-    }
-
     delete item;
+}
+
+void autocomplete_list_clear(TogglAutocompleteView *first) {
+    while (first) {
+        TogglAutocompleteView *next = reinterpret_cast<TogglAutocompleteView *>(first->Next);
+        autocomplete_item_clear(first);
+        first = next;
+    }
 }
 
 TogglGenericView *generic_to_view_item_list(
@@ -135,13 +135,15 @@ void autotracker_view_item_clear(TogglAutotrackerRuleView *view) {
     free(view->ProjectAndTaskLabel);
     view->ProjectAndTaskLabel = nullptr;
 
-    if (view->Next) {
-        TogglAutotrackerRuleView *next =
-            reinterpret_cast<TogglAutotrackerRuleView *>(view->Next);
-        autotracker_view_item_clear(next);
-    }
-
     delete view;
+}
+
+void autotracker_view_list_clear(TogglAutotrackerRuleView *first) {
+    while (first) {
+        TogglAutotrackerRuleView *next = reinterpret_cast<TogglAutotrackerRuleView *>(first->Next);
+        autotracker_view_item_clear(first);
+        first = next;
+    }
 }
 
 void view_item_clear(TogglGenericView *item) {
@@ -185,13 +187,15 @@ void country_item_clear(TogglCountryView *item) {
     free(item->VatRegex);
     item->VatRegex = nullptr;
 
-    if (item->Next) {
-        TogglCountryView *next =
-            reinterpret_cast<TogglCountryView *>(item->Next);
-        country_item_clear(next);
-    }
-
     delete item;
+}
+
+void country_list_clear(TogglCountryView *first) {
+    while (first) {
+        TogglCountryView *next = reinterpret_cast<TogglCountryView *>(first->Next);
+        country_item_clear(first);
+        first = next;
+    }
 }
 
 std::string to_string(const char_t *s) {
@@ -392,13 +396,6 @@ void time_entry_view_item_clear(
         item->Error = nullptr;
     }
 
-    if (item->Next) {
-        TogglTimeEntryView *next =
-            reinterpret_cast<TogglTimeEntryView *>(item->Next);
-        time_entry_view_item_clear(next);
-        item->Next = nullptr;
-    }
-
     free(item->GroupName);
     item->GroupName = nullptr;
 
@@ -406,6 +403,14 @@ void time_entry_view_item_clear(
     item->GroupDuration = nullptr;
 
     delete item;
+}
+
+void time_entry_view_list_clear(TogglTimeEntryView *first) {
+    while (first) {
+        TogglTimeEntryView *next = reinterpret_cast<TogglTimeEntryView *>(first->Next);
+        time_entry_view_item_clear(first);
+        first = next;
+    }
 }
 
 TogglSettingsView *settings_view_item_init(
@@ -484,7 +489,7 @@ TogglAutocompleteView *autocomplete_list_init(
     return first;
 }
 
-TogglHelpArticleView *help_artice_init(
+TogglHelpArticleView *help_article_init(
     const toggl::HelpArticle item) {
     TogglHelpArticleView *result = new TogglHelpArticleView();
     result->Category = copy_string(item.Type);
@@ -494,28 +499,29 @@ TogglHelpArticleView *help_artice_init(
     return result;
 }
 
-void help_article_clear(TogglHelpArticleView *item) {
-    if (!item) {
+void help_article_item_clear(TogglHelpArticleView *view) {
+    if (!view) {
         return;
     }
 
-    free(item->Category);
-    item->Category = nullptr;
+    free(view->Category);
+    view->Category = nullptr;
 
-    free(item->Name);
-    item->Name = nullptr;
+    free(view->Name);
+    view->Name = nullptr;
 
-    free(item->URL);
-    item->URL = nullptr;
+    free(view->URL);
+    view->URL = nullptr;
 
-    if (item->Next) {
-        TogglHelpArticleView *next =
-            reinterpret_cast<TogglHelpArticleView *>(item->Next);
-        help_article_clear(next);
-        item->Next = nullptr;
+    delete view;
+}
+
+void help_article_list_clear(TogglHelpArticleView *first) {
+    while (first) {
+        TogglHelpArticleView *next = reinterpret_cast<TogglHelpArticleView *>(first->Next);
+        help_article_item_clear(first);
+        first = next;
     }
-
-    delete item;
 }
 
 TogglHelpArticleView *help_article_list_init(
@@ -525,7 +531,7 @@ TogglHelpArticleView *help_article_list_init(
         items.rbegin();
             it != items.rend();
             it++) {
-        TogglHelpArticleView *item = help_artice_init(*it);
+        TogglHelpArticleView *item = help_article_init(*it);
         item->Next = first;
         first = item;
     }

--- a/src/toggl_api_private.h
+++ b/src/toggl_api_private.h
@@ -55,6 +55,8 @@ TogglAutotrackerRuleView *autotracker_rule_to_view_item(
 
 void autotracker_view_item_clear(TogglAutotrackerRuleView *view);
 
+void autotracker_view_list_clear(TogglAutotrackerRuleView *first);
+
 TogglAutocompleteView *autocomplete_item_init(
     const toggl::view::Autocomplete item);
 
@@ -64,10 +66,14 @@ void view_list_clear(TogglGenericView *first);
 
 void autocomplete_item_clear(TogglAutocompleteView *item);
 
+void autocomplete_list_clear(TogglAutocompleteView *first);
+
 TogglCountryView *country_list_init(
     std::vector<TogglCountryView> *items);
 
 void country_item_clear(TogglCountryView *item);
+
+void country_list_clear(TogglCountryView *first);
 
 TogglCountryView *country_view_item_init(
     const Json::Value v);
@@ -76,6 +82,8 @@ TogglTimeEntryView *time_entry_view_item_init(
     const toggl::view::TimeEntry &te);
 
 void time_entry_view_item_clear(TogglTimeEntryView *item);
+
+void time_entry_view_list_clear(TogglTimeEntryView *first);
 
 TogglSettingsView *settings_view_item_init(
     const bool_t record_timeline,
@@ -91,8 +99,9 @@ TogglAutocompleteView *autocomplete_list_init(
 TogglHelpArticleView *help_article_list_init(
     const std::vector<toggl::HelpArticle> items);
 
-void help_article_clear(
-    TogglHelpArticleView *first);
+void help_article_item_clear(TogglHelpArticleView *view);
+
+void help_article_list_clear(TogglHelpArticleView *first);
 
 Poco::Logger &logger();
 


### PR DESCRIPTION
### 📒 Description
This change makes deallocating the memory for API `View` structures not use recursion anymore. This fixes potential issues with tens of thousands of items like autocomplete lists, projects, etc (basically everything that gets passed as a `View`)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Nothing should change unless you have tens of thousands of stuff in your Toggl account. If that's the case, it should stop crashing.

