### PR TITLE
Remove compact mode api

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -1909,17 +1909,6 @@ void Context::SetMiniTimerW(const int64_t y) {
     displayError(db()->SetMiniTimerW(y));
 }
 
-void Context::SetCompactMode(
-    const bool value) {
-    displayError(db()->SetCompactMode(value));
-}
-
-bool Context::GetCompactMode() {
-    bool value(false);
-    displayError(db()->GetCompactMode(&value));
-    return value;
-}
-
 void Context::SetMiniTimerVisible(
     const bool value) {
     displayError(db()->SetMiniTimerVisible(value));

--- a/src/context.h
+++ b/src/context.h
@@ -188,11 +188,6 @@ class Context : public TimelineDatasource {
         const bool remind_sat,
         const bool remind_sun);
 
-    void SetCompactMode(
-        const bool);
-
-    bool GetCompactMode();
-
     void SetMiniTimerVisible(
         const bool);
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -625,15 +625,6 @@ error Database::LoadProxySettings(
     return last_error("LoadProxySettings");
 }
 
-error Database::SetCompactMode(
-    const bool value) {
-    return setSettingsValue("compact_mode", value);
-}
-
-error Database::GetCompactMode(bool *result) {
-    return getSettingsValue("compact_mode", result);
-}
-
 error Database::SetMiniTimerVisible(
     const bool value) {
     return setSettingsValue("mini_timer_visible", value);

--- a/src/database.h
+++ b/src/database.h
@@ -141,12 +141,6 @@ class Database {
     error LoadMigrations(
         std::vector<std::string> *);
 
-    error SetCompactMode(
-        const bool);
-
-    error GetCompactMode(
-        bool *);
-
     error SetMiniTimerVisible(
         const bool);
 

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1213,14 +1213,6 @@ error Migrations::migrateSettings() {
     }
 
     err = db_->Migrate(
-        "settings.compact_mode",
-        "ALTER TABLE settings "
-        "ADD COLUMN compact_mode INTEGER NOT NULL DEFAULT 0;");
-    if (err != noError) {
-        return err;
-    }
-
-    err = db_->Migrate(
         "settings.keep_end_time_fixed",
         "ALTER TABLE settings "
         "ADD COLUMN keep_end_time_fixed INTEGER NOT NULL DEFAULT 0;");

--- a/src/test/toggl_api_test.cc
+++ b/src/test/toggl_api_test.cc
@@ -1430,16 +1430,6 @@ TEST(toggl_api, concurrency) {
     }
 }
 
-TEST(toggl_api, toggl_set_compact_mode) {
-    testing::App app;
-
-    toggl_set_compact_mode(app.ctx(), true);
-    ASSERT_TRUE(toggl_get_compact_mode(app.ctx()));
-
-    toggl_set_compact_mode(app.ctx(), false);
-    ASSERT_FALSE(toggl_get_compact_mode(app.ctx()));
-}
-
 TEST(toggl_api, toggl_set_keep_end_times_fixed) {
     testing::App app;
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -1336,17 +1336,6 @@ bool_t testing_set_logged_in_user(
     return toggl::noError == ctx->SetLoggedInUserFromJSON(std::string(json));
 }
 
-void toggl_set_compact_mode(
-    void *context,
-    const bool_t value) {
-    app(context)->SetCompactMode(value);
-}
-
-bool_t toggl_get_compact_mode(
-    void *context) {
-    return app(context)->GetCompactMode();
-}
-
 void toggl_set_keep_end_time_fixed(
     void *context,
     const bool_t value) {

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -996,13 +996,6 @@ extern "C" {
         void *context,
         const char *json);
 
-    TOGGL_EXPORT void toggl_set_compact_mode(
-        void *context,
-        const bool_t value);
-
-    TOGGL_EXPORT bool_t toggl_get_compact_mode(
-        void *context);
-
     TOGGL_EXPORT void toggl_set_keep_end_time_fixed(
         void *context,
         const bool_t value);

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -1510,17 +1510,6 @@ public static partial class Toggl
         string json);
 
     [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    private static extern void toggl_set_compact_mode(
-        IntPtr context,
-        [MarshalAs(UnmanagedType.I1)]
-        bool value);
-
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
-    [return:MarshalAs(UnmanagedType.I1)]
-    private static extern bool toggl_get_compact_mode(
-        IntPtr context);
-
-    [DllImport(dll, CharSet = charset, CallingConvention = convention)]
     private static extern void toggl_set_keep_end_time_fixed(
         IntPtr context,
         [MarshalAs(UnmanagedType.I1)]


### PR DESCRIPTION
### 📒 Description
Removes all traces of compact mode.

We just remove the database migration that adds the column as it is not easy to remove the column with LiteSQL.

### 🕶️ Types of changes

- **Cleanup** (non-breaking change which fixes an issue)

### 👫 Relationships

Closes #3209 

### 🔎 Review hints
- Just run the app and all functionality should work without a problem

- Also deleting the database and starting app should be tested. The creation of the new database should work without issues.

