### PR TITLE
Fix starting new timer with menubar menu item

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -103,10 +103,6 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(stop:)
 													 name:kCommandStop
 												   object:nil];
-		[[NSNotificationCenter defaultCenter] addObserver:self
-												 selector:@selector(startNewShortcut:)
-													 name:kCommandNewShortcut
-												   object:nil];
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
 

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -10,7 +10,6 @@
 
 // Commands, backend <- UI
 extern NSString *const kCommandNew;
-extern NSString *const kCommandNewShortcut;
 extern NSString *const kCommandStop;
 extern NSString *const kCommandContinue;
 

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -9,7 +9,6 @@
 #import "UIEvents.h"
 
 NSString *const kCommandNew = @"New";
-NSString *const kCommandNewShortcut = @"NewShortcut";
 NSString *const kCommandStop = @"Stop";
 NSString *const kCommandContinue = @"Continue";
 

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -1010,7 +1010,7 @@ void *ctx;
 
 - (void)onNewMenuItem:(id)sender
 {
-	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandNewShortcut
+	[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kCommandNew
 																object:[[TimeEntryViewItem alloc] init]];
 }
 


### PR DESCRIPTION
### 📒 Description
The old solution would trigger a keypress of the "Start button". This was not working as it would just trigger stop of the running entry and would not start a new one. I've updated the logic to use the simple `toggl_start` to trigger starting the new entry

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 👫 Relationships

Closes #3335 

### 🔎 Review hints
- Start timer
- Select "new" from menubar menu or "Start New" from dock icon.
- Running entry should stop and new empty entry should be started

