### PR TITLE
Added global Toggl Button to TouchBar (mac)

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -251,6 +251,9 @@ void GoogleAnalyticsSettingsEvent::runTask() {
     setActionBool("stop_entry_on_shutdown_sleep-", settings.stop_entry_on_shutdown_sleep);
     makeReq();
 
+    setActionBool("show_touch_bar-", settings.show_touch_bar);
+    makeReq();
+
     if (settings.pomodoro_break) {
         setActionInt("pomodoro_break_minutes-",
                      settings.pomodoro_break_minutes);

--- a/src/context.cc
+++ b/src/context.cc
@@ -1812,6 +1812,11 @@ error Context::SetSettingsStopEntryOnShutdownSleep(const bool stop_entry) {
         db()->SetSettingsStopEntryOnShutdownSleep(stop_entry));
 }
 
+error Context::SetSettingsShowTouchBar(const bool show_touch_bar) {
+    return applySettingsSaveResultToUI(
+        db()->SetSettingsShowTouchBar(show_touch_bar));
+}
+
 error Context::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsIdleMinutes(idle_minutes));
@@ -1928,6 +1933,12 @@ void Context::SetKeepEndTimeFixed
 bool Context::GetKeepEndTimeFixed() {
     bool value(false);
     displayError(db()->GetKeepEndTimeFixed(&value));
+    return value;
+}
+
+bool Context::GetShowTouchBar() {
+    bool value(false);
+    displayError(db()->GetShowTouchBar(&value));
     return value;
 }
 
@@ -2276,7 +2287,7 @@ error Context::GoogleSignup(
 }
 
 error Context::AsyncGoogleSignup(const std::string &access_token,
-    const uint64_t country_id) {
+                                 const uint64_t country_id) {
     std::thread backgroundThread([&](std::string access_token, uint64_t country_id) {
         return this->GoogleSignup(access_token, country_id);
     }, access_token, country_id);
@@ -4861,9 +4872,9 @@ error Context::pushClients(
 }
 
 error Context::pushProjects(const std::vector<Project *> &projects,
-    const std::vector<Client *> &clients,
-    const std::string &api_token,
-    TogglClient toggl_client) {
+                            const std::vector<Client *> &clients,
+                            const std::string &api_token,
+                            TogglClient toggl_client) {
     error err = noError;
     std::string project_json("");
     for (std::vector<Project *>::const_iterator it =
@@ -4917,7 +4928,7 @@ error Context::pushProjects(const std::vector<Project *> &projects,
 }
 
 error Context::updateEntryProjects(const std::vector<Project *> &projects,
-    const std::vector<TimeEntry *> &time_entries) {
+                                   const std::vector<TimeEntry *> &time_entries) {
     for (std::vector<TimeEntry *>::const_iterator it =
         time_entries.begin();
             it != time_entries.end(); it++) {

--- a/src/context.h
+++ b/src/context.h
@@ -160,6 +160,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
 
     error SetSettingsStopEntryOnShutdownSleep(const bool stop_entry);
 
+    error SetSettingsShowTouchBar(const bool show_touch_bar);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool focus_on_shortcut);
@@ -197,6 +199,8 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         const bool);
 
     bool GetKeepEndTimeFixed();
+
+    bool GetShowTouchBar();
 
     void SetWindowMaximized(
         const bool value);
@@ -241,7 +245,7 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
     error ProxySettings(bool *use_proxy, Proxy *proxy);
 
     error SetProxySettings(const bool use_proxy,
-        const Proxy &proxy);
+                           const Proxy &proxy);
 
     error LoadWindowSettings(
         int64_t *window_x,
@@ -587,17 +591,17 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         TogglClient *https_client,
         bool *had_something_to_push);
     error pushClients(const std::vector<Client *> &clients,
-        const std::string &api_token,
-        TogglClient toggl_client);
+                      const std::string &api_token,
+                      TogglClient toggl_client);
     error pushProjects(
         const std::vector<Project *> &projects,
         const std::vector<Client *> &clients,
         const std::string &api_token,
         TogglClient toggl_client);
     error pushEntries(const std::map<std::string, BaseModel *> &models,
-        const std::vector<TimeEntry *> &time_entries,
-        const std::string &api_token,
-        TogglClient toggl_client);
+                      const std::vector<TimeEntry *> &time_entries,
+                      const std::string &api_token,
+                      TogglClient toggl_client);
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
@@ -613,10 +617,10 @@ class TOGGL_INTERNAL_EXPORT Context : public TimelineDatasource {
         std::string *user_data_json,
         const uint64_t country_id);
     static error me(TogglClient *https_client,
-        const std::string &email,
-        const std::string &password,
-        std::string *user_data,
-        const Poco::Int64 since);
+                    const std::string &email,
+                    const std::string &password,
+                    std::string *user_data,
+                    const Poco::Int64 since);
 
     bool isTimeEntryLocked(TimeEntry* te);
     bool isTimeLockedInWorkspace(time_t t, Workspace* ws);

--- a/src/database.cc
+++ b/src/database.cc
@@ -450,7 +450,7 @@ error Database::LoadSettings(Settings *settings) {
                   "remind_fri, remind_sat, remind_sun, autotrack, "
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
-                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep "
+                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),
@@ -481,6 +481,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->pomodoro_break),
                   into(settings->pomodoro_break_minutes),
                   into(settings->stop_entry_on_shutdown_sleep),
