### PR TITLE
Improve logic how we present the Create Tag button

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/TagDataSource.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/DataSource/TagDataSource.swift
@@ -47,29 +47,36 @@ final class TagDataSource: AutoCompleteViewDataSource {
 
         // show all
         if text.isEmpty {
-            render(with: TagStorage.shared.tags)
+            renderTagsAndCreateBtn(TagStorage.shared.tags, with: text)
             return
         }
 
         // Filter
         let filterItems = TagStorage.shared.filter(with: text)
-        render(with: filterItems)
-    }
-
-    override func render(with items: [Any]) {
-        super.render(with: items)
-
-        // Hide create if it's has content
-        if let first = items.first as? Tag, first.isEmptyTag {
-            autoCompleteView.setCreateButtonSectionHidden(false)
-            autoCompleteView.updateTitleForCreateButton(with: "Create new tag \"\(textField.stringValue)\"")
-        } else {
-            autoCompleteView.setCreateButtonSectionHidden(true)
-        }
+        renderTagsAndCreateBtn(filterItems, with: text)
     }
 
     func updateSelectedTags(_ tags: [Tag]) {
         self.selectedTags = tags
+    }
+
+    private func renderTagsAndCreateBtn(_ tags: [Tag], with text: String) {
+        render(with: tags)
+
+        // Determine if it should present the Create btn
+        var shouldShowCreateBtn = false
+        if let first = tags.first, first.isEmptyTag {
+            shouldShowCreateBtn = true
+        } else if !text.isEmpty && !tags.contains(where: { $0.name == text }) {
+            shouldShowCreateBtn = true
+        }
+
+        if shouldShowCreateBtn {
+            autoCompleteView.setCreateButtonSectionHidden(false)
+            autoCompleteView.updateTitleForCreateButton(with: "Create new tag \"\(text)\"")
+        } else {
+            autoCompleteView.setCreateButtonSectionHidden(true)
+        }
     }
 
     // MARK: Public


### PR DESCRIPTION
### 📒 Description
This PR improve how Tag AutoComplete presents the Create new Tag button.

### 🕶️ Types of changes
 **Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Improve the logic: Show the Tag button

### 👫 Relationships
Close #3410 

### 🔎 Review hints
- Try to create a new tag, which has same prefix with the existing tag. See the screenshot in the host ticket. => If we able to create -> 💯  
<img width="299" alt="Screen Shot 2019-10-09 at 15 17 22" src="https://user-images.githubusercontent.com/5878421/66464272-df1aed80-eaa8-11e9-9496-4fc0debe89ae.png">


