### PR TITLE
Fix memory leaks in View List handling

### DIFF
--- a/src/toggl_api_private.cc
+++ b/src/toggl_api_private.cc
@@ -64,8 +64,8 @@ void autocomplete_item_clear(TogglAutocompleteView *item) {
     free(item->ProjectColor);
     item->ProjectColor = nullptr;
 
-    free(item->WorkspaceName);
-    item->WorkspaceName = nullptr;
+    free(item->ProjectGUID);
+    item->ProjectGUID = nullptr;
 
     free(item->Tags);
     item->Tags = nullptr;

--- a/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
+++ b/src/ui/linux/TogglDesktop/autocompletelistmodel.cpp
@@ -13,6 +13,8 @@ void AutocompleteListModel::setList(QVector<AutocompleteView *> autocompletelist
     if (list == autocompletelist)
         return;
     beginResetModel();
+    for (auto i : list)
+        i->deleteLater();
     list = autocompletelist;
     endResetModel();
 }


### PR DESCRIPTION
### 📒 Description
This is a quick fix for some issues reported by Veljko on the channel last week. It should lower the memory footprint for users with a big count of projects, tasks and clients.
It also lowers memory usage when storing local items to the server (GUID field in the structure was not freed because of a typo)

### 🕶️ Types of changes
- **Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- Fixed a memory leak

### 👫 Relationships
Not sure if it actually closes the whole problem but it's definitely a part of fixing #1913 

### 🔎 Review hints
Check if memory footprint is lower with a big number of local items (when syncing to the server) or a lot of clients/projects/tasks. Also, the functionality of the Autocomplete should remain the same.