+                  into(settings->show_touch_bar),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {
@@ -641,6 +642,10 @@ error Database::SetKeepEndTimeFixed(
 
 error Database::GetKeepEndTimeFixed(bool *result) {
     return getSettingsValue("keep_end_time_fixed", result);
+}
+
+error Database::GetShowTouchBar(bool *result) {
+    return getSettingsValue("show_touch_bar", result);
 }
 
 error Database::SetWindowMaximized(
@@ -853,6 +858,10 @@ error Database::SetSettingsManualMode(const bool &manual_mode) {
 
 error Database::SetSettingsAutodetectProxy(const bool &autodetect_proxy) {
     return setSettingsValue("autodetect_proxy", autodetect_proxy);
+}
+
+error Database::SetSettingsShowTouchBar(const bool &show_touch_bar) {
+    return setSettingsValue("show_touch_bar", show_touch_bar);
 }
 
 template<typename T>

--- a/src/database.h
+++ b/src/database.h
@@ -125,6 +125,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error SetSettingsAutodetectProxy(const bool &autodetect_proxy);
 
+    error SetSettingsShowTouchBar(const bool &show_touch_bar);
+
     error SetSettingsRemindTimes(
         const std::string &remind_starts,
         const std::string &remind_ends);
@@ -152,6 +154,8 @@ class TOGGL_INTERNAL_EXPORT Database {
 
     error GetKeepEndTimeFixed(
         bool *);
+
+    error GetShowTouchBar(bool *result);
 
     error SetWindowMaximized(
         const bool value);

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -523,8 +523,8 @@ void GUI::DisplayWorkspaceSelect(
 }
 
 void GUI::DisplayTimeEntryEditor(const bool open,
-    const view::TimeEntry &te,
-    const std::string &focused_field_name) {
+                                 const view::TimeEntry &te,
+                                 const std::string &focused_field_name) {
 
     logger().debug(
         "DisplayTimeEntryEditor focused_field_name=" + focused_field_name);

--- a/src/gui.h
+++ b/src/gui.h
@@ -241,7 +241,8 @@ class TOGGL_INTERNAL_EXPORT Settings {
     , PomodoroBreak(false)
     , PomodoroMinutes(0)
     , PomodoroBreakMinutes(0)
-    , StopEntryOnShutdownSleep(false) {}
+    , StopEntryOnShutdownSleep(false)
+    , ShowTouchBar(true) {}
 
     bool UseProxy;
     std::string ProxyHost;
@@ -276,6 +277,7 @@ class TOGGL_INTERNAL_EXPORT Settings {
     uint64_t PomodoroMinutes;
     uint64_t PomodoroBreakMinutes;
     bool StopEntryOnShutdownSleep;
+    bool ShowTouchBar;
 
     bool operator == (const Settings& other) const;
 };

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1292,6 +1292,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.show_touch_bar",
+        "ALTER TABLE settings "
+        "ADD COLUMN show_touch_bar INTEGER NOT NULL DEFAULT 1;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -36,6 +36,7 @@ Json::Value Settings::SaveToJSON() const {
     json["pomodoro_break"] = pomodoro_break;
     json["pomodoro_break_minutes"] = Json::UInt64(pomodoro_break_minutes);
     json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
+    json["show_touch_bar"] = show_touch_bar;
     return json;
 }
 
@@ -69,7 +70,8 @@ std::string Settings::String() const {
        << " pomodoro_minutes=" << pomodoro_minutes
        << " pomodoro_break=" << pomodoro_break
        << " pomodoro_break_minutes=" << pomodoro_break_minutes
-       << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep;
+       << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep
+       << " show_touch_bar=" << show_touch_bar;
     return ss.str();
 }
 
@@ -101,7 +103,8 @@ bool Settings::IsSame(const Settings &other) const {
             && (pomodoro_minutes == other.pomodoro_minutes)
             && (pomodoro_break == other.pomodoro_break)
             && (pomodoro_break_minutes == other.pomodoro_break_minutes)
-            && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep));
+            && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep)
+            && (show_touch_bar == other.show_touch_bar));
 }
 
 std::string Settings::ModelName() const {

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,7 +44,8 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     , pomodoro_break(false)
     , pomodoro_minutes(0)
     , pomodoro_break_minutes(0)
-    , stop_entry_on_shutdown_sleep(false) {}
+    , stop_entry_on_shutdown_sleep(false)
+    , show_touch_bar(true) {}
 
     virtual ~Settings() {}
 
@@ -76,6 +77,7 @@ class TOGGL_INTERNAL_EXPORT Settings : public BaseModel {
     Poco::Int64 pomodoro_minutes;
     Poco::Int64 pomodoro_break_minutes;
     bool stop_entry_on_shutdown_sleep;
+    bool show_touch_bar;
 
     bool IsSame(const Settings &other) const;
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -169,6 +169,11 @@ bool_t toggl_set_settings_stop_entry_on_shutdown_sleep(
            SetSettingsStopEntryOnShutdownSleep(stop_entry);
 }
 
+bool_t toggl_set_settings_show_touch_bar(
+    void *context,
+    const bool_t show_touch_bar) {
+    return toggl::noError == app(context)->SetSettingsShowTouchBar(show_touch_bar);
+}
 
 bool_t toggl_set_settings_idle_minutes(
     void *context,
@@ -1347,6 +1352,10 @@ bool_t toggl_get_keep_end_time_fixed(
     return app(context)->GetKeepEndTimeFixed();
 }
 
+bool_t toggl_get_show_touch_bar(
+    void *context) {
+    return app(context)->GetShowTouchBar();
+}
 
 void toggl_set_mini_timer_x(
     void *context,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -164,6 +164,7 @@ extern "C" {
         int64_t PomodoroMinutes;
         int64_t PomodoroBreakMinutes;
         bool_t StopEntryOnShutdownSleep;
+        bool_t ShowTouchBar;
     } TogglSettingsView;
 
     typedef struct {
@@ -714,6 +715,10 @@ extern "C" {
         void *context,
         const bool_t stop_entry);
 
+    TOGGL_EXPORT bool_t toggl_set_settings_show_touch_bar(
+        void *context,
+        const bool_t show_touch_bar);
+
     TOGGL_EXPORT bool_t toggl_set_settings_idle_minutes(
         void *context,
         const uint64_t idle_minutes);
@@ -1004,6 +1009,8 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_get_keep_end_time_fixed(
         void *context);
 
+    TOGGL_EXPORT bool_t toggl_get_show_touch_bar(
+        void *context);
 
     TOGGL_EXPORT void toggl_set_mini_timer_x(
         void *context,

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -468,6 +468,7 @@ TogglSettingsView *settings_view_item_init(
     view->PomodoroBreak = settings.pomodoro_break;
     view->PomodoroBreakMinutes = settings.pomodoro_break_minutes;
     view->StopEntryOnShutdownSleep = settings.stop_entry_on_shutdown_sleep;
+    view->ShowTouchBar = settings.show_touch_bar;
     return view;
 }
 

--- a/src/ui/osx/TogglDesktop.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/src/ui/osx/TogglDesktop.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntry/TimeEntryDatasource.swift
@@ -125,6 +125,11 @@ class TimeEntryDatasource: NSObject {
             sections.append(TimeEntrySection.loadMoreSection())
         }
 
+        // Touch bar
+        if #available(OSX 10.12.2, *) {
+            TouchBarService.shared.updateTimeEntryList(timeEntries)
+        }
+
         // Reload
         reload(with: sections)
     }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/DesktopLibraryBridge.m
@@ -167,7 +167,6 @@ void *ctx;
 									 [timeEntry.GUID UTF8String],
 									 [autocomplete.Description UTF8String]);
 	[self updateTimeEntryWithTags:autocomplete.tags guid:timeEntry.GUID];
-
 }
 
 - (NSString *)convertDuratonInSecond:(int64_t)durationInSecond

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.xib
@@ -60,7 +60,7 @@
                                     <rect key="frame" x="1" y="1" width="252" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EMT-i8-OD1" customClass="DescriptionAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
+                                        <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMT-i8-OD1" customClass="DescriptionAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Description…" usesSingleLineMode="YES" id="0MM-Wa-hOG" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                 <font key="font" metaFont="system" size="14"/>
@@ -94,7 +94,7 @@
                                     <rect key="frame" x="1" y="1" width="252" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Doe-dQ-82A" customClass="ProjectAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
+                                        <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Doe-dQ-82A" customClass="ProjectAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                             <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Select project" usesSingleLineMode="YES" id="6po-73-koG" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                 <font key="font" metaFont="system" size="14"/>
@@ -146,7 +146,7 @@
                                                 <rect key="frame" x="1" y="1" width="252" height="28"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TEs-AY-h6J" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
+                                                    <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TEs-AY-h6J" customClass="AddTagButton" customModule="TogglDesktop" customModuleProvider="target">
                                                         <rect key="frame" x="-2" y="0.0" width="256" height="28"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Add tags" usesSingleLineMode="YES" id="yAk-86-67A" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                             <font key="font" metaFont="system" size="14"/>
@@ -192,7 +192,7 @@
                                     <rect key="frame" x="1" y="1" width="78" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q9U-uY-bOj" customClass="UndoTextField">
+                                        <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q9U-uY-bOj" customClass="UndoTextField">
                                             <rect key="frame" x="-2" y="0.0" width="82" height="28"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" title="0:00:00" placeholderString="0:00:00" id="dJu-5a-D7u" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                 <font key="font" metaFont="system" size="14"/>
@@ -448,7 +448,7 @@
                             <customView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Wyt-sv-sZR">
                                 <rect key="frame" x="98" y="159" width="168" height="18"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-ON-SgR" customClass="UndoTextField">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-ON-SgR" customClass="UndoTextField">
                                         <rect key="frame" x="-2" y="0.0" width="74" height="18"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="center" title="09:20 AM" id="XRL-p8-r7I">
                                             <font key="font" metaFont="system" size="14"/>
@@ -469,7 +469,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
-                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="8yt-KD-lKA" customClass="UndoTextField">
+                                    <textField horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8yt-KD-lKA" customClass="UndoTextField">
                                         <rect key="frame" x="96" y="0.0" width="74" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="70" id="l2i-Ea-wbs"/>

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/Project/ProjectCreationView.xib
@@ -77,7 +77,7 @@
                                         <rect key="frame" x="1" y="1" width="239" height="28"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eQK-O0-2vn">
+                                            <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQK-O0-2vn">
                                                 <rect key="frame" x="-2" y="0.0" width="243" height="28"/>
                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Project Name" usesSingleLineMode="YES" id="vml-ft-AoW" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                     <font key="font" metaFont="system" size="14"/>
@@ -144,7 +144,7 @@
                                 <rect key="frame" x="1" y="1" width="218" height="28"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I8L-vz-Mr7" customClass="WorkspaceAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
+                                    <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I8L-vz-Mr7" customClass="WorkspaceAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                         <rect key="frame" x="-2" y="0.0" width="222" height="28"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="Marketing Department" id="Kqx-Qa-pyM" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                             <font key="font" metaFont="system" size="14"/>
@@ -179,7 +179,7 @@
                                 <rect key="frame" x="1" y="1" width="218" height="28"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCQ-e0-gV1" customClass="ClientAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
+                                    <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCQ-e0-gV1" customClass="ClientAutoCompleteTextField" customModule="TogglDesktop" customModuleProvider="target">
                                         <rect key="frame" x="-2" y="0.0" width="222" height="28"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" alignment="left" placeholderString="No Client" id="8Nw-wN-b3U" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                             <font key="font" metaFont="system" size="14"/>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -1,0 +1,57 @@
+//
+//  GlobalTouchbarButton.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 9/30/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+@available(OSX 10.12.2, *)
+final class GlobalTouchbarButton: NSCustomTouchBarItem {
+
+    private struct Constants {
+        static let IDTouchBar = NSTouchBarItem.Identifier("toggl.touchbar")
+    }
+
+    // MARK: Variables
+
+    private let button: NSButton
+
+    // MARK: Init
+
+    override init(identifier: NSTouchBarItem.Identifier) {
+        let image = NSImage(named: "on")!
+        image.isTemplate = true
+        self.button = NSButton(image: image, target: nil, action: nil)
+        self.button.imagePosition = .imageOnly
+        super.init(identifier: identifier)
+        self.button.target = self
+        self.button.action = #selector(self.buttonOnTap)
+        self.view = self.button
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Don't support coder")
+    }
+
+    class func makeDefault() -> GlobalTouchbarButton {
+        let item = GlobalTouchbarButton(identifier: Constants.IDTouchBar)
+        return item
+    }
+
+    // MARK: Public
+
+
+}
+
+// MARK: Private
+
+@available(OSX 10.12.2, *)
+extension GlobalTouchbarButton {
+
+    @objc fileprivate func buttonOnTap() {
+
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -53,6 +53,6 @@ final class GlobalTouchbarButton: NSCustomTouchBarItem {
 extension GlobalTouchbarButton {
 
     @objc fileprivate func buttonOnTap() {
-
+        NotificationCenter.default.post(name: NSNotification.Name(kStartTimer), object: nil)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -9,20 +9,18 @@
 import Cocoa
 
 @available(OSX 10.12.2, *)
+@objcMembers
 final class GlobalTouchbarButton: NSCustomTouchBarItem {
-
-    private struct Constants {
-        static let IDTouchBar = NSTouchBarItem.Identifier("toggl.touchbar")
-    }
 
     // MARK: Variables
 
+    static let ID = NSTouchBarItem.Identifier("toggl.touchbar")
     private let button: NSButton
 
     // MARK: Init
 
     override init(identifier: NSTouchBarItem.Identifier) {
-        let image = NSImage(named: "on")!
+        let image = NSImage(named: "off")!
         image.isTemplate = true
         self.button = NSButton(image: image, target: nil, action: nil)
         self.button.imagePosition = .imageOnly
@@ -37,13 +35,16 @@ final class GlobalTouchbarButton: NSCustomTouchBarItem {
     }
 
     class func makeDefault() -> GlobalTouchbarButton {
-        let item = GlobalTouchbarButton(identifier: Constants.IDTouchBar)
-        return item
+        return GlobalTouchbarButton(identifier: GlobalTouchbarButton.ID)
     }
 
     // MARK: Public
 
-
+    func update(_ iconImage: NSImage) {
+        // This forces the icon to redraw
+        button.image = iconImage
+        button.imagePosition = .imageOnly
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
@@ -21,7 +21,6 @@ final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
     weak var delegate: TimeEntryScrubberFlowLayoutDelegate?
     private var itemAttributes: [NSScrubberLayoutAttributes] = []
     private var totalWidth: CGFloat = 0
-    private let templateBtn = NSButton(title: "", target: nil, action: nil)
 
     // MARK: Overriden
 
@@ -41,12 +40,15 @@ final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
             let attribute = NSScrubberLayoutAttributes(forItemAt: i)
 
             // Get the size depend on the length of text
+            let templateBtn = NSButton(title: "", target: nil, action: nil)
             templateBtn.title = title
             templateBtn.sizeToFit()
 
             // Override the size
-            let size = templateBtn.frame.size
-            let frame = CGRect(x: x, y: 0, width: size.width, height: size.height)
+            var size = templateBtn.frame.size
+            size.width += 20
+
+            let frame = CGRect(x: x, y: 0, width: size.width, height: 30)
             attribute.frame = frame
 
             //

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
@@ -1,0 +1,81 @@
+//
+//  TimeEntryScrubberFlowLayout.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 10/8/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+protocol TimeEntryScrubberFlowLayoutDelegate: class {
+
+    func timeEntryScrubberTitle(at index: Int) -> String
+}
+
+@available(OSX 10.12.2, *)
+final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
+
+    // MARK: Variables
+
+    weak var delegate: TimeEntryScrubberFlowLayoutDelegate?
+    private var itemAttributes: [NSScrubberLayoutAttributes] = []
+    private var totalWidth: CGFloat = 0
+    private let templateBtn = NSButton(title: "", target: nil, action: nil)
+
+    // MARK: Overriden
+
+    override func prepare() {
+        super.prepare()
+        guard let scrubber = scrubber else { return }
+        guard let numberOfItems = scrubber.dataSource?.numberOfItems(for: scrubber) else { return }
+
+        // Prepare data
+        var itemAttributes: [NSScrubberLayoutAttributes] = []
+        var totalWidth: CGFloat = 0
+        var x: CGFloat = 0
+
+        // Calculate the size for each items
+        for i in 0..<numberOfItems {
+            guard let title = delegate?.timeEntryScrubberTitle(at: i) else { continue }
+            let attribute = NSScrubberLayoutAttributes(forItemAt: i)
+
+            // Get the size depend on the length of text
+            templateBtn.title = title
+            templateBtn.sizeToFit()
+
+            // Override the size
+            let size = templateBtn.frame.size
+            let frame = CGRect(x: x, y: 0, width: size.width, height: size.height)
+            attribute.frame = frame
+
+            //
+            x += size.width + itemSpacing
+            totalWidth += size.width + itemSpacing
+            itemAttributes.append(attribute)
+        }
+
+        self.itemAttributes = itemAttributes
+        self.totalWidth = totalWidth
+    }
+
+    override func layoutAttributesForItem(at index: Int) -> NSScrubberLayoutAttributes? {
+        return itemAttributes[safe: index]
+    }
+
+    override func layoutAttributesForItems(in rect: NSRect) -> Set<NSScrubberLayoutAttributes> {
+        let atts = itemAttributes.compactMap({ (att) -> NSScrubberLayoutAttributes? in
+            if att.frame.intersects(rect) {
+                return att
+            }
+            return nil
+        })
+        return Set(atts)
+    }
+
+    override var scrubberContentSize: NSSize {
+        var size = super.scrubberContentSize
+        size.width = totalWidth
+        return size
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
@@ -46,7 +46,8 @@ final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
             // Get the size depend on the length of text
             let templateBtn = NSTextField(string: "")
             templateBtn.stringValue = title
-            let width = templateBtn.cell!.cellSize(forBounds: CGRect(x: 0, y: 0, width: 1000.0, height: Constants.BarItemHeight)).width
+            //let width = templateBtn.cell!.cellSize(forBounds: CGRect(x: 0, y: 0, width: 1000.0, height: Constants.BarItemHeight)).width
+            let width: CGFloat = 120
 
             // Override the size
             var size = CGSize(width: width, height: Constants.BarItemHeight)

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberFlowLayout.swift
@@ -16,6 +16,10 @@ protocol TimeEntryScrubberFlowLayoutDelegate: class {
 @available(OSX 10.12.2, *)
 final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
 
+    private struct Constants {
+        static let BarItemHeight: CGFloat = 30
+    }
+
     // MARK: Variables
 
     weak var delegate: TimeEntryScrubberFlowLayoutDelegate?
@@ -40,15 +44,15 @@ final class TimeEntryScrubberFlowLayout: NSScrubberFlowLayout {
             let attribute = NSScrubberLayoutAttributes(forItemAt: i)
 
             // Get the size depend on the length of text
-            let templateBtn = NSButton(title: "", target: nil, action: nil)
-            templateBtn.title = title
-            templateBtn.sizeToFit()
+            let templateBtn = NSTextField(string: "")
+            templateBtn.stringValue = title
+            let width = templateBtn.cell!.cellSize(forBounds: CGRect(x: 0, y: 0, width: 1000.0, height: Constants.BarItemHeight)).width
 
             // Override the size
-            var size = templateBtn.frame.size
-            size.width += 20
+            var size = CGSize(width: width, height: Constants.BarItemHeight)
+            size.width += 30 // Padding for button
 
-            let frame = CGRect(x: x, y: 0, width: size.width, height: 30)
+            let frame = CGRect(x: x, y: 0, width: size.width, height: Constants.BarItemHeight)
             attribute.frame = frame
 
             //

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -9,7 +9,7 @@
 import Cocoa
 
 @available(OSX 10.12.2, *)
-class TimeEntryScrubberItem: NSScrubberTextItemView {
+final class TimeEntryScrubberItem: NSScrubberTextItemView {
 
     // MARK: Public
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -20,6 +20,7 @@ final class TimeEntryScrubberItem: NSScrubberItemView {
     override func awakeFromNib() {
         super.awakeFromNib()
         if titleBtn.superview == nil {
+            titleBtn.setButtonType(NSButton.ButtonType.momentaryChange)
             titleBtn.translatesAutoresizingMaskIntoConstraints = false
             addSubview(titleBtn)
             titleBtn.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -15,12 +15,14 @@ final class TimeEntryScrubberItem: NSScrubberItemView {
 
     private lazy var titleBtn = NSButton(title: "", target: nil, action: nil)
     @IBOutlet weak var desciptionLbl: NSTextField!
-    @IBOutlet weak var projectLbl: NSTextField!
+    @IBOutlet weak var projectLbl: ProjectTextField!
+    @IBOutlet weak var dotImageView: DotImageView!
 
     // MARK: View Cycle
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        projectLbl.customClientTextColor = NSColor.secondaryLabelColor;
         if titleBtn.superview == nil {
             titleBtn.setButtonType(NSButton.ButtonType.momentaryChange)
             titleBtn.translatesAutoresizingMaskIntoConstraints = false
@@ -37,7 +39,21 @@ final class TimeEntryScrubberItem: NSScrubberItemView {
     // MARK: Public
 
     func config(_ item: TimeEntryViewItem) {
-        desciptionLbl.stringValue = item.descriptionName
-        projectLbl.stringValue = item.projectAndTaskLabel
+        if let descriptionName = item.descriptionName, !descriptionName.isEmpty {
+            desciptionLbl.stringValue = item.descriptionName
+        } else {
+            desciptionLbl.stringValue = "(No description)"
+        }
+        if let projectText = item.projectAndTaskLabel, !projectText.isEmpty {
+            projectLbl.setTitleWithTimeEntry(item)
+            dotImageView.isHidden = false
+            if let color = item.projectColor {
+                dotImageView.fill(with: ConvertHexColor.hexCode(toNSColor: color))
+            }
+        } else {
+            projectLbl.textColor = NSColor.secondaryLabelColor
+            projectLbl.stringValue = "(No Project)"
+            dotImageView.isHidden = true
+        }
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -9,11 +9,23 @@
 import Cocoa
 
 @available(OSX 10.12.2, *)
-final class TimeEntryScrubberItem: NSScrubberTextItemView {
+final class TimeEntryScrubberItem: NSScrubberItemView {
 
+    lazy var titleBtn = NSButton(title: "", target: nil, action: nil)
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        if titleBtn.superview == nil {
+            titleBtn.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(titleBtn)
+            titleBtn.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+            titleBtn.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        }
+    }
     // MARK: Public
 
     func config(_ item: TimeEntryViewItem) {
-        title = item.touchBarTitle
+        titleBtn.title = item.touchBarTitle
+        titleBtn.setTextColor(NSColor.white)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -1,0 +1,19 @@
+//
+//  TimeEntryScrubberItem.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 10/8/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+@available(OSX 10.12.2, *)
+class TimeEntryScrubberItem: NSScrubberTextItemView {
+
+    // MARK: Public
+
+    func config(_ item: TimeEntryViewItem) {
+        title = item.touchBarTitle
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -11,17 +11,24 @@ import Cocoa
 @available(OSX 10.12.2, *)
 final class TimeEntryScrubberItem: NSScrubberItemView {
 
-    lazy var titleBtn = NSButton(title: "", target: nil, action: nil)
+    // MARK: OUTLET
+
+    private lazy var titleBtn = NSButton(title: "", target: nil, action: nil)
+
+    // MARK: View Cycle
+
     override func awakeFromNib() {
         super.awakeFromNib()
-
         if titleBtn.superview == nil {
             titleBtn.translatesAutoresizingMaskIntoConstraints = false
             addSubview(titleBtn)
             titleBtn.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
             titleBtn.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+            titleBtn.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
+            titleBtn.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0).isActive = true
         }
     }
+
     // MARK: Public
 
     func config(_ item: TimeEntryViewItem) {

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.swift
@@ -14,6 +14,8 @@ final class TimeEntryScrubberItem: NSScrubberItemView {
     // MARK: OUTLET
 
     private lazy var titleBtn = NSButton(title: "", target: nil, action: nil)
+    @IBOutlet weak var desciptionLbl: NSTextField!
+    @IBOutlet weak var projectLbl: NSTextField!
 
     // MARK: View Cycle
 
@@ -22,18 +24,20 @@ final class TimeEntryScrubberItem: NSScrubberItemView {
         if titleBtn.superview == nil {
             titleBtn.setButtonType(NSButton.ButtonType.momentaryChange)
             titleBtn.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(titleBtn)
+            addSubview(titleBtn, positioned: NSWindow.OrderingMode.below, relativeTo: desciptionLbl)
             titleBtn.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
             titleBtn.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
             titleBtn.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 0).isActive = true
             titleBtn.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0).isActive = true
+            titleBtn.title = ""
+            titleBtn.setTextColor(NSColor.white)
         }
     }
 
     // MARK: Public
 
     func config(_ item: TimeEntryViewItem) {
-        titleBtn.title = item.touchBarTitle
-        titleBtn.setTextColor(NSColor.white)
+        desciptionLbl.stringValue = item.descriptionName
+        projectLbl.stringValue = item.projectAndTaskLabel
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
@@ -10,23 +10,9 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView identifier="TimeEntryScrubberItem" id="c22-O7-iKe" customClass="TimeEntryScrubberItem" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="114" height="30"/>
+            <rect key="frame" x="0.0" y="0.0" width="92" height="25"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PHz-qv-8Me">
-                    <rect key="frame" x="-6" y="-2" width="126" height="32"/>
-                    <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bxj-H6-tJh">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                </button>
-            </subviews>
-            <constraints>
-                <constraint firstAttribute="trailing" secondItem="PHz-qv-8Me" secondAttribute="trailing" id="Kq0-Mq-sMX"/>
-                <constraint firstItem="PHz-qv-8Me" firstAttribute="centerY" secondItem="c22-O7-iKe" secondAttribute="centerY" id="NyT-OM-zE0"/>
-                <constraint firstItem="PHz-qv-8Me" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="qKi-Bn-g54"/>
-            </constraints>
-            <point key="canvasLocation" x="-44" y="33"/>
+            <point key="canvasLocation" x="-33" y="33"/>
         </customView>
     </objects>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
@@ -12,7 +12,37 @@
         <customView identifier="TimeEntryScrubberItem" id="c22-O7-iKe" customClass="TimeEntryScrubberItem" customModule="TogglDesktop" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="92" height="25"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <point key="canvasLocation" x="-33" y="33"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LPf-Zn-zKx">
+                    <rect key="frame" x="2" y="9" width="65" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Description" usesSingleLineMode="YES" id="WiE-03-2mE">
+                        <font key="font" metaFont="controlContent" size="11"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bOg-rk-NNg">
+                    <rect key="frame" x="2" y="2" width="42" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Project" usesSingleLineMode="YES" id="9Mi-aX-45M">
+                        <font key="font" metaFont="controlContent" size="11"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <constraints>
+                <constraint firstItem="LPf-Zn-zKx" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="4" id="2zy-KV-ibl"/>
+                <constraint firstItem="bOg-rk-NNg" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="4" id="Arg-KK-EkE"/>
+                <constraint firstItem="LPf-Zn-zKx" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="2" id="H8s-z0-gpg"/>
+                <constraint firstAttribute="bottom" secondItem="bOg-rk-NNg" secondAttribute="bottom" constant="2" id="O2E-Hf-k3N"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LPf-Zn-zKx" secondAttribute="trailing" id="wqF-T0-oMp"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bOg-rk-NNg" secondAttribute="trailing" id="zl5-jD-qDc"/>
+            </constraints>
+            <connections>
+                <outlet property="desciptionLbl" destination="LPf-Zn-zKx" id="SDR-NV-VvU"/>
+                <outlet property="projectLbl" destination="bOg-rk-NNg" id="TXf-x3-csg"/>
+            </connections>
+            <point key="canvasLocation" x="-33" y="32.5"/>
         </customView>
     </objects>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView identifier="TimeEntryScrubberItem" id="c22-O7-iKe" customClass="TimeEntryScrubberItem" customModule="TogglDesktop" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="114" height="30"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PHz-qv-8Me">
+                    <rect key="frame" x="-6" y="-2" width="126" height="32"/>
+                    <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bxj-H6-tJh">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                </button>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="PHz-qv-8Me" secondAttribute="trailing" id="Kq0-Mq-sMX"/>
+                <constraint firstItem="PHz-qv-8Me" firstAttribute="centerY" secondItem="c22-O7-iKe" secondAttribute="centerY" id="NyT-OM-zE0"/>
+                <constraint firstItem="PHz-qv-8Me" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="qKi-Bn-g54"/>
+            </constraints>
+            <point key="canvasLocation" x="-44" y="33"/>
+        </customView>
+    </objects>
+</document>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryScrubberItem.xib
@@ -10,39 +10,64 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView identifier="TimeEntryScrubberItem" id="c22-O7-iKe" customClass="TimeEntryScrubberItem" customModule="TogglDesktop" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="92" height="25"/>
+            <rect key="frame" x="0.0" y="0.0" width="133" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LPf-Zn-zKx">
-                    <rect key="frame" x="2" y="9" width="65" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Description" usesSingleLineMode="YES" id="WiE-03-2mE">
-                        <font key="font" metaFont="controlContent" size="11"/>
+                    <rect key="frame" x="4" y="27" width="69" height="16"/>
+                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Description" id="WiE-03-2mE">
+                        <font key="font" metaFont="system" size="12"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bOg-rk-NNg">
-                    <rect key="frame" x="2" y="2" width="42" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" title="Project" usesSingleLineMode="YES" id="9Mi-aX-45M">
-                        <font key="font" metaFont="controlContent" size="11"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
+                <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="2" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CJZ-Nm-BPa">
+                    <rect key="frame" x="6" y="2" width="125" height="16"/>
+                    <subviews>
+                        <imageView horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="jV3-D3-rv6" customClass="DotImageView" customModule="TogglDesktop" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="5" width="6" height="6"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="6" id="2JI-g0-tkh"/>
+                                <constraint firstAttribute="height" constant="6" id="iGa-kr-ijj"/>
+                            </constraints>
+                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="time-entry-dot" id="ZvK-Hr-dZM"/>
+                        </imageView>
+                        <textField horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Td-j7-cbW" customClass="ProjectTextField">
+                            <rect key="frame" x="6" y="0.0" width="121" height="16"/>
+                            <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" alignment="left" title="NEW - TOGGL" placeholderString="+ Add project" id="SMR-gb-5FL">
+                                <font key="font" metaFont="system" size="12"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                    </subviews>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
             </subviews>
             <constraints>
-                <constraint firstItem="LPf-Zn-zKx" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="4" id="2zy-KV-ibl"/>
-                <constraint firstItem="bOg-rk-NNg" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="4" id="Arg-KK-EkE"/>
-                <constraint firstItem="LPf-Zn-zKx" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="2" id="H8s-z0-gpg"/>
-                <constraint firstAttribute="bottom" secondItem="bOg-rk-NNg" secondAttribute="bottom" constant="2" id="O2E-Hf-k3N"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LPf-Zn-zKx" secondAttribute="trailing" id="wqF-T0-oMp"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bOg-rk-NNg" secondAttribute="trailing" id="zl5-jD-qDc"/>
+                <constraint firstAttribute="bottom" secondItem="CJZ-Nm-BPa" secondAttribute="bottom" constant="2" id="04b-zC-uuA"/>
+                <constraint firstItem="LPf-Zn-zKx" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="6" id="2zy-KV-ibl"/>
+                <constraint firstItem="LPf-Zn-zKx" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="1" id="H8s-z0-gpg"/>
+                <constraint firstItem="CJZ-Nm-BPa" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="6" id="HYd-V3-Jar"/>
+                <constraint firstAttribute="trailing" secondItem="CJZ-Nm-BPa" secondAttribute="trailing" constant="2" id="Szv-xR-stR"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LPf-Zn-zKx" secondAttribute="trailing" constant="2" id="wqF-T0-oMp"/>
             </constraints>
             <connections>
                 <outlet property="desciptionLbl" destination="LPf-Zn-zKx" id="SDR-NV-VvU"/>
-                <outlet property="projectLbl" destination="bOg-rk-NNg" id="TXf-x3-csg"/>
+                <outlet property="dotImageView" destination="jV3-D3-rv6" id="Cuy-ZY-4lB"/>
+                <outlet property="projectLbl" destination="7Td-j7-cbW" id="vUP-NB-y7j"/>
             </connections>
-            <point key="canvasLocation" x="-33" y="32.5"/>
+            <point key="canvasLocation" x="-12.5" y="42"/>
         </customView>
     </objects>
+    <resources>
+        <image name="time-entry-dot" width="8" height="8"/>
+    </resources>
 </document>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -1,0 +1,59 @@
+//
+//  TimeEntryTouchbar.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 10/1/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+
+@available(OSX 10.12.2, *)
+final class TimeEntryTouchBar: NSObject {
+
+    // MARK: Variables
+
+    private lazy var touchBar = NSTouchBar()
+
+    // MARK: Init
+
+    override init() {
+        super.init()
+        initCommon()
+        setup()
+    }
+}
+
+@available(OSX 10.12.2, *)
+extension TimeEntryTouchBar {
+
+    fileprivate func initCommon() {
+
+    }
+
+    fileprivate func setup() {
+        touchBar.delegate = self
+        touchBar.customizationIdentifier = .timeEntry
+        touchBar.defaultItemIdentifiers = [.timeEntryItem, .flexibleSpace, .runningTimeEntry, .startStopItem]
+    }
+}
+
+// MARK: NSTouchBarDelegate
+
+@available(OSX 10.12.2, *)
+extension TimeEntryTouchBar: NSTouchBarDelegate {
+
+}
+
+@available(OSX 10.12.2, *)
+extension NSTouchBar.CustomizationIdentifier {
+    static let timeEntry = NSTouchBar.CustomizationIdentifier("com.toggl.toggldesktop.timeentrytouchbar")
+}
+
+@available(OSX 10.12.2, *)
+extension NSTouchBarItem.Identifier {
+
+    static let timeEntryItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.timeentryitems")
+    static let runningTimeEntry = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.runningtimeentry")
+    static let startStopItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.startstopbutton")
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -18,8 +18,10 @@ final class TimeEntryTouchBar: NSObject {
 
     private lazy var startButton: NSButton = {
         let btn = NSButton(title: "Start", target: self, action: #selector(self.startBtnOnTap(_:)))
-        btn.title = "Start"
-        btn.alternateTitle = "Stop"
+        btn.image = NSImage(named: NSImage.touchBarPlayTemplateName)
+        btn.alternateImage = NSImage(named: NSImage.touchBarRecordStopTemplateName)
+        btn.imagePosition = .imageOnly
+        btn.setButtonType(.toggle)
         return btn
     }()
 
@@ -58,10 +60,10 @@ extension TimeEntryTouchBar {
     }
 
     @objc private func stateButtonTimerBarChangeNotification(_ noti: Notification) {
-        guard let state = noti.object as? NSButton.StateValue else {
+        guard let value = noti.object as? NSNumber else {
             return
         }
-        startButton.state = state
+        startButton.state = NSControl.StateValue(rawValue: value.intValue)
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -9,11 +9,12 @@
 import Foundation
 
 @available(OSX 10.12.2, *)
+@objcMembers
 final class TimeEntryTouchBar: NSObject {
 
     // MARK: Variables
 
-    private lazy var touchBar = NSTouchBar()
+    lazy var touchBar = NSTouchBar()
 
     // MARK: Init
 
@@ -28,7 +29,7 @@ final class TimeEntryTouchBar: NSObject {
 extension TimeEntryTouchBar {
 
     fileprivate func initCommon() {
-
+        NSApplication.shared.isAutomaticCustomizeTouchBarMenuItemEnabled = true
     }
 
     fileprivate func setup() {
@@ -43,6 +44,27 @@ extension TimeEntryTouchBar {
 @available(OSX 10.12.2, *)
 extension TimeEntryTouchBar: NSTouchBarDelegate {
 
+    func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
+        switch identifier {
+        case NSTouchBarItem.Identifier.timeEntryItem:
+            let item = NSCustomTouchBarItem(identifier: identifier)
+            let button = NSButton(title: "TimeEntry 1", target: nil, action: nil)
+            item.view = button
+            return item
+        case NSTouchBarItem.Identifier.runningTimeEntry:
+            let item = NSCustomTouchBarItem(identifier: identifier)
+            let button = NSButton(title: "Running...", target: nil, action: nil)
+            item.view = button
+            return item
+        case NSTouchBarItem.Identifier.startStopItem:
+            let item = NSCustomTouchBarItem(identifier: identifier)
+            let button = NSButton(title: "Start", target: nil, action: nil)
+            item.view = button
+            return item
+        default:
+            return nil
+        }
+    }
 }
 
 @available(OSX 10.12.2, *)

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -12,6 +12,8 @@ import Foundation
 @objcMembers
 final class TimeEntryTouchBar: NSObject {
 
+    static let shared = TimeEntryTouchBar()
+    
     // MARK: Variables
 
     lazy var touchBar = NSTouchBar()

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -39,6 +39,17 @@ extension TimeEntryTouchBar {
         touchBar.customizationIdentifier = .timeEntry
         touchBar.defaultItemIdentifiers = [.timeEntryItem, .flexibleSpace, .runningTimeEntry, .startStopItem]
     }
+
+    fileprivate func initNotification() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(self.stateButtonTimerBarChangeNotification(_:)),
+                                               name: NSNotification.Name(kStartButtonStateChange),
+                                               object: nil)
+    }
+
+    @objc private func stateButtonTimerBarChangeNotification(_ noti: Notification) {
+        
+    }
 }
 
 // MARK: NSTouchBarDelegate

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TimeEntryTouchbar.swift
@@ -13,7 +13,16 @@ import Foundation
 final class TimeEntryTouchBar: NSObject {
 
     static let shared = TimeEntryTouchBar()
-    
+
+    // MARK: OUTLET
+
+    private lazy var startButton: NSButton = {
+        let btn = NSButton(title: "Start", target: self, action: #selector(self.startBtnOnTap(_:)))
+        btn.title = "Start"
+        btn.alternateTitle = "Stop"
+        return btn
+    }()
+
     // MARK: Variables
 
     lazy var touchBar = NSTouchBar()
@@ -24,6 +33,7 @@ final class TimeEntryTouchBar: NSObject {
         super.init()
         initCommon()
         setup()
+        initNotification()
     }
 }
 
@@ -48,7 +58,10 @@ extension TimeEntryTouchBar {
     }
 
     @objc private func stateButtonTimerBarChangeNotification(_ noti: Notification) {
-        
+        guard let state = noti.object as? NSButton.StateValue else {
+            return
+        }
+        startButton.state = state
     }
 }
 
@@ -71,8 +84,7 @@ extension TimeEntryTouchBar: NSTouchBarDelegate {
             return item
         case NSTouchBarItem.Identifier.startStopItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
-            let button = NSButton(title: "Start", target: nil, action: nil)
-            item.view = button
+            item.view = startButton
             return item
         default:
             return nil
@@ -91,4 +103,14 @@ extension NSTouchBarItem.Identifier {
     static let timeEntryItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.timeentryitems")
     static let runningTimeEntry = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.runningtimeentry")
     static let startStopItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.startstopbutton")
+}
+
+// MARK: Private
+
+@available(OSX 10.12.2, *)
+extension TimeEntryTouchBar {
+
+    @objc fileprivate func startBtnOnTap(_ sender: NSButton) {
+
+    }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
@@ -1,0 +1,22 @@
+//
+//  TouchBarService+Name.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 10/8/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Foundation
+
+@available(OSX 10.12.2, *)
+extension NSTouchBar.CustomizationIdentifier {
+    static let timeEntry = NSTouchBar.CustomizationIdentifier("com.toggl.toggldesktop.timeentrytouchbar")
+}
+
+@available(OSX 10.12.2, *)
+extension NSTouchBarItem.Identifier {
+
+    static let timeEntryItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.timeentryitems")
+    static let runningTimeEntry = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.runningtimeentry")
+    static let startStopItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.startstopbutton")
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService+Name.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @available(OSX 10.12.2, *)
 extension NSTouchBar.CustomizationIdentifier {
-    static let timeEntry = NSTouchBar.CustomizationIdentifier("com.toggl.toggldesktop.timeentrytouchbar")
+    static let mainTouchBar = NSTouchBar.CustomizationIdentifier("com.toggl.toggldesktop.maintouchbar")
 }
 
 @available(OSX 10.12.2, *)

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -19,6 +19,11 @@ final class TouchBarService: NSObject {
 
     static let shared = TouchBarService()
 
+    enum DisplayState {
+        case tracking
+        case normal
+    }
+
     // MARK: OUTLET
 
     private lazy var startButton: NSButton = {
@@ -34,6 +39,7 @@ final class TouchBarService: NSObject {
 
     lazy var touchBar = NSTouchBar()
     weak var delegate: TouchBarServiceDelegate?
+    private var displayState = DisplayState.normal { didSet { updateDisplayState() }}
 
     // MARK: Init
 
@@ -57,7 +63,7 @@ extension TouchBarService {
     fileprivate func setup() {
         touchBar.delegate = self
         touchBar.customizationIdentifier = .timeEntry
-        touchBar.defaultItemIdentifiers = [.timeEntryItem, .flexibleSpace, .runningTimeEntry, .startStopItem]
+        touchBar.defaultItemIdentifiers = [.timeEntryItem, .flexibleSpace, .startStopItem]
     }
 
     fileprivate func initNotification() {
@@ -72,6 +78,17 @@ extension TouchBarService {
             return
         }
         startButton.state = NSControl.StateValue(rawValue: value.intValue)
+        displayState = startButton.state == .on ? .tracking : .normal
+    }
+
+    private func updateDisplayState() {
+        switch displayState {
+        case .normal:
+            touchBar.defaultItemIdentifiers.removeAll(where: { $0 == .runningTimeEntry })
+        case .tracking:
+            let count = touchBar.defaultItemIdentifiers.count
+            touchBar.defaultItemIdentifiers.insert(.runningTimeEntry, at: count - 1)
+        }
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -53,8 +53,9 @@ final class TouchBarService: NSObject {
         view.dataSource = self
         view.mode = NSScrubber.Mode.free
         view.register(TimeEntryScrubberItem.self, forItemIdentifier: Constants.TimeEntryIdentifer)
-        let layout = NSScrubberFlowLayout()
-        layout.itemSize = CGSize(width: 200, height: 30)
+        let layout = TimeEntryScrubberFlowLayout()
+        layout.itemSpacing = 4
+        layout.delegate = self
         view.scrubberLayout = layout
         return view
     }()
@@ -162,6 +163,8 @@ extension TouchBarService {
     }
 }
 
+// MARK: NSScrubberDataSource
+
 @available(OSX 10.12.2, *)
 extension TouchBarService: NSScrubberDelegate, NSScrubberDataSource {
 
@@ -179,5 +182,16 @@ extension TouchBarService: NSScrubberDelegate, NSScrubberDataSource {
 
     func scrubber(_ scrubber: NSScrubber, didSelectItemAt selectedIndex: Int) {
         print(selectedIndex)
+    }
+}
+
+// MARK: TimeEntryScrubberFlowLayoutDelegate
+
+@available(OSX 10.12.2, *)
+extension TouchBarService: TimeEntryScrubberFlowLayoutDelegate {
+
+    func timeEntryScrubberTitle(at index: Int) -> String {
+        let timeEntry = timeEntries[index]
+        return timeEntry.touchBarTitle
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -52,8 +52,10 @@ final class TouchBarService: NSObject {
         view.delegate = self
         view.dataSource = self
         view.mode = NSScrubber.Mode.free
-//        view.itemAlignment = NSScrubber.Alignment.leading
         view.register(TimeEntryScrubberItem.self, forItemIdentifier: Constants.TimeEntryIdentifer)
+        let layout = NSScrubberFlowLayout()
+        layout.itemSize = CGSize(width: 200, height: 30)
+        view.scrubberLayout = layout
         return view
     }()
 
@@ -128,17 +130,16 @@ extension TouchBarService: NSTouchBarDelegate {
         switch identifier {
         case NSTouchBarItem.Identifier.timeEntryItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
-            item.visibilityPriority = .high
             item.view = scrubberView
             return item
         case NSTouchBarItem.Identifier.runningTimeEntry:
             let item = NSCustomTouchBarItem(identifier: identifier)
-//            item.visibilityPriority = .high
+            item.visibilityPriority = .high
             item.view = runningTimeEntryBtn
             return item
         case NSTouchBarItem.Identifier.startStopItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
-//            item.visibilityPriority = .high
+            item.visibilityPriority = .high
             item.view = startButton
             return item
         default:

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -52,6 +52,9 @@ final class TouchBarService: NSObject {
         view.delegate = self
         view.dataSource = self
         view.mode = NSScrubber.Mode.free
+        view.selectionBackgroundStyle = .outlineOverlay
+        view.selectionOverlayStyle = .outlineOverlay
+        view.showsAdditionalContentIndicators = true
         view.register(NSNib(nibNamed: NSNib.Name("TimeEntryScrubberItem"), bundle: nil), forItemIdentifier: Constants.TimeEntryIdentifer)
         let layout = TimeEntryScrubberFlowLayout()
         layout.itemSpacing = 8

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -52,7 +52,7 @@ final class TouchBarService: NSObject {
         view.delegate = self
         view.dataSource = self
         view.mode = NSScrubber.Mode.free
-        view.register(TimeEntryScrubberItem.self, forItemIdentifier: Constants.TimeEntryIdentifer)
+        view.register(NSNib(nibNamed: NSNib.Name("TimeEntryScrubberItem"), bundle: nil), forItemIdentifier: Constants.TimeEntryIdentifer)
         let layout = TimeEntryScrubberFlowLayout()
         layout.itemSpacing = 4
         layout.delegate = self

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -1,5 +1,5 @@
 //
-//  TimeEntryTouchbar.swift
+//  TouchBarService.swift
 //  TogglDesktop
 //
 //  Created by Nghia Tran on 10/1/19.
@@ -8,11 +8,16 @@
 
 import Foundation
 
+@objc protocol TouchBarServiceDelegate: class {
+
+    func touchBarServiceStartTimeEntryOnTap()
+}
+
 @available(OSX 10.12.2, *)
 @objcMembers
-final class TimeEntryTouchBar: NSObject {
+final class TouchBarService: NSObject {
 
-    static let shared = TimeEntryTouchBar()
+    static let shared = TouchBarService()
 
     // MARK: OUTLET
 
@@ -28,6 +33,7 @@ final class TimeEntryTouchBar: NSObject {
     // MARK: Variables
 
     lazy var touchBar = NSTouchBar()
+    weak var delegate: TouchBarServiceDelegate?
 
     // MARK: Init
 
@@ -39,8 +45,10 @@ final class TimeEntryTouchBar: NSObject {
     }
 }
 
+// MARK: Private
+
 @available(OSX 10.12.2, *)
-extension TimeEntryTouchBar {
+extension TouchBarService {
 
     fileprivate func initCommon() {
         NSApplication.shared.isAutomaticCustomizeTouchBarMenuItemEnabled = true
@@ -70,7 +78,7 @@ extension TimeEntryTouchBar {
 // MARK: NSTouchBarDelegate
 
 @available(OSX 10.12.2, *)
-extension TimeEntryTouchBar: NSTouchBarDelegate {
+extension TouchBarService: NSTouchBarDelegate {
 
     func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
         switch identifier {
@@ -94,25 +102,12 @@ extension TimeEntryTouchBar: NSTouchBarDelegate {
     }
 }
 
-@available(OSX 10.12.2, *)
-extension NSTouchBar.CustomizationIdentifier {
-    static let timeEntry = NSTouchBar.CustomizationIdentifier("com.toggl.toggldesktop.timeentrytouchbar")
-}
-
-@available(OSX 10.12.2, *)
-extension NSTouchBarItem.Identifier {
-
-    static let timeEntryItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.timeentryitems")
-    static let runningTimeEntry = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.runningtimeentry")
-    static let startStopItem = NSTouchBarItem.Identifier("com.toggl.toggldesktop.timeentrytouchbar.startstopbutton")
-}
-
 // MARK: Private
 
 @available(OSX 10.12.2, *)
-extension TimeEntryTouchBar {
+extension TouchBarService {
 
     @objc fileprivate func startBtnOnTap(_ sender: NSButton) {
-
+        delegate?.touchBarServiceStartTimeEntryOnTap()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -35,6 +35,8 @@ final class TouchBarService: NSObject {
         return btn
     }()
 
+    private lazy var runningTimeEntryBtn = NSButton(title: "Running...", target: nil, action: nil)
+
     // MARK: Variables
 
     lazy var touchBar = NSTouchBar()
@@ -48,6 +50,16 @@ final class TouchBarService: NSObject {
         initCommon()
         setup()
         initNotification()
+    }
+
+    // MARK: Public
+
+    func updateRunningItem(_ timeEntry: TimeEntryViewItem) {
+        var title = timeEntry.descriptionName ?? ""
+        if title.isEmpty { title = "(no description)" }
+
+        // Update
+        runningTimeEntryBtn.title = title
     }
 }
 
@@ -101,16 +113,18 @@ extension TouchBarService: NSTouchBarDelegate {
         switch identifier {
         case NSTouchBarItem.Identifier.timeEntryItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
+            item.visibilityPriority = .normal
             let button = NSButton(title: "TimeEntry 1", target: nil, action: nil)
             item.view = button
             return item
         case NSTouchBarItem.Identifier.runningTimeEntry:
             let item = NSCustomTouchBarItem(identifier: identifier)
-            let button = NSButton(title: "Running...", target: nil, action: nil)
-            item.view = button
+            item.visibilityPriority = .high
+            item.view = runningTimeEntryBtn
             return item
         case NSTouchBarItem.Identifier.startStopItem:
             let item = NSCustomTouchBarItem(identifier: identifier)
+            item.visibilityPriority = .high
             item.view = startButton
             return item
         default:

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -102,6 +102,17 @@ final class TouchBarService: NSObject {
         self.timeEntries = (touchBarEntries)
         scrubberView.reloadData()
     }
+
+    func reset() {
+        self.timeEntries = []
+        scrubberView.reloadData()
+        startButton.isHidden = true
+    }
+
+    func prepareForPresent() {
+        scrubberView.reloadData()
+        startButton.isHidden = false
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -157,10 +157,6 @@ extension TouchBarService {
     @objc fileprivate func startBtnOnTap(_ sender: NSButton) {
         delegate?.touchBarServiceStartTimeEntryOnTap()
     }
-
-    @objc fileprivate func timeEntryBtnOnTap(_ sender: NSButton) {
-
-    }
 }
 
 // MARK: NSScrubberDataSource
@@ -181,7 +177,11 @@ extension TouchBarService: NSScrubberDelegate, NSScrubberDataSource {
     }
 
     func scrubber(_ scrubber: NSScrubber, didSelectItemAt selectedIndex: Int) {
-        print(selectedIndex)
+        guard let item = timeEntries[safe: selectedIndex] else { return }
+        NotificationCenter.default.post(name: NSNotification.Name(kCommandContinue), object: item.guid)
+
+        // Deselect, so we can select it again
+        scrubber.selectedIndex = -1
     }
 }
 

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -26,6 +26,7 @@ final class TouchBarService: NSObject {
 
     fileprivate struct Constants {
         static let TimeEntryIdentifer = NSUserInterfaceItemIdentifier("TimeEntryScrubberItem")
+        static let NumberTimeEntry = 5
     }
 
     // MARK: OUTLET
@@ -86,7 +87,19 @@ final class TouchBarService: NSObject {
     }
 
     func updateTimeEntryList(_ timeEntries: [TimeEntryViewItem]) {
-        self.timeEntries = Array(timeEntries.prefix(5))
+        // Only get unique Time Entry (Don't get the TE in the group)
+        var touchBarEntries: [TimeEntryViewItem] = []
+        for timeEntry in timeEntries {
+            // Ingore the time entry in the group
+            if timeEntry.groupOpen && !timeEntry.group {
+                continue
+            }
+            touchBarEntries.append(timeEntry)
+            if touchBarEntries.count >= Constants.NumberTimeEntry {
+                break
+            }
+        }
+        self.timeEntries = (touchBarEntries)
         scrubberView.reloadData()
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -54,7 +54,7 @@ final class TouchBarService: NSObject {
         view.mode = NSScrubber.Mode.free
         view.register(NSNib(nibNamed: NSNib.Name("TimeEntryScrubberItem"), bundle: nil), forItemIdentifier: Constants.TimeEntryIdentifer)
         let layout = TimeEntryScrubberFlowLayout()
-        layout.itemSpacing = 4
+        layout.itemSpacing = 8
         layout.delegate = self
         view.scrubberLayout = layout
         return view

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/TouchBarService.swift
@@ -51,7 +51,7 @@ final class TouchBarService: NSObject {
         let view = NSScrubber(frame: .zero)
         view.delegate = self
         view.dataSource = self
-        view.mode = NSScrubber.Mode.free
+        view.mode = .free
         view.selectionBackgroundStyle = .outlineOverlay
         view.selectionOverlayStyle = .outlineOverlay
         view.showsAdditionalContentIndicators = true
@@ -76,6 +76,13 @@ final class TouchBarService: NSObject {
 
     func updateRunningItem(_ timeEntry: TimeEntryViewItem) {
         runningTimeEntryBtn.title = timeEntry.touchBarTitle
+        if let colorStr = timeEntry.projectColor,
+            !colorStr.isEmpty,
+            let color = ConvertHexColor.hexCode(toNSColor: colorStr) {
+            runningTimeEntryBtn.bezelColor = color
+        } else {
+            runningTimeEntryBtn.bezelColor = nil
+        }
     }
 
     func updateTimeEntryList(_ timeEntries: [TimeEntryViewItem]) {
@@ -180,11 +187,15 @@ extension TouchBarService: NSScrubberDelegate, NSScrubberDataSource {
     }
 
     func scrubber(_ scrubber: NSScrubber, didSelectItemAt selectedIndex: Int) {
-        guard let item = timeEntries[safe: selectedIndex] else { return }
+        continueTimeEntry(at: selectedIndex)
+    }
+
+    private func continueTimeEntry(at index: Int) {
+        guard let item = timeEntries[safe: index] else { return }
         NotificationCenter.default.post(name: NSNotification.Name(kCommandContinue), object: item.guid)
 
         // Deselect, so we can select it again
-        scrubber.selectedIndex = -1
+        scrubberView.selectedIndex = -1
     }
 }
 

--- a/src/ui/osx/TogglDesktop/LoginViewController.m
+++ b/src/ui/osx/TogglDesktop/LoginViewController.m
@@ -527,4 +527,9 @@ extern void *ctx;
 	return YES;
 }
 
+- (NSTouchBar *)makeTouchBar
+{
+	return nil;
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -285,4 +285,9 @@ extern void *ctx;
 	}
 }
 
+- (NSTouchBar *)makeTouchBar
+{
+	return [self.timeEntryListViewController makeTouchBar];
+}
+
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -287,7 +287,7 @@ extern void *ctx;
 
 - (NSTouchBar *)makeTouchBar
 {
-	return [self.timeEntryListViewController makeTouchBar];
+	return [[TimeEntryTouchBar shared] touchBar];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -133,6 +133,9 @@ extern void *ctx;
 
 		[self.timeEntryListViewController.view removeFromSuperview];
 		[self.overlayViewController.view removeFromSuperview];
+
+		// Reset the data
+		[[TouchBarService shared] reset];
 	}
 }
 
@@ -162,6 +165,9 @@ extern void *ctx;
 
 			[[NSNotificationCenter defaultCenter] postNotificationOnMainThread:kFocusTimer
 																		object:nil];
+
+			// Prepare the Touch bar
+			[[TouchBarService shared] prepareForPresent];
 		}
 	}
 }
@@ -297,6 +303,10 @@ extern void *ctx;
 
 - (NSTouchBar *)makeTouchBar
 {
+	if (self.loginViewController.view.superview != nil)
+	{
+		return nil;
+	}
 	return [[TouchBarService shared] touchBar];
 }
 

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -18,7 +18,7 @@
 #import "TogglDesktop-Swift.h"
 #import "TimerEditViewController.h"
 
-@interface MainWindowController ()
+@interface MainWindowController () <TouchBarServiceDelegate>
 @property (weak) IBOutlet NSView *contentView;
 @property (weak) IBOutlet NSView *mainView;
 @property (nonatomic, strong) LoginViewController *loginViewController;
@@ -87,6 +87,14 @@ extern void *ctx;
 	// Error View
 	[self initErrorView];
 	[self setInitialWindowSizeIfNeed];
+
+	// Touch bar
+	[self initTouchBar];
+}
+
+- (void)initTouchBar
+{
+	[TouchBarService shared].delegate = self;
 }
 
 - (void)initErrorView {
@@ -285,9 +293,16 @@ extern void *ctx;
 	}
 }
 
+#pragma mark - Touch Bar
+
 - (NSTouchBar *)makeTouchBar
 {
-	return [[TimeEntryTouchBar shared] touchBar];
+	return [[TouchBarService shared] touchBar];
+}
+
+- (void)touchBarServiceStartTimeEntryOnTap
+{
+	[self.timeEntryListViewController.timerEditViewController startButtonClicked:self];
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -71,6 +71,8 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet NSButton *changeDurationButton;
 @property (weak) IBOutlet NSSegmentedControl *tabSegment;
 @property (weak) IBOutlet NSTabView *tabView;
+@property (weak) IBOutlet NSButton *showTouchBarButton;
+@property (weak) IBOutlet NSLayoutConstraint *bottomContainerHeight;
 
 @property (nonatomic, assign) NSInteger selectedProxyIndex;
 @property (nonatomic, strong) NSArray<AutotrackerRuleItem *> *rules;
@@ -106,6 +108,7 @@ typedef enum : NSUInteger
 - (IBAction)openEditorOnShortcut:(id)sender;
 - (IBAction)defaultProjectSelected:(id)sender;
 - (IBAction)changeDurationButtonChanged:(id)sender;
+- (IBAction)touchBarButtonChanged:(id)sender;
 
 @end
 
@@ -202,6 +205,9 @@ extern void *ctx;
 - (IBAction)changeDurationButtonChanged:(id)sender
 {
 	toggl_set_keep_end_time_fixed(ctx, [Utils stateToBool:[self.changeDurationButton state]]);
+}
+
+- (IBAction)touchBarButtonChanged:(id)sender {
 }
 
 - (IBAction)proxyRadioChanged:(id)sender

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -207,7 +207,9 @@ extern void *ctx;
 	toggl_set_keep_end_time_fixed(ctx, [Utils stateToBool:[self.changeDurationButton state]]);
 }
 
-- (IBAction)touchBarButtonChanged:(id)sender {
+- (IBAction)touchBarButtonChanged:(id)sender
+{
+	toggl_set_settings_show_touch_bar(ctx, [Utils stateToBool:[self.showTouchBarButton state]]);
 }
 
 - (IBAction)proxyRadioChanged:(id)sender
@@ -499,6 +501,18 @@ const int kUseProxyToConnectToToggl = 2;
 	free(default_project_name);
 
 	[self.changeDurationButton setState:[Utils boolToState:toggl_get_keep_end_time_fixed(ctx)]];
+
+	if (@available(macOS 10.12.2, *))
+	{
+		self.showTouchBarButton.hidden = NO;
+		self.bottomContainerHeight.constant = 58;
+		[self.showTouchBarButton setState:[Utils boolToState:toggl_get_show_touch_bar(ctx)]];
+	}
+	else
+	{
+		self.showTouchBarButton.hidden = YES;
+		self.bottomContainerHeight.constant = 38;
+	}
 }
 
 - (void)selectProxyRadioWithTag:(NSInteger)tag

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,6 +14,7 @@
                 <outlet property="autotrackerProject" destination="TN9-Mx-4gf" id="94P-Mq-SHg"/>
                 <outlet property="autotrackerRulesTableView" destination="aw6-zQ-ZW8" id="3SU-TC-YlQ"/>
                 <outlet property="autotrackerTerm" destination="afg-Ty-RcE" id="KZ5-IU-C0e"/>
+                <outlet property="bottomContainerHeight" destination="i5y-AO-dds" id="qBO-oj-OAo"/>
                 <outlet property="changeDurationButton" destination="TkJ-tA-lDK" id="tZ1-lP-zjX"/>
                 <outlet property="defaultProject" destination="AQZ-NT-Pr8" id="Yug-eK-iIR"/>
                 <outlet property="dockIconCheckbox" destination="kR2-Ee-viZ" id="Nm7-te-1KH"/>
@@ -44,6 +45,7 @@
                 <outlet property="reminderCheckbox" destination="Spu-c6-dBl" id="rce-jc-2Cq"/>
                 <outlet property="reminderMinutesTextField" destination="R9v-BZ-yhR" id="OVt-ic-hzF"/>
                 <outlet property="showHideShortcutView" destination="DLB-Fw-7tX" id="T2o-mF-KXG"/>
+                <outlet property="showTouchBarButton" destination="uPL-ax-1Ux" id="eAl-AY-wbs"/>
                 <outlet property="startStopShortcutView" destination="Ft4-tk-xRA" id="5tb-G5-s2R"/>
                 <outlet property="stopOnShutdownCheckbox" destination="n3k-Br-KIY" id="guw-6w-Kef"/>
                 <outlet property="tabSegment" destination="2zJ-7y-OAc" id="qpb-67-EOV"/>
@@ -60,21 +62,21 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="Preferences" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="400" height="570"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <value key="minSize" type="size" width="400" height="570"/>
+            <rect key="contentRect" x="196" y="240" width="400" height="590"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <value key="minSize" type="size" width="400" height="590"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="qdc-hR-YLw">
-                        <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                        <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                         <view key="contentView" id="QZK-80-mX3">
-                            <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                            <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RqW-Eb-jQc">
-                                    <rect key="frame" x="166" y="551" width="81" height="17"/>
+                                    <rect key="frame" x="166" y="571" width="81" height="17"/>
                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="DcZ-K3-JhQ">
                                         <font key="font" usesAppearanceFont="YES"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -90,16 +92,16 @@
                         <color key="fillColor" name="preference-background-color"/>
                     </box>
                     <tabView drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="ZDX-gA-MBn">
-                        <rect key="frame" x="0.0" y="0.0" width="412" height="540"/>
+                        <rect key="frame" x="0.0" y="0.0" width="412" height="560"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="3dj-rq-0aF">
                                 <view key="view" id="7qY-5d-VHf">
-                                    <rect key="frame" x="0.0" y="0.0" width="412" height="540"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="412" height="560"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="KYJ-q7-LnW">
-                                            <rect key="frame" x="15" y="320" width="382" height="208"/>
+                                            <rect key="frame" x="15" y="340" width="382" height="208"/>
                                             <view key="contentView" id="a3O-tS-arC">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="208"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -292,7 +294,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="brM-0V-2IH">
-                                            <rect key="frame" x="15" y="180" width="382" height="130"/>
+                                            <rect key="frame" x="15" y="200" width="382" height="130"/>
                                             <view key="contentView" id="vnT-py-ejH">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="130"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -371,7 +373,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zQS-pF-1EQ">
-                                            <rect key="frame" x="15" y="112" width="382" height="58"/>
+                                            <rect key="frame" x="15" y="132" width="382" height="58"/>
                                             <view key="contentView" id="Kte-rl-Tae">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -412,7 +414,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zez-BU-pHz">
-                                            <rect key="frame" x="15" y="56" width="382" height="46"/>
+                                            <rect key="frame" x="15" y="76" width="382" height="46"/>
                                             <view key="contentView" id="PaI-l4-AmI">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="46"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -455,31 +457,55 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="4OJ-cM-plX">
-                                            <rect key="frame" x="15" y="8" width="382" height="38"/>
+                                            <rect key="frame" x="15" y="8" width="382" height="58"/>
                                             <view key="contentView" id="l4g-U3-2Pc">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="38"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="TkJ-tA-lDK">
-                                                        <rect key="frame" x="8" y="11" width="297" height="16"/>
-                                                        <buttonCell key="cell" type="check" title="Change duration when changing start time" bezelStyle="regularSquare" imagePosition="left" inset="2" id="I1Q-IJ-dNX">
-                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                            <font key="font" metaFont="system" size="14"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="changeDurationButtonChanged:" target="-2" id="7MA-Tq-Byc"/>
-                                                            <outlet property="nextKeyView" destination="DLB-Fw-7tX" id="fV4-6n-SEL"/>
-                                                        </connections>
-                                                    </button>
+                                                    <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kxD-OV-7on">
+                                                        <rect key="frame" x="10" y="10" width="362" height="38"/>
+                                                        <subviews>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="TkJ-tA-lDK">
+                                                                <rect key="frame" x="-2" y="22" width="297" height="18"/>
+                                                                <buttonCell key="cell" type="check" title="Change duration when changing start time" bezelStyle="regularSquare" imagePosition="left" inset="2" id="I1Q-IJ-dNX">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system" size="14"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="changeDurationButtonChanged:" target="-2" id="7MA-Tq-Byc"/>
+                                                                    <outlet property="nextKeyView" destination="uPL-ax-1Ux" id="TX2-rh-CKg"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="uPL-ax-1Ux">
+                                                                <rect key="frame" x="-2" y="-2" width="181" height="18"/>
+                                                                <buttonCell key="cell" type="check" title="Show Toggl in Touch Bar" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Ies-tN-a1z">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system" size="14"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="touchBarButtonChanged:" target="-2" id="0PY-k5-epN"/>
+                                                                    <outlet property="nextKeyView" destination="DLB-Fw-7tX" id="50c-bo-ok0"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                        <visibilityPriorities>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                        </visibilityPriorities>
+                                                        <customSpacing>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                        </customSpacing>
+                                                    </stackView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="TkJ-tA-lDK" firstAttribute="leading" secondItem="l4g-U3-2Pc" secondAttribute="leading" constant="10" id="7ee-Qr-ikP"/>
-                                                    <constraint firstItem="TkJ-tA-lDK" firstAttribute="top" secondItem="l4g-U3-2Pc" secondAttribute="top" constant="13" id="RhY-kT-f2D"/>
-                                                    <constraint firstAttribute="bottom" secondItem="TkJ-tA-lDK" secondAttribute="bottom" constant="13" id="YxE-My-Mqw"/>
+                                                    <constraint firstAttribute="trailing" secondItem="kxD-OV-7on" secondAttribute="trailing" constant="10" id="7Sr-bV-ezI"/>
+                                                    <constraint firstItem="kxD-OV-7on" firstAttribute="top" secondItem="l4g-U3-2Pc" secondAttribute="top" constant="10" id="9ap-aJ-V6I"/>
+                                                    <constraint firstItem="kxD-OV-7on" firstAttribute="leading" secondItem="l4g-U3-2Pc" secondAttribute="leading" constant="10" id="f6y-qJ-EQ3"/>
                                                 </constraints>
                                             </view>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="38" id="i5y-AO-dds"/>
+                                                <constraint firstAttribute="height" constant="58" id="i5y-AO-dds"/>
                                             </constraints>
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
@@ -790,7 +816,7 @@
                                                         <rect key="frame" x="10" y="12" width="362" height="257"/>
                                                         <clipView key="contentView" id="anG-U7-QUu">
                                                             <rect key="frame" x="1" y="1" width="360" height="255"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="SWk-HQ-4y3" id="aw6-zQ-ZW8">
                                                                     <rect key="frame" x="0.0" y="0.0" width="360" height="232"/>
@@ -1171,7 +1197,7 @@
                         </tabViewItems>
                     </tabView>
                     <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="x8k-FT-alL">
-                        <rect key="frame" x="32" y="518" width="348" height="20"/>
+                        <rect key="frame" x="32" y="538" width="348" height="20"/>
                         <view key="contentView" id="6PL-X1-TWK">
                             <rect key="frame" x="0.0" y="0.0" width="348" height="20"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1179,7 +1205,7 @@
                         <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </box>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2zJ-7y-OAc">
-                        <rect key="frame" x="30" y="515" width="352" height="24"/>
+                        <rect key="frame" x="30" y="535" width="352" height="24"/>
                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="V97-Jh-edB">
                             <font key="font" metaFont="system"/>
                             <segments>

--- a/src/ui/osx/TogglDesktop/Settings.h
+++ b/src/ui/osx/TogglDesktop/Settings.h
@@ -42,6 +42,7 @@
 @property (nonatomic, assign) NSInteger pomodoro_minutes;
 @property (nonatomic, assign) NSInteger pomodoro_break_minutes;
 @property (nonatomic, assign) BOOL stopWhenShutdown;
+@property (nonatomic, assign) BOOL showTouchBar;
 
 - (void)load:(TogglSettingsView *)data;
 @end

--- a/src/ui/osx/TogglDesktop/Settings.m
+++ b/src/ui/osx/TogglDesktop/Settings.m
@@ -52,6 +52,7 @@
 
 	self.open_editor_on_shortcut = data->OpenEditorOnShortcut;
 	self.stopWhenShutdown = data->StopEntryOnShutdownSleep;
+	self.showTouchBar = data->ShowTouchBar;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -25,6 +25,7 @@ static NSString *kFrameKey = @"frame";
 @property (weak) IBOutlet TimeEntryCollectionView *collectionView;
 @property (weak) IBOutlet NSBox *emptyViewContainerView;
 
+@property (nonatomic, strong) TimeEntryTouchBar *timeEntryTouchBar;
 @property (nonatomic, strong) TimeEntryDatasource *dataSource;
 @property (nonatomic, assign) NSInteger defaultPopupHeight;
 @property (nonatomic, assign) NSInteger defaultPopupWidth;
@@ -728,6 +729,15 @@ extern void *ctx;
 		return;
 	}
 	[self.timerEditViewController focusTimer];
+}
+
+- (NSTouchBar *)makeTouchBar
+{
+	if (!self.timeEntryTouchBar)
+	{
+		self.timeEntryTouchBar = [[TimeEntryTouchBar alloc] init];
+	}
+	return self.timeEntryTouchBar.touchBar;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryListViewController.m
@@ -25,7 +25,6 @@ static NSString *kFrameKey = @"frame";
 @property (weak) IBOutlet TimeEntryCollectionView *collectionView;
 @property (weak) IBOutlet NSBox *emptyViewContainerView;
 
-@property (nonatomic, strong) TimeEntryTouchBar *timeEntryTouchBar;
 @property (nonatomic, strong) TimeEntryDatasource *dataSource;
 @property (nonatomic, assign) NSInteger defaultPopupHeight;
 @property (nonatomic, assign) NSInteger defaultPopupWidth;
@@ -729,15 +728,6 @@ extern void *ctx;
 		return;
 	}
 	[self.timerEditViewController focusTimer];
-}
-
-- (NSTouchBar *)makeTouchBar
-{
-	if (!self.timeEntryTouchBar)
-	{
-		self.timeEntryTouchBar = [[TimeEntryTouchBar alloc] init];
-	}
-	return self.timeEntryTouchBar.touchBar;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.h
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.h
@@ -58,6 +58,7 @@
 @property (copy, nonatomic) NSString *GroupDuration;
 // Group Item Count
 @property (assign, nonatomic) uint64_t GroupItemCount;
+@property (copy, nonatomic) NSString *touchBarTitle;
 
 - (NSString *)descriptionEntry;
 // if item can be deleted without confirm

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
@@ -161,7 +161,14 @@
 	}
 	else
 	{
-		self.touchBarTitle = self.ProjectLabel;
+		if (self.ProjectLabel.length != 0)
+		{
+			self.touchBarTitle = self.ProjectLabel;
+		}
+		else
+		{
+			self.touchBarTitle = @"(no description)";
+		}
 	}
 
 	[[UndoManager shared] storeWith:self];

--- a/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
+++ b/src/ui/osx/TogglDesktop/TimeEntryViewItem.m
@@ -155,6 +155,15 @@
 	self.GroupDuration = [NSString stringWithUTF8String:te->GroupDuration];
 	self.GroupItemCount = te->GroupItemCount;
 
+	if (self.descriptionName.length != 0)
+	{
+		self.touchBarTitle = self.descriptionName;
+	}
+	else
+	{
+		self.touchBarTitle = self.ProjectLabel;
+	}
+
 	[[UndoManager shared] storeWith:self];
 }
 

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.h
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.h
@@ -16,6 +16,7 @@
 @property (strong, nonatomic) NSArray *projectComboConstraint;
 @property (strong, nonatomic) NSArray *projectLabelConstraint;
 
+- (IBAction)startButtonClicked:(id)sender;
 - (void)timerFired:(NSTimer *)timer;
 - (void)fillEntryFromAutoComplete:(AutocompleteItem *)item;
 - (void)focusTimer;

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -296,6 +296,11 @@ NSString *kInactiveTimerColor = @"#999999";
 
 	// Hide
 	self.cancelBtn.hidden = YES;
+
+	if (self.time_entry != nil && self.time_entry.isRunning)
+	{
+		[[TouchBarService shared] updateRunningItem:self.time_entry];
+	}
 }
 
 - (void)startDisplayTimeEntryEditor:(NSNotification *)notification

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -31,6 +31,9 @@ typedef enum : NSUInteger
 	DisplayModeInput,
 } DisplayMode;
 
+static void *XXContext = &XXContext;
+static NSString *kStateKey = @"state";
+
 @interface TimerEditViewController () <ClickableImageViewDelegate>
 @property (weak) IBOutlet NSBoxClickable *manualBox;
 @property (weak) IBOutlet NSBoxClickable *mainBox;
@@ -126,11 +129,13 @@ NSString *kInactiveTimerColor = @"#999999";
 	[super viewDidLoad];
 
 	[self initCommon];
+	[self initKVO];
 }
 
 - (void)dealloc
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[self.startButton removeObserver:self forKeyPath:kStateKey];
 }
 
 - (void)initCommon
@@ -146,6 +151,14 @@ NSString *kInactiveTimerColor = @"#999999";
 
 	self.descriptionLabel.delegate = self;
 	self.tagFlag.delegate = self;
+}
+
+- (void)initKVO
+{
+	[self.startButton addObserver:self
+					   forKeyPath:kStateKey
+						  options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew
+						  context:XXContext];
 }
 
 - (void)viewDidAppear
@@ -758,6 +771,19 @@ NSString *kInactiveTimerColor = @"#999999";
 	self.billableFlag.hidden = YES;
 	self.cancelBtn.hidden = YES;
 	[self renderProjectLabelWithViewItem:nil];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+	if (context == XXContext)
+	{
+		id newValue = change[NSKeyValueChangeNewKey];
+		[[NSNotificationCenter defaultCenter] postNotificationName:kStartButtonStateChange object:newValue];
+	}
+	else
+	{
+		[super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+	}
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -50,7 +50,6 @@ static NSString *kStateKey = @"state";
 @property (weak) IBOutlet NSLayoutConstraint *projectTextFieldLeading;
 @property (weak) IBOutlet NSButton *cancelBtn;
 
-- (IBAction)startButtonClicked:(id)sender;
 - (IBAction)durationFieldChanged:(id)sender;
 - (IBAction)autoCompleteChanged:(id)sender;
 - (IBAction)addEntryBtnOnTap:(id)sender;

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -103,6 +103,10 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(stop:)
 													 name:kCommandStop
 												   object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(startTimerNotification:)
+													 name:kStartTimer
+												   object:nil];
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
 
@@ -711,7 +715,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 }
 
-- (void)startNewShortcut:(NSNotification *)notification
+- (void)startTimerNotification:(NSNotification *)notification
 {
 	[self startButtonClicked:self];
 }

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -777,8 +777,8 @@ NSString *kInactiveTimerColor = @"#999999";
 {
 	if (context == XXContext)
 	{
-		id newValue = change[NSKeyValueChangeNewKey];
-		[[NSNotificationCenter defaultCenter] postNotificationName:kStartButtonStateChange object:newValue];
+		[[NSNotificationCenter defaultCenter] postNotificationName:kStartButtonStateChange
+															object:[NSNumber numberWithInteger:self.startButton.state]];
 	}
 	else
 	{

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.xib
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.xib
@@ -257,7 +257,7 @@
                                     <rect key="frame" x="1" y="1" width="349" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Fy-tG-odG" customClass="BetterFocusAutoCompleteInput">
+                                        <textField verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Fy-tG-odG" customClass="BetterFocusAutoCompleteInput">
                                             <rect key="frame" x="-2" y="0.0" width="353" height="28"/>
                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" alignment="left" placeholderString="What are you doing?" usesSingleLineMode="YES" id="GDj-uR-Arc" customClass="VerticallyCenteredTextFieldCell" customModule="TogglDesktop" customModuleProvider="target">
                                                 <font key="font" metaFont="system" size="14"/>

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		95C0707A18CDB91500A34D0D /* NSCustomComboBox.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C0707918CDB91500A34D0D /* NSCustomComboBox.m */; };
 		BA00E9ED234C5A6C0011A703 /* TouchBarService+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */; };
 		BA00E9F0234C73990011A703 /* TimeEntryScrubberItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */; };
+		BA00E9F3234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9F2234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift */; };
+		BA00E9F5234C848A0011A703 /* TimeEntryScrubberItem.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA00E9F4234C848A0011A703 /* TimeEntryScrubberItem.xib */; };
 		BA013FF5225705B6000E5B91 /* HoverTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */; };
 		BA01404622570805000E5B91 /* TagCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA01404522570805000E5B91 /* TagCellView.swift */; };
 		BA0140482257080F000E5B91 /* TagCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA0140472257080F000E5B91 /* TagCellView.xib */; };
@@ -443,6 +445,8 @@
 		B671ACF75B3267B013176BD7 /* Pods-TogglDesktop.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TogglDesktop.release.xcconfig"; path = "Target Support Files/Pods-TogglDesktop/Pods-TogglDesktop.release.xcconfig"; sourceTree = "<group>"; };
 		BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TouchBarService+Name.swift"; sourceTree = "<group>"; };
 		BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntryScrubberItem.swift; sourceTree = "<group>"; };
+		BA00E9F2234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntryScrubberFlowLayout.swift; sourceTree = "<group>"; };
+		BA00E9F4234C848A0011A703 /* TimeEntryScrubberItem.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimeEntryScrubberItem.xib; sourceTree = "<group>"; };
 		BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverTableCellView.swift; sourceTree = "<group>"; };
 		BA01404522570805000E5B91 /* TagCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellView.swift; sourceTree = "<group>"; };
 		BA0140472257080F000E5B91 /* TagCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TagCellView.xib; sourceTree = "<group>"; };
@@ -1250,6 +1254,8 @@
 				BAF3ACD22343325A00E41B33 /* TouchBarService.swift */,
 				BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */,
 				BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */,
+				BA00E9F4234C848A0011A703 /* TimeEntryScrubberItem.xib */,
+				BA00E9F2234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift */,
 			);
 			path = TouchBar;
 			sourceTree = "<group>";
@@ -1401,6 +1407,7 @@
 				BA7D33532248981200B953A8 /* ProjectHeaderCellView.xib in Resources */,
 				BA05369F225E239600C26E1F /* ProjectWorksapceCellView.xib in Resources */,
 				BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */,
+				BA00E9F5234C848A0011A703 /* TimeEntryScrubberItem.xib in Resources */,
 				BA34F10122439C3000C27A15 /* EditorViewController.xib in Resources */,
 				74E857BC194F8854007A88B9 /* cacert.pem in Resources */,
 				BAB818EB228D5AA8008C2367 /* DescriptionContentCellView.xib in Resources */,
@@ -1661,6 +1668,7 @@
 				BA3E75D62229356D009AD291 /* SystemMessageView.swift in Sources */,
 				BA013FF5225705B6000E5B91 /* HoverTableCellView.swift in Sources */,
 				749BD0BD1833E28400980494 /* NSBoxClickable.m in Sources */,
+				BA00E9F3234C7BB80011A703 /* TimeEntryScrubberFlowLayout.swift in Sources */,
 				BA08E087222E709C0075F68E /* ProjectTextField.m in Sources */,
 				BA2E5FB1223787C300EB866E /* EditorPopover.swift in Sources */,
 				BA7D334F224897FC00B953A8 /* ProjectHeaderCellView.swift in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3C7B4E8D190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C7B4E8C190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m */; };
 		3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C7B4EB2190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m */; };
 		3C8979CA19235EA2007061E0 /* NSTextFieldClickablePointer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C8979C919235EA2007061E0 /* NSTextFieldClickablePointer.m */; };
+		3CB7CFF82222033B00A9C806 /* DFRFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */; };
 		3CC450E91A31ED540012440B /* NSTextFieldDuration.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CC450E81A31ED540012440B /* NSTextFieldDuration.m */; };
 		3CD30F431F58B02C006FAA0D /* OverlayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CD30F411F58B02C006FAA0D /* OverlayViewController.m */; };
 		3CD30F441F58B02C006FAA0D /* OverlayViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3CD30F421F58B02C006FAA0D /* OverlayViewController.xib */; };
@@ -329,6 +330,8 @@
 		3C7B4EB2190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSSecureTextFieldVerticallyAligned.m; sourceTree = "<group>"; };
 		3C8979C819235EA2007061E0 /* NSTextFieldClickablePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldClickablePointer.h; sourceTree = "<group>"; };
 		3C8979C919235EA2007061E0 /* NSTextFieldClickablePointer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldClickablePointer.m; sourceTree = "<group>"; };
+		3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DFRFoundation.framework; path = ../../../../../../../../System/Library/PrivateFrameworks/DFRFoundation.framework; sourceTree = "<group>"; };
+		3CB7CFF92222047C00A9C806 /* TouchBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchBar.h; sourceTree = "<group>"; };
 		3CC450E71A31ED540012440B /* NSTextFieldDuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFieldDuration.h; sourceTree = "<group>"; };
 		3CC450E81A31ED540012440B /* NSTextFieldDuration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSTextFieldDuration.m; sourceTree = "<group>"; };
 		3CD30F401F58B02C006FAA0D /* OverlayViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverlayViewController.h; sourceTree = "<group>"; };
@@ -615,6 +618,7 @@
 			files = (
 				BAD858CC228EAE7C00226C71 /* libz.tbd in Frameworks */,
 				74456B9D1A774BAE002A6338 /* TogglDesktopLibrary.dylib in Frameworks */,
+				3CB7CFF82222033B00A9C806 /* DFRFoundation.framework in Frameworks */,
 				743D94281827929C000E6F70 /* Carbon.framework in Frameworks */,
 				743D942618279290000E6F70 /* IOKit.framework in Frameworks */,
 				74AA947818090A8E0000539F /* Security.framework in Frameworks */,
@@ -703,6 +707,7 @@
 			children = (
 				BAD858CB228EAE7C00226C71 /* libz.tbd */,
 				BAD858C5228EAE3000226C71 /* libc++.tbd */,
+				3CB7CFD92222033B00A9C806 /* DFRFoundation.framework */,
 				74FD8CDF18A8EF8300F7DB80 /* TFDatePicker.framework */,
 				743D94271827929C000E6F70 /* Carbon.framework */,
 				743D942518279290000E6F70 /* IOKit.framework */,
@@ -1029,6 +1034,7 @@
 				BA3E75D722293576009AD291 /* SystemMessageView.xib */,
 				BA276A122240F5B500810C51 /* FloatingErrorView.swift */,
 				BA276A132240F5B500810C51 /* FloatingErrorView.xib */,
+				3CB7CFF92222047C00A9C806 /* TouchBar.h */,
 			);
 			path = SystemMessage;
 			sourceTree = "<group>";
@@ -1900,6 +1906,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Other/TogglDesktop-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1957,6 +1964,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Other/TogglDesktop-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		74F8FBA318313FA6000F09EE /* NSTextFieldClickable.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F8FBA218313FA6000F09EE /* NSTextFieldClickable.m */; };
 		95C0707718CDB67300A34D0D /* NSCustomComboBoxCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C0707618CDB67300A34D0D /* NSCustomComboBoxCell.m */; };
 		95C0707A18CDB91500A34D0D /* NSCustomComboBox.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C0707918CDB91500A34D0D /* NSCustomComboBox.m */; };
+		BA00E9ED234C5A6C0011A703 /* TouchBarService+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */; };
 		BA013FF5225705B6000E5B91 /* HoverTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */; };
 		BA01404622570805000E5B91 /* TagCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA01404522570805000E5B91 /* TagCellView.swift */; };
 		BA0140482257080F000E5B91 /* TagCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA0140472257080F000E5B91 /* TagCellView.xib */; };
@@ -233,7 +234,7 @@
 		BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */; };
 		BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
 		BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */; };
-		BAF3ACD32343325A00E41B33 /* TimeEntryTouchbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */; };
+		BAF3ACD32343325A00E41B33 /* TouchBarService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACD22343325A00E41B33 /* TouchBarService.swift */; };
 		BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAF50DE421A29FED0090BA95 /* Images.xcassets */; };
 		BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */; };
 		BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */; };
@@ -439,6 +440,7 @@
 		95C0707818CDB91500A34D0D /* NSCustomComboBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSCustomComboBox.h; sourceTree = "<group>"; };
 		95C0707918CDB91500A34D0D /* NSCustomComboBox.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSCustomComboBox.m; sourceTree = "<group>"; };
 		B671ACF75B3267B013176BD7 /* Pods-TogglDesktop.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TogglDesktop.release.xcconfig"; path = "Target Support Files/Pods-TogglDesktop/Pods-TogglDesktop.release.xcconfig"; sourceTree = "<group>"; };
+		BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TouchBarService+Name.swift"; sourceTree = "<group>"; };
 		BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverTableCellView.swift; sourceTree = "<group>"; };
 		BA01404522570805000E5B91 /* TagCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellView.swift; sourceTree = "<group>"; };
 		BA0140472257080F000E5B91 /* TagCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TagCellView.xib; sourceTree = "<group>"; };
@@ -593,7 +595,7 @@
 		BAE6379922B225C70024DD08 /* AddTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagButton.swift; sourceTree = "<group>"; };
 		BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTouchbarButton.swift; sourceTree = "<group>"; };
-		BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntryTouchbar.swift; sourceTree = "<group>"; };
+		BAF3ACD22343325A00E41B33 /* TouchBarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarService.swift; sourceTree = "<group>"; };
 		BAF50DE421A29FED0090BA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TogglDesktop/Images.xcassets; sourceTree = "<group>"; };
 		BAF50DF621A2A18D0090BA95 /* AppIconFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIconFactory.h; sourceTree = "<group>"; };
 		BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIconFactory.m; sourceTree = "<group>"; };
@@ -1243,7 +1245,8 @@
 			isa = PBXGroup;
 			children = (
 				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
-				BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */,
+				BAF3ACD22343325A00E41B33 /* TouchBarService.swift */,
+				BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */,
 			);
 			path = TouchBar;
 			sourceTree = "<group>";
@@ -1586,6 +1589,7 @@
 				BA13D2112269BE2F00EB3833 /* DateInfo.swift in Sources */,
 				BA13D20E2269BAA600EB3833 /* DateCellViewItem.swift in Sources */,
 				BA712EC821BF9F1200A2D8DD /* UndoStack.swift in Sources */,
+				BA00E9ED234C5A6C0011A703 /* TouchBarService+Name.swift in Sources */,
 				BA13D2172269DE3400EB3833 /* NoVibrantPopoverView.swift in Sources */,
 				3C6B2488203E01D90063FC08 /* AutoCompleteTable.m in Sources */,
 				BA412C1D224E0D61003CA17A /* ClientDataSource.swift in Sources */,
@@ -1691,7 +1695,7 @@
 				7430750418204EFB009019CB /* AboutWindowController.m in Sources */,
 				74D1D27217EB72D900E709B0 /* TimerEditViewController.m in Sources */,
 				3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */,
-				BAF3ACD32343325A00E41B33 /* TimeEntryTouchbar.swift in Sources */,
+				BAF3ACD32343325A00E41B33 /* TouchBarService.swift in Sources */,
 				741104BF18C7682700BC7A49 /* NSTextFieldWithBackground.m in Sources */,
 				BA80BEB2221EAE6F00BDFD35 /* Array+ByGroup.swift in Sources */,
 				BA067642233A492F00485C3C /* TogglApplication.m in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE6379922B225C70024DD08 /* AddTagButton.swift */; };
 		BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */; };
 		BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
+		BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */; };
 		BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAF50DE421A29FED0090BA95 /* Images.xcassets */; };
 		BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */; };
 		BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */; };
@@ -590,6 +591,7 @@
 		BAE49CAD222FC1C900773814 /* TimerContainerBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerContainerBox.swift; sourceTree = "<group>"; };
 		BAE6379922B225C70024DD08 /* AddTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagButton.swift; sourceTree = "<group>"; };
 		BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAutoCompleteTextField.swift; sourceTree = "<group>"; };
+		BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTouchbarButton.swift; sourceTree = "<group>"; };
 		BAF50DE421A29FED0090BA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TogglDesktop/Images.xcassets; sourceTree = "<group>"; };
 		BAF50DF621A2A18D0090BA95 /* AppIconFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIconFactory.h; sourceTree = "<group>"; };
 		BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIconFactory.m; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 		BA712EAF21BF904E00A2D8DD /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				BAF3ACCA2341F86300E41B33 /* TouchBar */,
 				BA5B0E2E2330E1A8008D1DED /* GoogleLogin */,
 				BA13D1E42269B4F600EB3833 /* Calendar */,
 				BA657280224DFA4F00BA4C60 /* ColorWheel */,
@@ -1232,6 +1235,14 @@
 				BAD15FFD223A530600A8CCC9 /* TimeEntryEmptyView.xib */,
 			);
 			path = TimeEntryEmptyView;
+			sourceTree = "<group>";
+		};
+		BAF3ACCA2341F86300E41B33 /* TouchBar */ = {
+			isa = PBXGroup;
+			children = (
+				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
+			);
+			path = TouchBar;
 			sourceTree = "<group>";
 		};
 		BAF50DF521A2A16D0090BA95 /* IconFactory */ = {
@@ -1595,6 +1606,7 @@
 				7438B3D318253CD2002AE43C /* MenuItemTags.m in Sources */,
 				3CE1CAC11C774F2B00D0ADD5 /* LoadMoreCell.m in Sources */,
 				749CB8CC18167D6E00814841 /* PreferencesWindowController.m in Sources */,
+				BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */,
 				3C7B4E8D190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m in Sources */,
 				BAB0027F22731248005ECC93 /* DayLabel.swift in Sources */,
 				3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */,

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		95C0707718CDB67300A34D0D /* NSCustomComboBoxCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C0707618CDB67300A34D0D /* NSCustomComboBoxCell.m */; };
 		95C0707A18CDB91500A34D0D /* NSCustomComboBox.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C0707918CDB91500A34D0D /* NSCustomComboBox.m */; };
 		BA00E9ED234C5A6C0011A703 /* TouchBarService+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */; };
+		BA00E9F0234C73990011A703 /* TimeEntryScrubberItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */; };
 		BA013FF5225705B6000E5B91 /* HoverTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */; };
 		BA01404622570805000E5B91 /* TagCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA01404522570805000E5B91 /* TagCellView.swift */; };
 		BA0140482257080F000E5B91 /* TagCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA0140472257080F000E5B91 /* TagCellView.xib */; };
@@ -441,6 +442,7 @@
 		95C0707918CDB91500A34D0D /* NSCustomComboBox.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSCustomComboBox.m; sourceTree = "<group>"; };
 		B671ACF75B3267B013176BD7 /* Pods-TogglDesktop.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TogglDesktop.release.xcconfig"; path = "Target Support Files/Pods-TogglDesktop/Pods-TogglDesktop.release.xcconfig"; sourceTree = "<group>"; };
 		BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TouchBarService+Name.swift"; sourceTree = "<group>"; };
+		BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntryScrubberItem.swift; sourceTree = "<group>"; };
 		BA013FF4225705B6000E5B91 /* HoverTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverTableCellView.swift; sourceTree = "<group>"; };
 		BA01404522570805000E5B91 /* TagCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCellView.swift; sourceTree = "<group>"; };
 		BA0140472257080F000E5B91 /* TagCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TagCellView.xib; sourceTree = "<group>"; };
@@ -1247,6 +1249,7 @@
 				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
 				BAF3ACD22343325A00E41B33 /* TouchBarService.swift */,
 				BA00E9EC234C5A6C0011A703 /* TouchBarService+Name.swift */,
+				BA00E9EF234C73990011A703 /* TimeEntryScrubberItem.swift */,
 			);
 			path = TouchBar;
 			sourceTree = "<group>";
@@ -1727,6 +1730,7 @@
 				BA9C2DFC224C8235002AD2A1 /* ColorPickerView.swift in Sources */,
 				BA276A142240F5B500810C51 /* FloatingErrorView.swift in Sources */,
 				C5DA1FC417F1B38B001C4565 /* LoginViewController.m in Sources */,
+				BA00E9F0234C73990011A703 /* TimeEntryScrubberItem.swift in Sources */,
 				743D942F1827C633000E6F70 /* IdleEvent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */; };
 		BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
 		BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */; };
+		BAF3ACD32343325A00E41B33 /* TimeEntryTouchbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */; };
 		BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAF50DE421A29FED0090BA95 /* Images.xcassets */; };
 		BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */; };
 		BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */; };
