### PR TITLE
Run Store app on startup

### DIFF
--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
@@ -49,7 +49,7 @@
       <Extensions>
         <desktop:Extension
           Category="windows.startupTask"
-          Executable="TogglDesktop.exe"
+          Executable="TogglDesktop\TogglDesktop.exe"
           EntryPoint="Windows.FullTrustApplication">
           <desktop:StartupTask
               TaskId="TogglDesktopStartupTask"

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
@@ -53,7 +53,7 @@
           EntryPoint="Windows.FullTrustApplication">
           <desktop:StartupTask
               TaskId="TogglDesktopStartupTask"
-              Enabled="true"
+              Enabled="false"
               DisplayName="Toggl Desktop" />
         </desktop:Extension>
       </Extensions>

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+  IgnorableNamespaces="uap rescap desktop">
 
   <Identity
     Name="TogglO.TogglDesktop"
@@ -45,6 +46,17 @@
         </uap:DefaultTile >
         <uap:SplashScreen Image="Images\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <desktop:Extension
+          Category="windows.startupTask"
+          Executable="TogglDesktop.exe"
+          EntryPoint="Windows.FullTrustApplication">
+          <desktop:StartupTask
+              TaskId="TogglDesktopStartupTask"
+              Enabled="true"
+              DisplayName="Toggl Desktop" />
+        </desktop:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/src/ui/windows/TogglDesktop/TogglDesktop.Package/TogglDesktop.Package.wapproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop.Package/TogglDesktop.Package.wapproj
@@ -44,8 +44,7 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <PackageCertificateThumbprint>322D8592D0FDB01F1C8FCA56ED3FBFAF646D3739</PackageCertificateThumbprint>
-    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='StoreDebug|x86'">
     <AppxBundle>Always</AppxBundle>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglDesktop.csproj
@@ -143,10 +143,30 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.InteropServices.WindowsRuntime" />
+    <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.Runtime.WindowsRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.WindowsRuntime.UI.Xaml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Windows\Microsoft.NET\Framework\v4.0.30319\System.Runtime.WindowsRuntime.UI.Xaml.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="Windows">
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.16299.0\Windows.winmd</HintPath>
+    </Reference>
+    <Reference Include="Windows.Foundation.FoundationContract">
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Windows.Foundation.UniversalApiContract">
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.UniversalApiContract\5.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
@@ -392,6 +412,7 @@
     </Compile>
     <Compile Include="ui\chrome\TogglWindow.cs" />
     <Compile Include="ui\chrome\TogglChromeDesignTimeConverter.cs" />
+    <Compile Include="Win10\RunOnStartup.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Win10/RunOnStartup.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Win10/RunOnStartup.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel;
+
+namespace TogglDesktop.Win10
+{
+#if MS_STORE
+    public static class RunOnStartup
+    {
+        /// <returns>
+        /// <c>true</c> if enabled
+        /// <c>false</c> if disabled but can be enabled from the app
+        /// <c>null</c> if disabled and cannot be enabled from the app
+        /// </returns>
+        public static async Task<bool?> IsRunOnStartupEnabled()
+        {
+            var startupTask = await GetStartupTask();
+            switch (startupTask.State)
+            {
+                case StartupTaskState.DisabledByPolicy:
+                    // disabled by group policy or not supported on this device
+                    // cannot be changed by the user
+                    return null;
+                case StartupTaskState.DisabledByUser:
+                    // disabled by the user in Task Manager
+                    // cannot be enabled from the app, only from Task Manager
+                    return null;
+                case StartupTaskState.Disabled:
+                    return false;
+                case StartupTaskState.Enabled:
+                    return true;
+                default:
+                    return null;
+            }
+        }
+
+        public static async Task<bool> TrySetRunOnStartup(bool isEnabled)
+        {
+            if (isEnabled)
+            {
+                return await TryEnableRunOnStartup();
+            }
+            else
+            {
+                await DisableRunOnStartup();
+                return true;
+            }
+        }
+
+        private static async Task DisableRunOnStartup()
+        {
+            var startupTask = await GetStartupTask();
+            if (startupTask.State == StartupTaskState.Enabled)
+            {
+                startupTask.Disable();
+            }
+        }
+
+        private static async Task<bool> TryEnableRunOnStartup()
+        {
+            var startupTask = await GetStartupTask();
+            if (startupTask.State == StartupTaskState.Disabled)
+            {
+                var newState = await startupTask.RequestEnableAsync();
+                if (newState == StartupTaskState.Enabled)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static async Task<StartupTask> GetStartupTask() => await StartupTask.GetAsync("TogglDesktopStartupTask");
+    }
+#endif
+}

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Win10/RunOnStartup.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Win10/RunOnStartup.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿#if MS_STORE
+using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 
 namespace TogglDesktop.Win10
 {
-#if MS_STORE
     public static class RunOnStartup
     {
         /// <returns>
@@ -72,5 +72,6 @@ namespace TogglDesktop.Win10
 
         private static async Task<StartupTask> GetStartupTask() => await StartupTask.GetAsync("TogglDesktopStartupTask");
     }
-#endif
+
 }
+#endif

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/windows/PreferencesWindow.xaml.cs
@@ -9,8 +9,9 @@ using System.Windows.Input;
 using TogglDesktop.AutoCompletion;
 using TogglDesktop.AutoCompletion.Implementation;
 using TogglDesktop.Diagnostics;
+#if MS_STORE
 using TogglDesktop.Win10;
-
+#endif
 namespace TogglDesktop
 {
     partial class PreferencesWindow


### PR DESCRIPTION
### 📒 Description
Makes "Run the app on Windows login" work for Microsoft Store version of the app.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3347.

### 🔎 Review hints

- Uninstall regular Toggl Desktop app to make sure you run a Store version of the app
- In Visual Studio Solution Explorer right-click `TogglDesktop.Package` -> Set as StartUp Project
- Run a Store app (`StoreDebug` or `StoreRelease` config) from Visual Studio. It installs the app on your PC when you run it
- Verify that "Preferences->Run the app on Windows login" is unchecked by default and "Toggl Desktop" entry is Disabled in Task Manager->Startup
- Restart the PC and verify that Toggl Desktop app is not running
- Check "Preferences->Run the app on Windows login"
- Restart the PC and verify that the Store version of Toggl Desktop app is running
- Go To Task Manager->Startup and Disable "Toggl Desktop"
- Open Preferences again and verify that "Run the app on Windows login" checkbox is hidden.