### PR TITLE
Alternative solution for handling 429 error message

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -70,6 +70,7 @@
 #define kUnacceptableCertificate "Unacceptable certificate from www.toggl.com"
 #define kCannotUpgradeToWebSocketConnection "Cannot upgrade to WebSocket connection"  // NOLINT
 #define kSSLException "SSL Exception"
+#define kRateLimit "Too many requests, sync delayed by 1 minute"
 #define kCannotWriteFile "Cannot write file"
 #define kIsSuspended "is suspended"
 #define kRequestToServerFailedWithStatusCode403 "Request to server failed with status code: 403"  // NOLINT

--- a/src/context.cc
+++ b/src/context.cc
@@ -4999,6 +4999,10 @@ error Context::pushEntries(
             if (error_message == noError) {
                 error_message = resp.err;
             }
+            if (resp.status_code == 429) {
+                error_message = error(kRateLimit);
+            }
+
             // Mark the time entry as unsynced now
             (*it)->SetUnsynced();
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -4995,10 +4995,7 @@ error Context::pushEntries(
                 continue;
             }
             error_found = true;
-            error_message = resp.body;
-            if (error_message == noError) {
-                error_message = resp.err;
-            }
+            error_message = resp.err;
             if (resp.status_code == 429) {
                 error_message = error(kRateLimit);
             }

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -150,7 +150,7 @@ error GUI::DisplayError(const error &err) {
         if (kBackendIsDownError == err) {
             DisplayOnlineState(kOnlineStateBackendDown);
         }
-        else if (kRateLimit != err) {
+        else {
             DisplayOnlineState(kOnlineStateNoNetwork);
         }
         return err;

--- a/src/gui.cc
+++ b/src/gui.cc
@@ -149,7 +149,8 @@ error GUI::DisplayError(const error &err) {
         ss << "You are offline (" << err << ")";
         if (kBackendIsDownError == err) {
             DisplayOnlineState(kOnlineStateBackendDown);
-        } else {
+        }
+        else if (kRateLimit != err) {
             DisplayOnlineState(kOnlineStateNoNetwork);
         }
         return err;


### PR DESCRIPTION
## Description
Simple solution to handle 429 error message in all platforms.

## Changelogs
- [x] Treat 429 response as a normal error message 
- [x] Present the error by `DisplayError` func as usual 

## Steps to review

See https://github.com/toggl/toggldesktop/pull/3387