@@ -592,6 +593,7 @@
 		BAE6379922B225C70024DD08 /* AddTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagButton.swift; sourceTree = "<group>"; };
 		BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAutoCompleteTextField.swift; sourceTree = "<group>"; };
 		BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTouchbarButton.swift; sourceTree = "<group>"; };
+		BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeEntryTouchbar.swift; sourceTree = "<group>"; };
 		BAF50DE421A29FED0090BA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TogglDesktop/Images.xcassets; sourceTree = "<group>"; };
 		BAF50DF621A2A18D0090BA95 /* AppIconFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIconFactory.h; sourceTree = "<group>"; };
 		BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIconFactory.m; sourceTree = "<group>"; };
@@ -1241,6 +1243,7 @@
 			isa = PBXGroup;
 			children = (
 				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
+				BAF3ACD22343325A00E41B33 /* TimeEntryTouchbar.swift */,
 			);
 			path = TouchBar;
 			sourceTree = "<group>";
@@ -1688,6 +1691,7 @@
 				7430750418204EFB009019CB /* AboutWindowController.m in Sources */,
 				74D1D27217EB72D900E709B0 /* TimerEditViewController.m in Sources */,
 				3C2F239D21A7B43400CBE6BC /* UnsupportedNotice.m in Sources */,
+				BAF3ACD32343325A00E41B33 /* TimeEntryTouchbar.swift in Sources */,
 				741104BF18C7682700BC7A49 /* NSTextFieldWithBackground.m in Sources */,
 				BA80BEB2221EAE6F00BDFD35 /* Array+ByGroup.swift in Sources */,
 				BA067642233A492F00485C3C /* TogglApplication.m in Sources */,

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -36,6 +36,7 @@ extern NSString *const kDisplayTimerState;
 extern NSString *const kDisplayUnsyncedItems;
 extern NSString *const kDisplayAutotrackerRules;
 extern NSString *const kDisplayPromotion;
