### PR TITLE
Only format the TogglDeskop source (mac)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ fmt_lib: third_party/google-astyle/build/google-astyle
 	third_party/google-astyle/build/google-astyle -n src/ui/windows/TogglDesktop/TogglDesktopDLLInteropTest//*.cs
 
 fmt_ui:
-	./third_party/Xcode-formatter/CodeFormatter/scripts/formatAllSources.sh src/ui/osx/
+	./third_party/Xcode-formatter/CodeFormatter/scripts/formatAllSources.sh src/ui/osx/TogglDesktop
 	third_party/google-astyle/build/google-astyle -n src/ui/windows/TogglDesktop/TogglDesktop/*.cs
 	third_party/google-astyle/build/google-astyle -n src/ui/windows/TogglDesktop/TogglDesktop/TogglApi.cs
 


### PR DESCRIPTION
### 📒 Description
This PR will change the direction of xcode-formatter.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Only format the TogglDesktop's source code

### 👫 Relationships
Closes #3395 

### 🔎 Review hints
1. Start / Stop in Debug mode 20 times
2. Check the size of those files in `./src/ui/osx/Pods/GTMSessionFetcher/Source/*`
3. If the size is not change -> 💯 
4. Check the build log -> Make sure xcode-formatter doesn't format those Pod's libraries

<img width="1792" alt="Screen Shot 2019-10-04 at 16 45 19" src="https://user-images.githubusercontent.com/5878421/66198976-dbaded80-e6c7-11e9-829d-9b0a592265bd.png">


