### PR TITLE
Return empty string if `XDG_CURRENT_DESKTOP` is not set

### DIFF
--- a/src/platforminfo.cc
+++ b/src/platforminfo.cc
@@ -132,7 +132,7 @@ std::string getWMName() {
 
 std::string getDEName() {
     char *env = getenv("XDG_CURRENT_DESKTOP");
-    return std::string(env);
+    return env ? std::string(env) : "";
 }
 
 std::string getDistroName() {


### PR DESCRIPTION
### 📒 Description
This makes `getDEName` return empty string instead of crashing on the [null pointer](https://en.cppreference.com/w/cpp/utility/program/getenv) when `XDG_CURRENT_DESKTOP` env variable is not provided.

### 🕶️ Types of changes
<!-- What types of changes does your code introduce? Uncomment all lines that apply: -->
This fixes #3336.
<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

### 🤯 List of changes
<!-- The changelog of this PR. It's useful for bigger PR-s -->

### 👫 Relationships
<!-- Mention your Issue or other PR, which connects with this PR -->
Closes #3336.
<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
<!-- Tips to the reviewer about how this should be tested -->
To check that the issue has been resolved, you can run:
```bash
unset XDG_CURRENT_DESKTOP
TogglDesktop
```