+extern NSString *const kStartTimer;
 
 extern NSString *const kHideDisplayError;
 extern NSString *const kForceCloseEditPopover;

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -60,3 +60,5 @@ const char *kFocusedFieldNameDuration;
 const char *kFocusedFieldNameDescription;
 const char *kFocusedFieldNameProject;
 const char *kFocusedFieldNameTag;
+
+extern NSString *const kStartButtonStateChange;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -58,3 +58,5 @@ const char *kFocusedFieldNameDuration = "duration";
 const char *kFocusedFieldNameDescription = "description";
 const char *kFocusedFieldNameProject = "project";
 const char *kFocusedFieldNameTag = "tag";
+
+NSString *const kStartButtonStateChange = @"kStartButtonStateChange";

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -33,6 +33,7 @@ NSString *const kDisplayTimerState = @"kDisplayTimerState";
 NSString *const kDisplayUnsyncedItems = @"kDisplayUnsyncedItems";
 NSString *const kDisplayAutotrackerRules = @"kDisplayAutotrackerRules";
 NSString *const kDisplayPromotion = @"kDisplayPromotion";
+NSString *const kStartTimer = @"kStartTimer";
 
 NSString *const kHideDisplayError = @"kHideDisplayError";
 NSString *const kForceCloseEditPopover = @"kForceCloseEditPopover";

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -995,6 +995,7 @@ void *ctx;
 
 - (void)setupTouchBar
 {
+	DFRSystemModalShowsCloseBoxWhenFrontMost(YES);
 	self.touchItem = [GlobalTouchbarButton makeDefault];
 	[NSTouchBarItem addSystemTrayItem:self.touchItem];
 	DFRElementSetControlStripPresenceForIdentifier([GlobalTouchbarButton ID], YES);

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -38,8 +38,6 @@
 #import "Reachability.h"
 #import <AppAuth/AppAuth.h>
 
-static const NSTouchBarItemIdentifier touchIdentifier = @"toggl.touchbar";
-
 @interface AppDelegate ()
 @property (nonatomic, strong) MainWindowController *mainWindowController;
 @property (nonatomic, strong) PreferencesWindowController *preferencesWindowController;
@@ -49,9 +47,7 @@ static const NSTouchBarItemIdentifier touchIdentifier = @"toggl.touchbar";
 @property (nonatomic, strong) ConsoleViewController *consoleWindowController;
 
 // Touch Bar items
-@property NSCustomTouchBarItem *touchItem;
-@property NSButton *touchBarButton;
-@property NSImage *iconImage;
+@property (nonatomic, strong) GlobalTouchbarButton *touchItem;
 
 // Remember some app state
 @property (nonatomic, strong) TimeEntryViewItem *lastKnownRunningTimeEntry;
@@ -825,8 +821,8 @@ void *ctx;
 			key = @"offline_off";
 		}
 	}
