### PR TITLE
Fix Tag AutoComplete couldn't hide

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/TagAutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/TagAutoCompleteTextField.swift
@@ -13,7 +13,7 @@ final class TagAutoCompleteTextField: AutoCompleteTextField, NSWindowDelegate {
     // Hack
     // Because the TagAutoCompleteTextField is inside the AutoCompleteWindow
     // So we have to prevent the action to closeSuggestion when the textField is resigned
-    private var isPressingTab = false
+    private var skipCloseAutocomplete = false
 
     // The design for TagTextField is different than other
     // The AutoCompleteWindow will contain the TextView
@@ -36,7 +36,7 @@ final class TagAutoCompleteTextField: AutoCompleteTextField, NSWindowDelegate {
     }
 
     override func controlTextDidEndEditing(_ obj: Notification) {
-        if !isPressingTab {
+        if !skipCloseAutocomplete {
             super.controlTextDidEndEditing(obj)
         }
     }
@@ -65,12 +65,19 @@ final class TagAutoCompleteTextField: AutoCompleteTextField, NSWindowDelegate {
         closeSuggestion()
     }
 
+    func focus() {
+        // If we makeFirstResponder, it will trigger the -controlTextDidEndEditing and collapse the AutoCompleteView
+        skipCloseAutocomplete = true
+        window?.makeFirstResponder(self)
+        skipCloseAutocomplete = false
+    }
+
     override func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         if commandSelector == #selector(NSResponder.insertTab(_:)) {
-            isPressingTab = true
+            skipCloseAutocomplete = true
         }
         let handled = super.control(control, textView: textView, doCommandBy: commandSelector)
-        isPressingTab = false
+        skipCloseAutocomplete = false
         return handled
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -536,6 +536,12 @@ extension EditorViewController: AutoCompleteTextFieldDelegate {
             tagTextField.removeFromSuperview()
             tagAutoCompleteContainerView.addSubview(tagTextField)
             tagTextField.edgesToSuperView()
+
+            // Since Tag Token appear -> There is no text field to be focus
+            // Focus on duration
+            if !tagStackView.isHidden && durationTextField.currentEditor() == nil {
+                view.window?.makeFirstResponder(durationTextField)
+            }
         }
     }
     

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -526,7 +526,7 @@ extension EditorViewController: AutoCompleteTextFieldDelegate {
             DesktopLibraryBridge.shared().updateTimeEntry(withTags: selectedTags.toNames(), guid: timeEntry.guid)
 
             // Focus on tag textfield agains, so user can continue typying
-            sender.window?.makeFirstResponder(tagTextField)
+            tagTextField.focus()
             tagTextField.resetText()
         }
     }


### PR DESCRIPTION
### 📒 Description
This PR fixes the issues that the Tag AutoComplete View couldn't collapse properly when creating a new tag.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Should not collapse the autocomplete view when re-focusing on the Tag Text Field

### 👫 Relationships
Closes #3325

### 🔎 Review hints
#### 1. Re-focus on Tag Text Field when creating new Tag by mouse
1. Open Editor
2. Create a new tag by clicking on the "Create a new Tag" button
3. The new tag is created and add to list -> 💯 
4. The Tag Text Field should be focused again and be able to continue typing -> 💯  

#### 1. Re-focus on Tag Text Field when creating new by keyboard
1. Open Editor
2. Type new tag, and press Tab to focus on Create Button -> Hit Space
3. The new tag is created and add to list -> 💯 
4. The Tag Text Field should be focused again and be able to continue typing -> 💯  

#### Able to close by clicking outside.
1. Do 1st and 2nd above review and make sure we can close the Tag AutoComplete View by clicking on outside the view.

#### Resolve the bug
- See "Step to reproduce" (https://github.com/toggl/toggldesktop/issues/3325) and make sure this bug is gone 💯 

![2019-09-24 20 38 50](https://user-images.githubusercontent.com/5878421/65517084-57f84200-df0c-11e9-8b32-539e5192761d.gif)
