### PR TITLE
Improve status code 429 handling

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -4996,7 +4996,7 @@ error Context::pushEntries(
             }
             error_found = true;
             error_message = resp.body;
-            if (error_message == noError) {
+            if (error_message == noError || resp.status_code == 429) {
                 error_message = resp.err;
             }
             // Mark the time entry as unsynced now

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -149,6 +149,8 @@ error GUI::DisplayError(const error &err) {
         ss << "You are offline (" << err << ")";
         if (kBackendIsDownError == err) {
             DisplayOnlineState(kOnlineStateBackendDown);
+        } else if (kCannotConnectError == err) {
+            DisplayOnlineState(kOnlineStateRateLimit);
         } else {
             DisplayOnlineState(kOnlineStateNoNetwork);
         }
@@ -336,7 +338,8 @@ void GUI::DisplayOnlineState(const Poco::Int64 state) {
 
     if (!(kOnlineStateOnline == state
             || kOnlineStateNoNetwork == state
-            || kOnlineStateBackendDown == state)) {
+            || kOnlineStateBackendDown == state
+            || kOnlineStateRateLimit == state)) {
         std::stringstream ss;
         ss << "Invalid online state " << state;
         logger().error(ss.str());
@@ -355,6 +358,9 @@ void GUI::DisplayOnlineState(const Poco::Int64 state) {
         break;
     case kOnlineStateBackendDown:
         ss << "backend is down";
+        break;
+    case kOnlineStateRateLimit:
+        ss << "too many requests";
         break;
     }
     logger().debug(ss.str());

--- a/src/toggl_api.h
+++ b/src/toggl_api.h
@@ -30,6 +30,7 @@ extern "C" {
 #define kOnlineStateOnline 0
 #define kOnlineStateNoNetwork 1
 #define kOnlineStateBackendDown 2
+#define kOnlineStateRateLimit 3
 
 #define kSyncStateIdle 0
 #define kSyncStateWork 1

--- a/src/ui/osx/TogglDesktop/MainWindowController.m
+++ b/src/ui/osx/TogglDesktop/MainWindowController.m
@@ -215,6 +215,9 @@ extern void *ctx;
 		case 2 :
 			[[SystemMessage shared] presentOffline:@"Error" subTitle:@"Offline, Toggl not responding"];
 			break;
+        case 3 :
+            [[SystemMessage shared] presentOffline:@"Error" subTitle:@"Too many requests, sync delayed by 1 minute"];
+            break;
 		default :
 			[self closeError];
 			break;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/Toggl.cs
@@ -49,7 +49,8 @@ public static partial class Toggl
     {
         Online = kOnlineStateOnline,
         NoNetwork = kOnlineStateNoNetwork,
-        BackendDown = kOnlineStateBackendDown
+        BackendDown = kOnlineStateBackendDown,
+        RateLimit = kOnlineStateRateLimit
     }
 
     public enum SyncState

--- a/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
@@ -24,6 +24,7 @@ public static partial class Toggl
     private const int kOnlineStateOnline = 0;
     private const int kOnlineStateNoNetwork = 1;
     private const int kOnlineStateBackendDown = 2;
+    private const int kOnlineStateRateLimit = 3;
 
     private const int kSyncStateIdle = 0;
     private const int kSyncStateWork = 1;

--- a/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/StatusBar.xaml.cs
+++ b/src/ui/windows/TogglDesktop/TogglDesktop/ui/controls/StatusBar.xaml.cs
@@ -60,6 +60,11 @@ namespace TogglDesktop
                     this.statusText.Text = "Offline, Toggl not responding";
                     break;
                 }
+                case Toggl.OnlineState.RateLimit:
+                {
+                    this.statusText.Text = "Too many requests, sync delayed by 1 minute";
+                    break;
+                }
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
### 📒 Description
We show a human-readable error message when 429 happens. 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)


### 👫 Relationships

Closes #2245
Closes #3379 
Closes #3372

### 🔎 Review hints
 - Create a rate limit situation (pressing the keyboard shortcut for "new" million times)
 - Or simulate 429 some other way
 - Wait to see the error message about delayed sync