-	self.iconImage = [self.statusImages objectForKey:key];
-	NSAssert(self.iconImage, @"status image not found!");
+	NSImage *image = [self.statusImages objectForKey:key];
+	NSAssert(image, @"status image not found!");
 
 	if (![title isEqualToString:self.statusItem.title])
 	{
@@ -838,13 +834,10 @@ void *ctx;
 		[self.statusItem setTitle:title];
 	}
 
-	if (self.iconImage != self.statusItem.image)
+	if (image != self.statusItem.image)
 	{
-		[self.statusItem setImage:self.iconImage];
-
-		// This forces the icon to redraw
-		[self.touchBarButton setImage:self.iconImage];
-		self.touchBarButton.imagePosition = NSImageOnly;
+		[self.statusItem setImage:image];
+		[self.touchItem update:image];
 	}
 }
 
@@ -1002,12 +995,9 @@ void *ctx;
 
 - (void)setupTouchBar
 {
-	self.touchItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:touchIdentifier];
-	self.touchBarButton = [NSButton buttonWithImage:self.iconImage target:nil action:nil];
-	self.touchItem.view = self.touchBarButton;
-
+	self.touchItem = [GlobalTouchbarButton makeDefault];
 	[NSTouchBarItem addSystemTrayItem:self.touchItem];
