### PR TITLE
Global Toggl Touch Bar

### DIFF
--- a/src/analytics.cc
+++ b/src/analytics.cc
@@ -251,6 +251,9 @@ void GoogleAnalyticsSettingsEvent::runTask() {
     setActionBool("stop_entry_on_shutdown_sleep-", settings.stop_entry_on_shutdown_sleep);
     makeReq();
 
+    setActionBool("show_touch_bar-", settings.show_touch_bar);
+    makeReq();
+
     if (settings.pomodoro_break) {
         setActionInt("pomodoro_break_minutes-",
                      settings.pomodoro_break_minutes);

--- a/src/context.cc
+++ b/src/context.cc
@@ -1296,7 +1296,7 @@ void Context::startPeriodicUpdateCheck() {
     (*this, &Context::onPeriodicUpdateCheck);
 
     Poco::Int64 micros = kCheckUpdateIntervalSeconds *
-                          Poco::Int64(kOneSecondInMicros);
+                         Poco::Int64(kOneSecondInMicros);
     Poco::Timestamp next_periodic_check_at = Poco::Timestamp() + micros;
     Poco::Mutex::ScopedLock lock(timer_m_);
     timer_.schedule(ptask, next_periodic_check_at);
@@ -1812,6 +1812,11 @@ error Context::SetSettingsStopEntryOnShutdownSleep(const bool stop_entry) {
         db()->SetSettingsStopEntryOnShutdownSleep(stop_entry));
 }
 
+error Context::SetSettingsShowTouchBar(const bool show_touch_bar) {
+    return applySettingsSaveResultToUI(
+        db()->SetSettingsShowTouchBar(show_touch_bar));
+}
+
 error Context::SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes) {
     return applySettingsSaveResultToUI(
         db()->SetSettingsIdleMinutes(idle_minutes));
@@ -1928,6 +1933,12 @@ void Context::SetKeepEndTimeFixed
 bool Context::GetKeepEndTimeFixed() {
     bool value(false);
     displayError(db()->GetKeepEndTimeFixed(&value));
+    return value;
+}
+
+bool Context::GetShowTouchBar() {
+    bool value(false);
+    displayError(db()->GetShowTouchBar(&value));
     return value;
 }
 
@@ -2276,7 +2287,7 @@ error Context::GoogleSignup(
 }
 
 error Context::AsyncGoogleSignup(const std::string &access_token,
-    const uint64_t country_id) {
+                                 const uint64_t country_id) {
     std::thread backgroundThread([&](std::string access_token, uint64_t country_id) {
         return this->GoogleSignup(access_token, country_id);
     }, access_token, country_id);
@@ -4861,9 +4872,9 @@ error Context::pushClients(
 }
 
 error Context::pushProjects(const std::vector<Project *> &projects,
-    const std::vector<Client *> &clients,
-    const std::string &api_token,
-    TogglClient toggl_client) {
+                            const std::vector<Client *> &clients,
+                            const std::string &api_token,
+                            TogglClient toggl_client) {
     error err = noError;
     std::string project_json("");
     for (std::vector<Project *>::const_iterator it =
@@ -4917,7 +4928,7 @@ error Context::pushProjects(const std::vector<Project *> &projects,
 }
 
 error Context::updateEntryProjects(const std::vector<Project *> &projects,
-    const std::vector<TimeEntry *> &time_entries) {
+                                   const std::vector<TimeEntry *> &time_entries) {
     for (std::vector<TimeEntry *>::const_iterator it =
         time_entries.begin();
             it != time_entries.end(); it++) {

--- a/src/context.h
+++ b/src/context.h
@@ -160,6 +160,8 @@ class Context : public TimelineDatasource {
 
     error SetSettingsStopEntryOnShutdownSleep(const bool stop_entry);
 
+    error SetSettingsShowTouchBar(const bool show_touch_bar);
+
     error SetSettingsIdleMinutes(const Poco::UInt64 idle_minutes);
 
     error SetSettingsFocusOnShortcut(const bool focus_on_shortcut);
@@ -197,6 +199,8 @@ class Context : public TimelineDatasource {
         const bool);
 
     bool GetKeepEndTimeFixed();
+
+    bool GetShowTouchBar();
 
     void SetWindowMaximized(
         const bool value);
@@ -241,7 +245,7 @@ class Context : public TimelineDatasource {
     error ProxySettings(bool *use_proxy, Proxy *proxy);
 
     error SetProxySettings(const bool use_proxy,
-        const Proxy &proxy);
+                           const Proxy &proxy);
 
     error LoadWindowSettings(
         int64_t *window_x,
@@ -587,17 +591,17 @@ class Context : public TimelineDatasource {
         TogglClient *https_client,
         bool *had_something_to_push);
     error pushClients(const std::vector<Client *> &clients,
-        const std::string &api_token,
-        TogglClient toggl_client);
+                      const std::string &api_token,
+                      TogglClient toggl_client);
     error pushProjects(
         const std::vector<Project *> &projects,
         const std::vector<Client *> &clients,
         const std::string &api_token,
         TogglClient toggl_client);
     error pushEntries(const std::map<std::string, BaseModel *> &models,
-        const std::vector<TimeEntry *> &time_entries,
-        const std::string &api_token,
-        TogglClient toggl_client);
+                      const std::vector<TimeEntry *> &time_entries,
+                      const std::string &api_token,
+                      TogglClient toggl_client);
     error updateEntryProjects(
         const std::vector<Project *> &projects,
         const std::vector<TimeEntry *> &time_entries);
@@ -613,10 +617,10 @@ class Context : public TimelineDatasource {
         std::string *user_data_json,
         const uint64_t country_id);
     static error me(TogglClient *https_client,
-        const std::string &email,
-        const std::string &password,
-        std::string *user_data,
-        const Poco::Int64 since);
+                    const std::string &email,
+                    const std::string &password,
+                    std::string *user_data,
+                    const Poco::Int64 since);
 
     bool isTimeEntryLocked(TimeEntry* te);
     bool isTimeLockedInWorkspace(time_t t, Workspace* ws);

--- a/src/database.cc
+++ b/src/database.cc
@@ -450,7 +450,7 @@ error Database::LoadSettings(Settings *settings) {
                   "remind_fri, remind_sat, remind_sun, autotrack, "
                   "open_editor_on_shortcut, has_seen_beta_offering, "
                   "pomodoro, pomodoro_minutes, "
-                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep "
+                  "pomodoro_break, pomodoro_break_minutes, stop_entry_on_shutdown_sleep, show_touch_bar "
                   "from settings "
                   "limit 1",
                   into(settings->use_idle_detection),
@@ -481,6 +481,7 @@ error Database::LoadSettings(Settings *settings) {
                   into(settings->pomodoro_break),
                   into(settings->pomodoro_break_minutes),
                   into(settings->stop_entry_on_shutdown_sleep),
+                  into(settings->show_touch_bar),
                   limit(1),
                   now;
     } catch(const Poco::Exception& exc) {
@@ -641,6 +642,10 @@ error Database::SetKeepEndTimeFixed(
 
 error Database::GetKeepEndTimeFixed(bool *result) {
     return getSettingsValue("keep_end_time_fixed", result);
+}
+
+error Database::GetShowTouchBar(bool *result) {
+    return getSettingsValue("show_touch_bar", result);
 }
 
 error Database::SetWindowMaximized(
@@ -853,6 +858,10 @@ error Database::SetSettingsManualMode(const bool &manual_mode) {
 
 error Database::SetSettingsAutodetectProxy(const bool &autodetect_proxy) {
     return setSettingsValue("autodetect_proxy", autodetect_proxy);
+}
+
+error Database::SetSettingsShowTouchBar(const bool &show_touch_bar) {
+    return setSettingsValue("show_touch_bar", show_touch_bar);
 }
 
 template<typename T>

--- a/src/database.h
+++ b/src/database.h
@@ -125,6 +125,8 @@ class Database {
 
     error SetSettingsAutodetectProxy(const bool &autodetect_proxy);
 
+    error SetSettingsShowTouchBar(const bool &show_touch_bar);
+
     error SetSettingsRemindTimes(
         const std::string &remind_starts,
         const std::string &remind_ends);
@@ -152,6 +154,8 @@ class Database {
 
     error GetKeepEndTimeFixed(
         bool *);
+
+    error GetShowTouchBar(bool *result);
 
     error SetWindowMaximized(
         const bool value);

--- a/src/get_focused_window_linux.cc
+++ b/src/get_focused_window_linux.cc
@@ -138,7 +138,7 @@ int getFocusedWindowInfo(
     unsigned long *pid = nullptr;
     if (active_window) {
         pid = reinterpret_cast<unsigned long*>(get_property(display, active_window,
-                                                            XA_CARDINAL, "_NET_WM_PID", nullptr));
+                                               XA_CARDINAL, "_NET_WM_PID", nullptr));
         if (pid) {
             // get process name by pid
             char buf[256];

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -522,8 +522,8 @@ void GUI::DisplayWorkspaceSelect(
 }
 
 void GUI::DisplayTimeEntryEditor(const bool open,
-    const view::TimeEntry &te,
-    const std::string &focused_field_name) {
+                                 const view::TimeEntry &te,
+                                 const std::string &focused_field_name) {
 
     logger().debug(
         "DisplayTimeEntryEditor focused_field_name=" + focused_field_name);

--- a/src/gui.h
+++ b/src/gui.h
@@ -239,7 +239,8 @@ class Settings {
     , PomodoroBreak(false)
     , PomodoroMinutes(0)
     , PomodoroBreakMinutes(0)
-    , StopEntryOnShutdownSleep(false) {}
+    , StopEntryOnShutdownSleep(false)
+    , ShowTouchBar(true) {}
 
     bool UseProxy;
     std::string ProxyHost;
@@ -274,6 +275,7 @@ class Settings {
     uint64_t PomodoroMinutes;
     uint64_t PomodoroBreakMinutes;
     bool StopEntryOnShutdownSleep;
+    bool ShowTouchBar;
 
     bool operator == (const Settings& other) const;
 };

--- a/src/idle.h
+++ b/src/idle.h
@@ -44,7 +44,7 @@ class Idle {
 
  private:
     void computeIdleState(const Poco::Int64 idle_seconds,
-        User *current_user);
+                          User *current_user);
 
     Poco::Logger &logger() const;
 

--- a/src/migrations.cc
+++ b/src/migrations.cc
@@ -1292,6 +1292,14 @@ error Migrations::migrateSettings() {
         return err;
     }
 
+    err = db_->Migrate(
+        "settings.show_touch_bar",
+        "ALTER TABLE settings "
+        "ADD COLUMN show_touch_bar INTEGER NOT NULL DEFAULT 1;");
+    if (err != noError) {
+        return err;
+    }
+
     return noError;
 }
 

--- a/src/related_data.h
+++ b/src/related_data.h
@@ -115,9 +115,9 @@ class RelatedData {
         std::map<std::string, std::vector<view::Autocomplete> > *items) const;
 
     void taskAutocompleteItems(std::set<std::string> *unique_names,
-        std::map<Poco::UInt64, std::string> *ws_names,
-        std::vector<view::Autocomplete> *list,
-        std::map<Poco::UInt64, std::vector<view::Autocomplete> > *items) const;
+                               std::map<Poco::UInt64, std::string> *ws_names,
+                               std::vector<view::Autocomplete> *list,
+                               std::map<Poco::UInt64, std::vector<view::Autocomplete> > *items) const;
 
     void projectAutocompleteItems(
         std::set<std::string> *unique_names,

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -36,6 +36,7 @@ Json::Value Settings::SaveToJSON() const {
     json["pomodoro_break"] = pomodoro_break;
     json["pomodoro_break_minutes"] = Json::UInt64(pomodoro_break_minutes);
     json["stop_entry_on_shutdown_sleep"] = stop_entry_on_shutdown_sleep;
+    json["show_touch_bar"] = show_touch_bar;
     return json;
 }
 
@@ -69,7 +70,8 @@ std::string Settings::String() const {
        << " pomodoro_minutes=" << pomodoro_minutes
        << " pomodoro_break=" << pomodoro_break
        << " pomodoro_break_minutes=" << pomodoro_break_minutes
-       << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep;
+       << " stop_entry_on_shutdown_sleep=" << stop_entry_on_shutdown_sleep
+       << " show_touch_bar=" << show_touch_bar;
     return ss.str();
 }
 
@@ -101,7 +103,8 @@ bool Settings::IsSame(const Settings &other) const {
             && (pomodoro_minutes == other.pomodoro_minutes)
             && (pomodoro_break == other.pomodoro_break)
             && (pomodoro_break_minutes == other.pomodoro_break_minutes)
-            && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep));
+            && (stop_entry_on_shutdown_sleep == other.stop_entry_on_shutdown_sleep)
+            && (show_touch_bar == other.show_touch_bar));
 }
 
 std::string Settings::ModelName() const {

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,7 +44,8 @@ class Settings : public BaseModel {
     , pomodoro_break(false)
     , pomodoro_minutes(0)
     , pomodoro_break_minutes(0)
-    , stop_entry_on_shutdown_sleep(false) {}
+    , stop_entry_on_shutdown_sleep(false)
+    , show_touch_bar(true) {}
 
     virtual ~Settings() {}
 
@@ -76,6 +77,7 @@ class Settings : public BaseModel {
     Poco::Int64 pomodoro_minutes;
     Poco::Int64 pomodoro_break_minutes;
     bool stop_entry_on_shutdown_sleep;
+    bool show_touch_bar;
 
     bool IsSame(const Settings &other) const;
 

--- a/src/toggl_api.cc
+++ b/src/toggl_api.cc
@@ -169,6 +169,11 @@ bool_t toggl_set_settings_stop_entry_on_shutdown_sleep(
            SetSettingsStopEntryOnShutdownSleep(stop_entry);
 }
 
+bool_t toggl_set_settings_show_touch_bar(
+    void *context,
+    const bool_t show_touch_bar) {
+    return toggl::noError == app(context)->SetSettingsShowTouchBar(show_touch_bar);
+}
 
 bool_t toggl_set_settings_idle_minutes(
     void *context,
@@ -1347,6 +1352,10 @@ bool_t toggl_get_keep_end_time_fixed(
     return app(context)->GetKeepEndTimeFixed();
 }
 
+bool_t toggl_get_show_touch_bar(
+    void *context) {
+    return app(context)->GetShowTouchBar();
+}
 
 void toggl_set_mini_timer_x(
     void *context,

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -163,6 +163,7 @@ extern "C" {
         int64_t PomodoroMinutes;
         int64_t PomodoroBreakMinutes;
         bool_t StopEntryOnShutdownSleep;
+        bool_t ShowTouchBar;
     } TogglSettingsView;
 
     typedef struct {
@@ -713,6 +714,10 @@ extern "C" {
         void *context,
         const bool_t stop_entry);
 
+    TOGGL_EXPORT bool_t toggl_set_settings_show_touch_bar(
+        void *context,
+        const bool_t show_touch_bar);
+
     TOGGL_EXPORT bool_t toggl_set_settings_idle_minutes(
         void *context,
         const uint64_t idle_minutes);
@@ -1003,6 +1008,8 @@ extern "C" {
     TOGGL_EXPORT bool_t toggl_get_keep_end_time_fixed(
         void *context);
 
+    TOGGL_EXPORT bool_t toggl_get_show_touch_bar(
+        void *context);
 
     TOGGL_EXPORT void toggl_set_mini_timer_x(
         void *context,

--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -457,6 +457,7 @@ TogglSettingsView *settings_view_item_init(
     view->PomodoroBreak = settings.pomodoro_break;
     view->PomodoroBreakMinutes = settings.pomodoro_break_minutes;
     view->StopEntryOnShutdownSleep = settings.stop_entry_on_shutdown_sleep;
+    view->ShowTouchBar = settings.show_touch_bar;
     return view;
 }
 

--- a/src/ui/osx/TogglDesktop.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/src/ui/osx/TogglDesktop.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -1,0 +1,57 @@
+//
+//  GlobalTouchbarButton.swift
+//  TogglDesktop
+//
+//  Created by Nghia Tran on 9/30/19.
+//  Copyright © 2019 Alari. All rights reserved.
+//
+
+import Cocoa
+
+@available(OSX 10.12.2, *)
+final class GlobalTouchbarButton: NSCustomTouchBarItem {
+
+    private struct Constants {
+        static let IDTouchBar = NSTouchBarItem.Identifier("toggl.touchbar")
+    }
+
+    // MARK: Variables
+
+    private let button: NSButton
+
+    // MARK: Init
+
+    override init(identifier: NSTouchBarItem.Identifier) {
+        let image = NSImage(named: "on")!
+        image.isTemplate = true
+        self.button = NSButton(image: image, target: nil, action: nil)
+        self.button.imagePosition = .imageOnly
+        super.init(identifier: identifier)
+        self.button.target = self
+        self.button.action = #selector(self.buttonOnTap)
+        self.view = self.button
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Don't support coder")
+    }
+
+    class func makeDefault() -> GlobalTouchbarButton {
+        let item = GlobalTouchbarButton(identifier: Constants.IDTouchBar)
+        return item
+    }
+
+    // MARK: Public
+
+
+}
+
+// MARK: Private
+
+@available(OSX 10.12.2, *)
+extension GlobalTouchbarButton {
+
+    @objc fileprivate func buttonOnTap() {
+
+    }
+}

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -53,6 +53,6 @@ final class GlobalTouchbarButton: NSCustomTouchBarItem {
 extension GlobalTouchbarButton {
 
     @objc fileprivate func buttonOnTap() {
-
+        NotificationCenter.default.post(name: NSNotification.Name(kStartTimer), object: nil)
     }
 }

--- a/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TouchBar/GlobalTouchbarButton.swift
@@ -9,20 +9,18 @@
 import Cocoa
 
 @available(OSX 10.12.2, *)
+@objcMembers
 final class GlobalTouchbarButton: NSCustomTouchBarItem {
-
-    private struct Constants {
-        static let IDTouchBar = NSTouchBarItem.Identifier("toggl.touchbar")
-    }
 
     // MARK: Variables
 
+    static let ID = NSTouchBarItem.Identifier("toggl.touchbar")
     private let button: NSButton
 
     // MARK: Init
 
     override init(identifier: NSTouchBarItem.Identifier) {
-        let image = NSImage(named: "on")!
+        let image = NSImage(named: "off")!
         image.isTemplate = true
         self.button = NSButton(image: image, target: nil, action: nil)
         self.button.imagePosition = .imageOnly
@@ -37,13 +35,16 @@ final class GlobalTouchbarButton: NSCustomTouchBarItem {
     }
 
     class func makeDefault() -> GlobalTouchbarButton {
-        let item = GlobalTouchbarButton(identifier: Constants.IDTouchBar)
-        return item
+        return GlobalTouchbarButton(identifier: GlobalTouchbarButton.ID)
     }
 
     // MARK: Public
 
-
+    func update(_ iconImage: NSImage) {
+        // This forces the icon to redraw
+        button.image = iconImage
+        button.imagePosition = .imageOnly
+    }
 }
 
 // MARK: Private

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -71,6 +71,8 @@ typedef enum : NSUInteger
 @property (weak) IBOutlet NSButton *changeDurationButton;
 @property (weak) IBOutlet NSSegmentedControl *tabSegment;
 @property (weak) IBOutlet NSTabView *tabView;
+@property (weak) IBOutlet NSButton *showTouchBarButton;
+@property (weak) IBOutlet NSLayoutConstraint *bottomContainerHeight;
 
 @property (nonatomic, assign) NSInteger selectedProxyIndex;
 @property (nonatomic, strong) NSArray<AutotrackerRuleItem *> *rules;
@@ -106,6 +108,7 @@ typedef enum : NSUInteger
 - (IBAction)openEditorOnShortcut:(id)sender;
 - (IBAction)defaultProjectSelected:(id)sender;
 - (IBAction)changeDurationButtonChanged:(id)sender;
+- (IBAction)touchBarButtonChanged:(id)sender;
 
 @end
 
@@ -202,6 +205,9 @@ extern void *ctx;
 - (IBAction)changeDurationButtonChanged:(id)sender
 {
 	toggl_set_keep_end_time_fixed(ctx, [Utils stateToBool:[self.changeDurationButton state]]);
+}
+
+- (IBAction)touchBarButtonChanged:(id)sender {
 }
 
 - (IBAction)proxyRadioChanged:(id)sender

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.m
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.m
@@ -207,7 +207,9 @@ extern void *ctx;
 	toggl_set_keep_end_time_fixed(ctx, [Utils stateToBool:[self.changeDurationButton state]]);
 }
 
-- (IBAction)touchBarButtonChanged:(id)sender {
+- (IBAction)touchBarButtonChanged:(id)sender
+{
+	toggl_set_settings_show_touch_bar(ctx, [Utils stateToBool:[self.showTouchBarButton state]]);
 }
 
 - (IBAction)proxyRadioChanged:(id)sender
@@ -499,6 +501,18 @@ const int kUseProxyToConnectToToggl = 2;
 	free(default_project_name);
 
 	[self.changeDurationButton setState:[Utils boolToState:toggl_get_keep_end_time_fixed(ctx)]];
+
+	if (@available(macOS 10.12.2, *))
+	{
+		self.showTouchBarButton.hidden = NO;
+		self.bottomContainerHeight.constant = 58;
+		[self.showTouchBarButton setState:[Utils boolToState:toggl_get_show_touch_bar(ctx)]];
+	}
+	else
+	{
+		self.showTouchBarButton.hidden = YES;
+		self.bottomContainerHeight.constant = 38;
+	}
 }
 
 - (void)selectProxyRadioWithTag:(NSInteger)tag

--- a/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
+++ b/src/ui/osx/TogglDesktop/PreferencesWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,6 +14,7 @@
                 <outlet property="autotrackerProject" destination="TN9-Mx-4gf" id="94P-Mq-SHg"/>
                 <outlet property="autotrackerRulesTableView" destination="aw6-zQ-ZW8" id="3SU-TC-YlQ"/>
                 <outlet property="autotrackerTerm" destination="afg-Ty-RcE" id="KZ5-IU-C0e"/>
+                <outlet property="bottomContainerHeight" destination="i5y-AO-dds" id="qBO-oj-OAo"/>
                 <outlet property="changeDurationButton" destination="TkJ-tA-lDK" id="tZ1-lP-zjX"/>
                 <outlet property="defaultProject" destination="AQZ-NT-Pr8" id="Yug-eK-iIR"/>
                 <outlet property="dockIconCheckbox" destination="kR2-Ee-viZ" id="Nm7-te-1KH"/>
@@ -44,6 +45,7 @@
                 <outlet property="reminderCheckbox" destination="Spu-c6-dBl" id="rce-jc-2Cq"/>
                 <outlet property="reminderMinutesTextField" destination="R9v-BZ-yhR" id="OVt-ic-hzF"/>
                 <outlet property="showHideShortcutView" destination="DLB-Fw-7tX" id="T2o-mF-KXG"/>
+                <outlet property="showTouchBarButton" destination="uPL-ax-1Ux" id="eAl-AY-wbs"/>
                 <outlet property="startStopShortcutView" destination="Ft4-tk-xRA" id="5tb-G5-s2R"/>
                 <outlet property="stopOnShutdownCheckbox" destination="n3k-Br-KIY" id="guw-6w-Kef"/>
                 <outlet property="tabSegment" destination="2zJ-7y-OAc" id="qpb-67-EOV"/>
@@ -60,21 +62,21 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="Preferences" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="400" height="570"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <value key="minSize" type="size" width="400" height="570"/>
+            <rect key="contentRect" x="196" y="240" width="400" height="590"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <value key="minSize" type="size" width="400" height="590"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <box boxType="custom" borderType="none" borderWidth="0.0" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="qdc-hR-YLw">
-                        <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                        <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                         <view key="contentView" id="QZK-80-mX3">
-                            <rect key="frame" x="0.0" y="0.0" width="412" height="570"/>
+                            <rect key="frame" x="0.0" y="0.0" width="412" height="590"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RqW-Eb-jQc">
-                                    <rect key="frame" x="166" y="551" width="81" height="17"/>
+                                    <rect key="frame" x="166" y="571" width="81" height="17"/>
                                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Preferences" id="DcZ-K3-JhQ">
                                         <font key="font" usesAppearanceFont="YES"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -90,16 +92,16 @@
                         <color key="fillColor" name="preference-background-color"/>
                     </box>
                     <tabView drawsBackground="NO" allowsTruncatedLabels="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="ZDX-gA-MBn">
-                        <rect key="frame" x="0.0" y="0.0" width="412" height="540"/>
+                        <rect key="frame" x="0.0" y="0.0" width="412" height="560"/>
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="3dj-rq-0aF">
                                 <view key="view" id="7qY-5d-VHf">
-                                    <rect key="frame" x="0.0" y="0.0" width="412" height="540"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="412" height="560"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="KYJ-q7-LnW">
-                                            <rect key="frame" x="15" y="320" width="382" height="208"/>
+                                            <rect key="frame" x="15" y="340" width="382" height="208"/>
                                             <view key="contentView" id="a3O-tS-arC">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="208"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -292,7 +294,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="brM-0V-2IH">
-                                            <rect key="frame" x="15" y="180" width="382" height="130"/>
+                                            <rect key="frame" x="15" y="200" width="382" height="130"/>
                                             <view key="contentView" id="vnT-py-ejH">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="130"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -371,7 +373,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zQS-pF-1EQ">
-                                            <rect key="frame" x="15" y="112" width="382" height="58"/>
+                                            <rect key="frame" x="15" y="132" width="382" height="58"/>
                                             <view key="contentView" id="Kte-rl-Tae">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -412,7 +414,7 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="zez-BU-pHz">
-                                            <rect key="frame" x="15" y="56" width="382" height="46"/>
+                                            <rect key="frame" x="15" y="76" width="382" height="46"/>
                                             <view key="contentView" id="PaI-l4-AmI">
                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="46"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -455,31 +457,55 @@
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
                                         <box autoresizesSubviews="NO" boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="4OJ-cM-plX">
-                                            <rect key="frame" x="15" y="8" width="382" height="38"/>
+                                            <rect key="frame" x="15" y="8" width="382" height="58"/>
                                             <view key="contentView" id="l4g-U3-2Pc">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="38"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="TkJ-tA-lDK">
-                                                        <rect key="frame" x="8" y="11" width="297" height="16"/>
-                                                        <buttonCell key="cell" type="check" title="Change duration when changing start time" bezelStyle="regularSquare" imagePosition="left" inset="2" id="I1Q-IJ-dNX">
-                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                            <font key="font" metaFont="system" size="14"/>
-                                                        </buttonCell>
-                                                        <connections>
-                                                            <action selector="changeDurationButtonChanged:" target="-2" id="7MA-Tq-Byc"/>
-                                                            <outlet property="nextKeyView" destination="DLB-Fw-7tX" id="fV4-6n-SEL"/>
-                                                        </connections>
-                                                    </button>
+                                                    <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="10" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kxD-OV-7on">
+                                                        <rect key="frame" x="10" y="10" width="362" height="38"/>
+                                                        <subviews>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="TkJ-tA-lDK">
+                                                                <rect key="frame" x="-2" y="22" width="297" height="18"/>
+                                                                <buttonCell key="cell" type="check" title="Change duration when changing start time" bezelStyle="regularSquare" imagePosition="left" inset="2" id="I1Q-IJ-dNX">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system" size="14"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="changeDurationButtonChanged:" target="-2" id="7MA-Tq-Byc"/>
+                                                                    <outlet property="nextKeyView" destination="uPL-ax-1Ux" id="TX2-rh-CKg"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="uPL-ax-1Ux">
+                                                                <rect key="frame" x="-2" y="-2" width="181" height="18"/>
+                                                                <buttonCell key="cell" type="check" title="Show Toggl in Touch Bar" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Ies-tN-a1z">
+                                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                    <font key="font" metaFont="system" size="14"/>
+                                                                </buttonCell>
+                                                                <connections>
+                                                                    <action selector="touchBarButtonChanged:" target="-2" id="0PY-k5-epN"/>
+                                                                    <outlet property="nextKeyView" destination="DLB-Fw-7tX" id="50c-bo-ok0"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                        <visibilityPriorities>
+                                                            <integer value="1000"/>
+                                                            <integer value="1000"/>
+                                                        </visibilityPriorities>
+                                                        <customSpacing>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                            <real value="3.4028234663852886e+38"/>
+                                                        </customSpacing>
+                                                    </stackView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="TkJ-tA-lDK" firstAttribute="leading" secondItem="l4g-U3-2Pc" secondAttribute="leading" constant="10" id="7ee-Qr-ikP"/>
-                                                    <constraint firstItem="TkJ-tA-lDK" firstAttribute="top" secondItem="l4g-U3-2Pc" secondAttribute="top" constant="13" id="RhY-kT-f2D"/>
-                                                    <constraint firstAttribute="bottom" secondItem="TkJ-tA-lDK" secondAttribute="bottom" constant="13" id="YxE-My-Mqw"/>
+                                                    <constraint firstAttribute="trailing" secondItem="kxD-OV-7on" secondAttribute="trailing" constant="10" id="7Sr-bV-ezI"/>
+                                                    <constraint firstItem="kxD-OV-7on" firstAttribute="top" secondItem="l4g-U3-2Pc" secondAttribute="top" constant="10" id="9ap-aJ-V6I"/>
+                                                    <constraint firstItem="kxD-OV-7on" firstAttribute="leading" secondItem="l4g-U3-2Pc" secondAttribute="leading" constant="10" id="f6y-qJ-EQ3"/>
                                                 </constraints>
                                             </view>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="38" id="i5y-AO-dds"/>
+                                                <constraint firstAttribute="height" constant="58" id="i5y-AO-dds"/>
                                             </constraints>
                                             <color key="fillColor" name="preference-box-background-color"/>
                                         </box>
@@ -790,7 +816,7 @@
                                                         <rect key="frame" x="10" y="12" width="362" height="257"/>
                                                         <clipView key="contentView" id="anG-U7-QUu">
                                                             <rect key="frame" x="1" y="1" width="360" height="255"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="SWk-HQ-4y3" id="aw6-zQ-ZW8">
                                                                     <rect key="frame" x="0.0" y="0.0" width="360" height="232"/>
@@ -1171,7 +1197,7 @@
                         </tabViewItems>
                     </tabView>
                     <box boxType="custom" borderType="none" borderWidth="0.0" cornerRadius="4" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="x8k-FT-alL">
-                        <rect key="frame" x="32" y="518" width="348" height="20"/>
+                        <rect key="frame" x="32" y="538" width="348" height="20"/>
                         <view key="contentView" id="6PL-X1-TWK">
                             <rect key="frame" x="0.0" y="0.0" width="348" height="20"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1179,7 +1205,7 @@
                         <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </box>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2zJ-7y-OAc">
-                        <rect key="frame" x="30" y="515" width="352" height="24"/>
+                        <rect key="frame" x="30" y="535" width="352" height="24"/>
                         <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="V97-Jh-edB">
                             <font key="font" metaFont="system"/>
                             <segments>

--- a/src/ui/osx/TogglDesktop/Settings.h
+++ b/src/ui/osx/TogglDesktop/Settings.h
@@ -42,6 +42,7 @@
 @property (nonatomic, assign) NSInteger pomodoro_minutes;
 @property (nonatomic, assign) NSInteger pomodoro_break_minutes;
 @property (nonatomic, assign) BOOL stopWhenShutdown;
+@property (nonatomic, assign) BOOL showTouchBar;
 
 - (void)load:(TogglSettingsView *)data;
 @end

--- a/src/ui/osx/TogglDesktop/Settings.m
+++ b/src/ui/osx/TogglDesktop/Settings.m
@@ -52,6 +52,7 @@
 
 	self.open_editor_on_shortcut = data->OpenEditorOnShortcut;
 	self.stopWhenShutdown = data->StopEntryOnShutdownSleep;
+	self.showTouchBar = data->ShowTouchBar;
 }
 
 @end

--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -103,6 +103,10 @@ NSString *kInactiveTimerColor = @"#999999";
 												 selector:@selector(stop:)
 													 name:kCommandStop
 												   object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(startTimerNotification:)
+													 name:kStartTimer
+												   object:nil];
 
 		self.time_entry = [[TimeEntryViewItem alloc] init];
 
@@ -714,7 +718,7 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 }
 
-- (void)startNewShortcut:(NSNotification *)notification
+- (void)startTimerNotification:(NSNotification *)notification
 {
 	[self startButtonClicked:self];
 }
@@ -750,6 +754,7 @@ NSString *kInactiveTimerColor = @"#999999";
 - (IBAction)cancelBtnOnTap:(id)sender
 {
 	NSString *description = self.time_entry.Description;
+
 	self.time_entry = [[TimeEntryViewItem alloc] init];
 	self.time_entry.Description = description;
 	self.tagFlag.hidden = YES;

--- a/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
+++ b/src/ui/osx/TogglDesktop/TogglDesktop.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		BAE6379A22B225C70024DD08 /* AddTagButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE6379922B225C70024DD08 /* AddTagButton.swift */; };
 		BAE8E845224CA9AC006D534E /* ProjectAutoCompleteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */; };
 		BAF38FEF2241FF20009147D7 /* FloatingErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA276A132240F5B500810C51 /* FloatingErrorView.xib */; };
+		BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */; };
 		BAF50DE521A29FED0090BA95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAF50DE421A29FED0090BA95 /* Images.xcassets */; };
 		BAF50DF821A2A18D0090BA95 /* AppIconFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */; };
 		BAF6319C21E6F868002DD6AB /* NotificationCenter+MainThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF6319B21E6F868002DD6AB /* NotificationCenter+MainThread.swift */; };
@@ -590,6 +591,7 @@
 		BAE49CAD222FC1C900773814 /* TimerContainerBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerContainerBox.swift; sourceTree = "<group>"; };
 		BAE6379922B225C70024DD08 /* AddTagButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTagButton.swift; sourceTree = "<group>"; };
 		BAE8E844224CA9AC006D534E /* ProjectAutoCompleteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAutoCompleteTextField.swift; sourceTree = "<group>"; };
+		BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTouchbarButton.swift; sourceTree = "<group>"; };
 		BAF50DE421A29FED0090BA95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TogglDesktop/Images.xcassets; sourceTree = "<group>"; };
 		BAF50DF621A2A18D0090BA95 /* AppIconFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIconFactory.h; sourceTree = "<group>"; };
 		BAF50DF721A2A18D0090BA95 /* AppIconFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIconFactory.m; sourceTree = "<group>"; };
@@ -1127,6 +1129,7 @@
 		BA712EAF21BF904E00A2D8DD /* Feature */ = {
 			isa = PBXGroup;
 			children = (
+				BAF3ACCA2341F86300E41B33 /* TouchBar */,
 				BA5B0E2E2330E1A8008D1DED /* GoogleLogin */,
 				BA13D1E42269B4F600EB3833 /* Calendar */,
 				BA657280224DFA4F00BA4C60 /* ColorWheel */,
@@ -1232,6 +1235,14 @@
 				BAD15FFD223A530600A8CCC9 /* TimeEntryEmptyView.xib */,
 			);
 			path = TimeEntryEmptyView;
+			sourceTree = "<group>";
+		};
+		BAF3ACCA2341F86300E41B33 /* TouchBar */ = {
+			isa = PBXGroup;
+			children = (
+				BAF3ACCB2341F8AC00E41B33 /* GlobalTouchbarButton.swift */,
+			);
+			path = TouchBar;
 			sourceTree = "<group>";
 		};
 		BAF50DF521A2A16D0090BA95 /* IconFactory */ = {
@@ -1595,6 +1606,7 @@
 				7438B3D318253CD2002AE43C /* MenuItemTags.m in Sources */,
 				3CE1CAC11C774F2B00D0ADD5 /* LoadMoreCell.m in Sources */,
 				749CB8CC18167D6E00814841 /* PreferencesWindowController.m in Sources */,
+				BAF3ACCC2341F8AC00E41B33 /* GlobalTouchbarButton.swift in Sources */,
 				3C7B4E8D190FA6D200627DC3 /* NSTextFieldVerticallyAligned.m in Sources */,
 				BAB0027F22731248005ECC93 /* DayLabel.swift in Sources */,
 				3C7B4EB3190FB57A00627DC3 /* NSSecureTextFieldVerticallyAligned.m in Sources */,

--- a/src/ui/osx/TogglDesktop/UIEvents.h
+++ b/src/ui/osx/TogglDesktop/UIEvents.h
@@ -36,6 +36,7 @@ extern NSString *const kDisplayTimerState;
 extern NSString *const kDisplayUnsyncedItems;
 extern NSString *const kDisplayAutotrackerRules;
 extern NSString *const kDisplayPromotion;
+extern NSString *const kStartTimer;
 
 extern NSString *const kHideDisplayError;
 extern NSString *const kForceCloseEditPopover;

--- a/src/ui/osx/TogglDesktop/UIEvents.m
+++ b/src/ui/osx/TogglDesktop/UIEvents.m
@@ -33,6 +33,7 @@ NSString *const kDisplayTimerState = @"kDisplayTimerState";
 NSString *const kDisplayUnsyncedItems = @"kDisplayUnsyncedItems";
 NSString *const kDisplayAutotrackerRules = @"kDisplayAutotrackerRules";
 NSString *const kDisplayPromotion = @"kDisplayPromotion";
+NSString *const kStartTimer = @"kStartTimer";
 
 NSString *const kHideDisplayError = @"kHideDisplayError";
 NSString *const kForceCloseEditPopover = @"kForceCloseEditPopover";

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -995,6 +995,7 @@ void *ctx;
 
 - (void)setupTouchBar
 {
+	DFRSystemModalShowsCloseBoxWhenFrontMost(YES);
 	self.touchItem = [GlobalTouchbarButton makeDefault];
 	[NSTouchBarItem addSystemTrayItem:self.touchItem];
 	DFRElementSetControlStripPresenceForIdentifier([GlobalTouchbarButton ID], YES);

--- a/src/ui/osx/TogglDesktop/test2/AppDelegate.m
+++ b/src/ui/osx/TogglDesktop/test2/AppDelegate.m
@@ -38,8 +38,6 @@
 #import "Reachability.h"
 #import <AppAuth/AppAuth.h>
 
-static const NSTouchBarItemIdentifier touchIdentifier = @"toggl.touchbar";
-
 @interface AppDelegate ()
 @property (nonatomic, strong) MainWindowController *mainWindowController;
 @property (nonatomic, strong) PreferencesWindowController *preferencesWindowController;
@@ -49,9 +47,7 @@ static const NSTouchBarItemIdentifier touchIdentifier = @"toggl.touchbar";
 @property (nonatomic, strong) ConsoleViewController *consoleWindowController;
 
 // Touch Bar items
-@property NSCustomTouchBarItem *touchItem;
-@property NSButton *touchBarButton;
-@property NSImage *iconImage;
+@property (nonatomic, strong) GlobalTouchbarButton *touchItem;
 
 // Remember some app state
 @property (nonatomic, strong) TimeEntryViewItem *lastKnownRunningTimeEntry;
@@ -825,8 +821,8 @@ void *ctx;
 			key = @"offline_off";
 		}
 	}
-	self.iconImage = [self.statusImages objectForKey:key];
-	NSAssert(self.iconImage, @"status image not found!");
+	NSImage *image = [self.statusImages objectForKey:key];
+	NSAssert(image, @"status image not found!");
 
 	if (![title isEqualToString:self.statusItem.title])
 	{
@@ -838,13 +834,10 @@ void *ctx;
 		[self.statusItem setTitle:title];
 	}
 
-	if (self.iconImage != self.statusItem.image)
+	if (image != self.statusItem.image)
 	{
-		[self.statusItem setImage:self.iconImage];
-
-		// This forces the icon to redraw
-		[self.touchBarButton setImage:self.iconImage];
-		self.touchBarButton.imagePosition = NSImageOnly;
+		[self.statusItem setImage:image];
+		[self.touchItem update:image];
 	}
 }
 
@@ -1002,12 +995,9 @@ void *ctx;
 
 - (void)setupTouchBar
 {
-	self.touchItem = [[NSCustomTouchBarItem alloc] initWithIdentifier:touchIdentifier];
-	self.touchBarButton = [NSButton buttonWithImage:self.iconImage target:nil action:nil];
-	self.touchItem.view = self.touchBarButton;
-
+	self.touchItem = [GlobalTouchbarButton makeDefault];
 	[NSTouchBarItem addSystemTrayItem:self.touchItem];
-	DFRElementSetControlStripPresenceForIdentifier(touchIdentifier, YES);
+	DFRElementSetControlStripPresenceForIdentifier([GlobalTouchbarButton ID], YES);
 }
 
 - (IBAction)onConsoleMenuItem:(id)sender


### PR DESCRIPTION
### 📒 Description
This PR introduces the Global Toggl on Touch Bar.

### 🕶️ Types of changes
**New feature** (non-breaking change which adds functionality)

### 🤯 List of changes
- [x] Introduce GlobalTouchBarButton on Control Strip (The right panel)
- [x] Introduce show_touch_bar in library (database and migration)
- [x] Get / set show_touch_bar in library
- [x] Add "Show Toggl in Touch Bar" in Preference. Hide if OS X < 10.12.2
- [x] Start / Stop the TimeEntry when tapping on this global button

### 👫 Relationships
Close #3349 

### 🔎 Review hints
#### Prepare 
- If your macbook has Touch Bar, it's good news
- If not, please open the Touch Bar Simulator at Xcode app -> Windows Menu -> Show Touch Bar

#### The Global button state is matching the current TE state
1. Start app
2. Check if the Global button is shown -> 💯 
<img width="1141" alt="Screen Shot 2019-09-30 at 20 20 43" src="https://user-images.githubusercontent.com/5878421/65882847-0ba37b00-e3c0-11e9-885e-f3e6233e2e73.png">
3. Start the TE on app -> Global btn change to ON icon -> 💯 
4. Stop the TE on app -> Global Btn change to OFF icon -> 💯 
5. Tap on Global btn -> Start or Stop the TE -> 💯 

#### Preference 
1. Open Preference
2. Un-check the "Show Toggl touch bar"
3. The Global btn disappears -> 💯 
4. Stop app
5. Open again and verify that the state is persisted -> 💯 

