### PR TITLE
Able to click on Project labl in AutoComplete Cell (mac)

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -138,9 +138,6 @@ NSString *kInactiveTimerColor = @"#999999";
 	[self.liteAutocompleteDataSource setFilter:@""];
 
 	[self.startButton setHoverAlpha:0.75];
-
-	[self.autoCompleteInput.autocompleteTableView setTarget:self];
-	[self.autoCompleteInput.autocompleteTableView setAction:@selector(performClick:)];
 	self.autoCompleteInput.responderDelegate = self.autocompleteContainerView;
 
 	self.descriptionLabel.delegate = self;
@@ -541,6 +538,31 @@ NSString *kInactiveTimerColor = @"#999999";
 	return YES;
 }
 
+- (void)tableViewSelectionDidChange:(NSNotification *)notification
+{
+	NSInteger row = [self.autoCompleteInput.autocompleteTableView selectedRow];
+
+	if (row < 0)
+	{
+		return;
+	}
+
+	AutocompleteItem *item = [self.liteAutocompleteDataSource itemAtIndex:row];
+	// Category clicked
+	if (item == nil || item.Type < 0)
+	{
+		return;
+	}
+	[self fillEntryFromAutoComplete:item];
+	NSRange tRange = [[self.descriptionLabel currentEditor] selectedRange];
+	[[self.descriptionLabel currentEditor] setSelectedRange:NSMakeRange(tRange.length, 0)];
+	[self.autoCompleteInput resetTable];
+	[self.liteAutocompleteDataSource clearFilter];
+
+	// Show cancel btn
+	self.cancelBtn.hidden = NO;
+}
+
 - (NSView *) tableView:(NSTableView *)tableView
 	viewForTableColumn:(NSTableColumn *)tableColumn
 				   row:(NSInteger)row
@@ -586,31 +608,6 @@ NSString *kInactiveTimerColor = @"#999999";
 
 	// Other cells
 	return self.autoCompleteInput.itemHeight;
-}
-
-- (IBAction)performClick:(id)sender
-{
-	NSInteger row = [self.autoCompleteInput.autocompleteTableView clickedRow];
-
-	if (row < 0)
-	{
-		return;
-	}
-
-	AutocompleteItem *item = [self.liteAutocompleteDataSource itemAtIndex:row];
-	// Category clicked
-	if (item == nil || item.Type < 0)
-	{
-		return;
-	}
-	[self fillEntryFromAutoComplete:item];
-	NSRange tRange = [[self.descriptionLabel currentEditor] selectedRange];
-	[[self.descriptionLabel currentEditor] setSelectedRange:NSMakeRange(tRange.length, 0)];
-	[self.autoCompleteInput resetTable];
-	[self.liteAutocompleteDataSource clearFilter];
-
-	// Show cancel btn
-	self.cancelBtn.hidden = NO;
 }
 
 - (BOOL)control:(NSControl *)control textView:(NSTextView *)fieldEditor doCommandBySelector:(SEL)commandSelector
@@ -750,6 +747,7 @@ NSString *kInactiveTimerColor = @"#999999";
 - (IBAction)cancelBtnOnTap:(id)sender
 {
 	NSString *description = self.time_entry.Description;
+
 	self.time_entry = [[TimeEntryViewItem alloc] init];
 	self.time_entry.Description = description;
 	self.tagFlag.hidden = YES;

--- a/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
+++ b/src/ui/osx/TogglDesktop/test2/ProjectTextField.m
@@ -34,6 +34,7 @@
 - (void)mouseDown:(NSEvent *)theEvent
 {
 	[self sendAction:@selector(textFieldClicked:) to:[self delegate]];
+	[super mouseDown:theEvent];
 }
 
 - (void)setAttributedStringValue:(NSAttributedString *)attributedStringValue


### PR DESCRIPTION
### 📒 Description
This PR introduce the fix when the user couldn't click on the Project label of the AutoComplete Cell. (see the host ticket for the bug video)

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Adopt Selection Change from TableView's Delegate rather than using ClickPerform
- [x] Pass the click event to other view in Project label 

### 👫 Relationships
Closes  #3378

### 🔎 Review hints
- Able to select on any part of the AutoComplete Cell in Timer Bar
- Able to select the Project in Editor 

![2019-10-09 17 42 06](https://user-images.githubusercontent.com/5878421/66475134-ecda6e00-eabc-11e9-81e2-98433372a4a6.gif)

