### PR TITLE
Enable Actions for create only for the master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - '**'
   create:
+    branches:
+      - 'master'
     tags:
       - '**'
 


### PR DESCRIPTION
This disables running the `create` workflow for any branch that's not `master` which solves running it for each new branch and also it won't (probably, the docs are not really clear on this) build tags that are not present on `master`.