### PR TITLE
Set UIModifiedAt to 0 for synced items (lib)

### DIFF
--- a/src/time_entry.cc
+++ b/src/time_entry.cc
@@ -457,7 +457,7 @@ void TimeEntry::LoadFromJSON(Json::Value data) {
     SetBillable(data["billable"].asBool());
     SetDurOnly(data["duronly"].asBool());
     SetUpdatedAtString(data["at"].asString());
-    SetUIModifiedAt(Formatter::Parse8601(data["at"].asString()));
+    SetUIModifiedAt(0);
 
     ClearUnsynced();
 }


### PR DESCRIPTION
### 📒 Description
Fixes issue with unsynced items counter on Windows app caused by 2c22dd1a39610742762372004024a13dda721330
#3328 broke library logic related to synced/unsynced items and caused issues with unsynced items counter in the Windows app
![image](https://user-images.githubusercontent.com/16451391/65420861-de2c5f80-de0a-11e9-8c6c-f73f53f57504.png).
 If `ui_modified_at` is not  0 it is marked as unsynced and `BaseModel::NeedsPUT()` returns `true` which means `BaseModel::NeedsPush()` also returns `true`.
I looked at the PR and setting UIModifiedAt to UpdatedAt seems unnecessary for the fix.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue)

### 🔎 Review hints
Same test cases as https://github.com/toggl/toggldesktop/pull/3328.