### PR TITLE
Highlight all tag text field after selection

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/AutoComplete/Input/AutoCompleteTextField.swift
@@ -131,9 +131,8 @@ class AutoCompleteTextField: UndoTextField, NSTextFieldDelegate, AutoCompleteVie
         state = .collapse
     }
 
-    func resetText() {
-        stringValue = ""
-        handleTextDidChange()
+    func selectAllText() {
+        currentEditor()?.selectAll(nil)
     }
 
     func updateWindowContent(with view: NSView, height: CGFloat) {

--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -537,7 +537,7 @@ extension EditorViewController: AutoCompleteTextFieldDelegate {
 
             // Focus on tag textfield agains, so user can continue typying
             tagTextField.focus()
-            tagTextField.resetText()
+            tagTextField.selectAllText()
         }
     }
 
@@ -617,7 +617,7 @@ extension EditorViewController: TagDataSourceDelegate {
     func tagSelectionChanged(with selectedTags: [Tag]) {
         let tags = selectedTags.toNames()
         DesktopLibraryBridge.shared().updateTimeEntry(withTags: tags, guid: timeEntry.guid)
-        tagTextField.resetText()
+        tagTextField.selectAllText()
     }
 }
 


### PR DESCRIPTION
### 📒 Description
This PR introduce the UI Improvement:
- Keep the Tag Text Field and highlight it after selecting an tag

### 🕶️ Types of changes
**Improvement** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Don't reset Tag Text Field
- [x] Select All (Highlight) text

### 👫 Relationships
Closes #3438 

### 🔎 Review hints
#### Tag Text field is remained and select all
1. Select any TE
2. Type some word on Tag Text Field -> Make sure there are couple results
3. Select tag by mouse or keyboard -> The Tag Text Field won't reset and the text is highlight-> 💯 
4. Able to select other result -> 💯 

### GIF
![2019-10-21 13 53 24](https://user-images.githubusercontent.com/5878421/67182975-8df4ed00-f40a-11e9-9f42-ee19b85e3393.gif)