-	DFRElementSetControlStripPresenceForIdentifier(touchIdentifier, YES);
+	DFRElementSetControlStripPresenceForIdentifier([GlobalTouchbarButton ID], YES);
 }
 
 - (IBAction)onConsoleMenuItem:(id)sender

--- a/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
+++ b/src/ui/osx/TogglDesktop/test2/AutoCompleteInput.m
@@ -36,6 +36,7 @@ static NSString *const upArrow = @"\u25B2";
 	self = [super initWithCoder:coder];
 	if (self)
 	{
+		self.automaticTextCompletionEnabled = NO;
 		self.posY = 0;
 		self.constraintsActive = NO;
 		self.itemHeight = 30.0;

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.h
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL isInTimerBar;
 @property (assign, nonatomic) BOOL renderClient;
 @property (assign, nonatomic) BOOL renderTask;
+@property (strong, nonatomic) NSColor *customClientTextColor;
 
 - (void)setTitleWithTimeEntry:(TimeEntryViewItem *)item;
 - (void)setTitleWithAutoCompleteItem:(AutocompleteItem *)item;

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -120,6 +120,11 @@
 
 - (NSColor *)clientTextColor
 {
+	if (self.customClientTextColor != nil)
+	{
+		return self.customClientTextColor;
+	}
+
 	if (@available(macOS 10.13, *))
 	{
 		return [NSColor colorNamed:@"grey-text-color"];

--- a/src/ui/osx/TogglDesktop/test2/TouchBar.h
+++ b/src/ui/osx/TogglDesktop/test2/TouchBar.h
@@ -1,0 +1,30 @@
+//
+//  TouchBar.h
+//  TogglDesktop
+//
+//  Created by Indrek Vändrik on 24/02/2019.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+#ifndef TouchBar_h
+#define TouchBar_h
+
+#import <AppKit/AppKit.h>
+
+extern void DFRElementSetControlStripPresenceForIdentifier(NSString *, BOOL);
+extern void DFRSystemModalShowsCloseBoxWhenFrontMost(BOOL);
+
+@interface NSTouchBarItem ()
+
++ (void)addSystemTrayItem:(NSTouchBarItem *)item;
++ (void)removeSystemTrayItem:(NSTouchBarItem *)item;
+
+@end
+
+@interface NSTouchBar ()
+
++ (void)presentSystemModalFunctionBar:(NSTouchBar *)touchBar systemTrayItemIdentifier:(NSString *)identifier;
+
+@end
+
+#endif /* TouchBar_h */

--- a/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
@@ -12,7 +12,6 @@ namespace TogglDesktop
         }
 
         public event Action BeforeStartup;
-    public event Action BeforeStartup;
 
         protected override bool OnStartup(Microsoft.VisualBasic.ApplicationServices.StartupEventArgs e)
         {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/SingleInstanceManager.cs
@@ -12,6 +12,7 @@ namespace TogglDesktop
         }
 
         public event Action BeforeStartup;
+    public event Action BeforeStartup;
 
         protected override bool OnStartup(Microsoft.VisualBasic.ApplicationServices.StartupEventArgs e)
         {


### PR DESCRIPTION
### 📒 Description
Adds global button to touchbar. Also updates the button design the same way menubar icon is updated. Running/Stopped

### 🕶️ Types of changes

**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes

- [x] Add preference `Show Toggl in Touch Bar`
- [x] Add global button to touch bar
- [x] Pressing the button starts/stops timer

### 👫 Relationships

Closes #3349

### 🔎 Review hints

- If the setting is enabled touch bar button should appear
- Touch bar button should be removed on app quit

