### PR TITLE
Add Tooltip which displays time up to seconds precision 

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -86,6 +86,12 @@ final class EditorViewController: NSViewController {
                 NSAttributedString.Key.foregroundColor: NSColor.labelColor]
     }()
     fileprivate var isRegisterTimerNotification = false
+    private lazy var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .medium
+        return formatter
+    }()
 
     // MARK: View Cyclex
 
@@ -353,9 +359,6 @@ extension EditorViewController {
         durationTextField.stringValue = timeEntry.duration
         startAtTextField.stringValue = timeEntry.startTimeString
         endAtTextField.stringValue = timeEntry.endTimeString
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .none
-        dateFormatter.timeStyle = .medium
         startAtTextField.toolTip = dateFormatter.string(from: timeEntry.started)
         endAtTextField.toolTip = dateFormatter.string(from: timeEntry.ended)
     }

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -90,6 +90,8 @@ final class EditorViewController: NSViewController {
         let formatter = DateFormatter()
         formatter.dateStyle = .none
         formatter.timeStyle = .medium
+        formatter.timeZone = TimeZone.current
+        formatter.locale = Locale.current
         return formatter
     }()
 

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -353,6 +353,11 @@ extension EditorViewController {
         durationTextField.stringValue = timeEntry.duration
         startAtTextField.stringValue = timeEntry.startTimeString
         endAtTextField.stringValue = timeEntry.endTimeString
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .medium
+        startAtTextField.toolTip = dateFormatter.string(from: timeEntry.started)
+        endAtTextField.toolTip = dateFormatter.string(from: timeEntry.ended)
     }
 
     fileprivate func updateNextKeyViews() {

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/views/EditView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -108,11 +109,16 @@ namespace TogglDesktop
                 this.endTimeTextBox.IsEnabled = !isCurrentlyRunning;
                 this.startDatePicker.IsEnabled = !isCurrentlyRunning;
 
+                var startDateTime = Toggl.DateTimeFromUnix(timeEntry.Started);
+                var endDateTime = Toggl.DateTimeFromUnix(timeEntry.Ended);
+
                 setText(this.descriptionTextBox, timeEntry.Description, open);
                 setTime(this.durationTextBox, timeEntry.Duration, open);
                 setTime(this.startTimeTextBox, timeEntry.StartTimeString, open);
+                this.startTimeTextBox.ToolTip = startDateTime.ToString("T", CultureInfo.CurrentCulture);
                 setTime(this.endTimeTextBox, timeEntry.EndTimeString, open);
-                this.startDatePicker.SelectedDate = Toggl.DateTimeFromUnix(timeEntry.Started);
+                this.endTimeTextBox.ToolTip = endDateTime.ToString("T", CultureInfo.CurrentCulture);
+                this.startDatePicker.SelectedDate = startDateTime;
                 if (isDifferentTimeEntry)
                 {
                     this.clearUndoHistory();


### PR DESCRIPTION
### 📒 Description
Add start/end time tooltip to show time up to seconds precision on Windows and macOS

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 👫 Relationships
Closes #3309

### 🔎 Review hints
Hovering over start/end time in Edit view should show start/end time up to seconds with the user's current locale

