### PR TITLE
Lite version Timeline for Catalina

### DIFF
--- a/src/lib/osx/Kopsik/MacOSVersionChecker.mm
+++ b/src/lib/osx/Kopsik/MacOSVersionChecker.mm
@@ -1,0 +1,53 @@
+//
+//  MacOSVersionChecker.m
+//  TogglDesktopLibrary
+//
+//  Created by Nghia Tran on 10/21/19.
+//  Copyright © 2019 Toggl. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSProcessInfo.h>
+#include <string.h>
+#include <iostream>
+
+struct OSVersion {
+    long major;
+    long minor;
+    long path;
+
+    OSVersion(long major, long minor, long path) {
+        this->major = major;
+        this->minor = minor;
+        this->path = path;
+    }
+};
+
+OSVersion* getProcessInfoVersion (void) {
+    NSProcessInfo *processInfo = [[NSProcessInfo alloc] init];
+
+    // check avaiability of the property operatingSystemVersion (10.10+) at runtime
+    if ([processInfo respondsToSelector:@selector(operatingSystemVersion)])
+    {
+        NSOperatingSystemVersion versionObj = [processInfo operatingSystemVersion];
+        OSVersion *version = new OSVersion(versionObj.majorVersion, versionObj.minorVersion, versionObj.patchVersion);
+        return version;
+    }
+    else
+    {
+        return nil;
+    }
+}
+
+// Check if Screen Recording permission is needed in OS >= 10.15
+bool isScreenRecordingPermissionAvailable(void) {
+    OSVersion *version = getProcessInfoVersion();
+    if (version == nullptr) {
+        return false;
+    }
+    if (version->major >= 10 && version->minor >= 15) {
+        return true;
+    }
+    return false;
+}
+

--- a/src/lib/osx/Kopsik/MacOSVersionChecker.mm
+++ b/src/lib/osx/Kopsik/MacOSVersionChecker.mm
@@ -39,8 +39,7 @@ OSVersion* getProcessInfoVersion (void) {
     }
 }
 
-// Check if Screen Recording permission is needed in OS >= 10.15
-bool isScreenRecordingPermissionAvailable(void) {
+bool isCatalinaOSX(void) {
     OSVersion *version = getProcessInfoVersion();
     if (version == nullptr) {
         return false;
@@ -50,4 +49,3 @@ bool isScreenRecordingPermissionAvailable(void) {
     }
     return false;
 }
-

--- a/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
+++ b/src/lib/osx/TogglDesktopLibrary.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		74EB0F1817F9A2600046ABC1 /* https_client.h in Headers */ = {isa = PBXBuildFile; fileRef = 74EB0F1617F9A2600046ABC1 /* https_client.h */; };
 		74F7CDDB18199FA300630BD0 /* window_change_recorder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 74F7CDD918199FA300630BD0 /* window_change_recorder.cc */; };
 		74F7CDDC18199FA300630BD0 /* window_change_recorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 74F7CDDA18199FA300630BD0 /* window_change_recorder.h */; };
+		BA1AB53E235DEAD4000433AE /* MacOSVersionChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */; };
 		BA2DA11C21A6864D0027B7A5 /* rectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = BA2DA11A21A6864D0027B7A5 /* rectangle.h */; };
 		BA2DA11D21A6864D0027B7A5 /* rectangle.cc in Sources */ = {isa = PBXBuildFile; fileRef = BA2DA11B21A6864D0027B7A5 /* rectangle.cc */; };
 		BAD233E321D60A4D0039C742 /* libPocoNet.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BAD233DA21D60A4D0039C742 /* libPocoNet.dylib */; };
@@ -176,6 +177,7 @@
 		74EB0F1617F9A2600046ABC1 /* https_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = https_client.h; path = ../../../https_client.h; sourceTree = "<group>"; };
 		74F7CDD918199FA300630BD0 /* window_change_recorder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = window_change_recorder.cc; path = ../../../window_change_recorder.cc; sourceTree = "<group>"; };
 		74F7CDDA18199FA300630BD0 /* window_change_recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = window_change_recorder.h; path = ../../../window_change_recorder.h; sourceTree = "<group>"; };
+		BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MacOSVersionChecker.mm; sourceTree = "<group>"; };
 		BA2DA11A21A6864D0027B7A5 /* rectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rectangle.h; path = ../../../rectangle.h; sourceTree = "<group>"; };
 		BA2DA11B21A6864D0027B7A5 /* rectangle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rectangle.cc; path = ../../../rectangle.cc; sourceTree = "<group>"; };
 		BAD233DA21D60A4D0039C742 /* libPocoNet.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libPocoNet.dylib; path = ../../../third_party/poco/lib/Darwin/x86_64/libPocoNet.dylib; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				C55DA59F17F06A3B00B42178 /* Supporting Files */,
 				BA2DA11A21A6864D0027B7A5 /* rectangle.h */,
 				BA2DA11B21A6864D0027B7A5 /* rectangle.cc */,
+				BA1AB53D235DEAD4000433AE /* MacOSVersionChecker.mm */,
 			);
 			name = lib;
 			path = Kopsik;
@@ -517,6 +520,7 @@
 				7408EDB818C51CEB00CBE8F1 /* feedback.cc in Sources */,
 				74E16831180F26D90026261C /* websocket_client.cc in Sources */,
 				74B587CA18BBC77E00E9F6CE /* client.cc in Sources */,
+				BA1AB53E235DEAD4000433AE /* MacOSVersionChecker.mm in Sources */,
 				7408EDB118C51CEB00CBE8F1 /* proxy.cc in Sources */,
 				C5DA1FAB17F18D7B001C4565 /* database.cc in Sources */,
 				748B7DA51AC5963B00FE01D2 /* custom_error_handler.cc in Sources */,

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -10,6 +10,8 @@
 #include "Poco/Logger.h"
 #include "Poco/Thread.h"
 
+extern bool isScreenRecordingPermissionAvailable(void);
+
 namespace toggl {
 
 Poco::Logger &WindowChangeRecorder::logger() {
@@ -58,6 +60,11 @@ void WindowChangeRecorder::inspectFocusedWindow() {
 #if !defined(_WIN32) && !defined(WIN32)
         return;
 #endif
+    }
+
+    // Check if we need ScreenRecording permssion in order to the Window's title
+    if (isScreenRecordingPermissionAvailable()) {
+        return;
     }
 
     time_t now;

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -103,6 +103,13 @@ void WindowChangeRecorder::inspectFocusedWindow() {
         return;
     }
 
+    // Lite version of timeline recorder
+    // Since we don't have Screen Recording permission yet => title will be empty
+    // So we only track the primary timeline (treat title is filename)
+    if (is_catalina_OSX && last_title_ == title && last_filename_ == filename) {
+        return;
+    }
+
     // We actually record the *previous* event. Meaning, when
     // you have "terminal" open and then switch to "skype",
     // then "terminal" gets recorded here:

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -10,7 +10,7 @@
 #include "Poco/Logger.h"
 #include "Poco/Thread.h"
 
-extern bool isScreenRecordingPermissionAvailable(void);
+extern bool isCatalinaOSX(void);
 
 namespace toggl {
 
@@ -63,7 +63,7 @@ void WindowChangeRecorder::inspectFocusedWindow() {
     }
 
     // Check if we need ScreenRecording permission in order to receive the Window's title
-    if (isScreenRecordingPermissionAvailable()) {
+    if (is_catalina_OSX) {
 
         // It's lite version of Timeline recording
         // 10.15+ and title is empty

--- a/src/window_change_recorder.cc
+++ b/src/window_change_recorder.cc
@@ -62,9 +62,15 @@ void WindowChangeRecorder::inspectFocusedWindow() {
 #endif
     }
 
-    // Check if we need ScreenRecording permssion in order to the Window's title
+    // Check if we need ScreenRecording permission in order to receive the Window's title
     if (isScreenRecordingPermissionAvailable()) {
-        return;
+
+        // It's lite version of Timeline recording
+        // 10.15+ and title is empty
+        // Just set it as a filename
+        if (title.empty()) {
+            title = std::string(filename);
+        }
     }
 
     time_t now;

--- a/src/window_change_recorder.h
+++ b/src/window_change_recorder.h
@@ -11,6 +11,8 @@
 
 #include "Poco/Activity.h"
 
+extern bool isCatalinaOSX(void);
+
 namespace Poco {
 class Logger;
 }
@@ -30,7 +32,9 @@ class TOGGL_INTERNAL_EXPORT WindowChangeRecorder {
     , shutdown_(false)
     , isLocked_(false)
     , isSleeping_(false)
+    , is_catalina_OSX(false)
     , timeline_errors_() {
+        is_catalina_OSX = isCatalinaOSX();
         recording_.start();
     }
 
@@ -54,6 +58,7 @@ class TOGGL_INTERNAL_EXPORT WindowChangeRecorder {
     void recordLoop();
 
  private:
+    bool is_catalina_OSX;
     void inspectFocusedWindow();
 
     bool hasWindowChanged(


### PR DESCRIPTION
### 📒 Description
As we agreed that we would implement the Lite version of Timeline in macOS 10.15 until we officially supported the Screen Recording permission.

This PR introduces the Lite version:
- OS 10.15+ -> Get Window title and no things more
- <= OS 10.14 -> Work as usual.

### 🕶️ Types of changes
**Breaking change** (fix or feature that would cause existing functionality to change)
- Please make sure the OS <= 10.14 will work as usual.

### 🤯 List of changes
- [x] Logic to detect OS version on library
- [x] If it's 10.15+, set `title` as `filename`

### 👫 Relationships
Closes #3427
Closes #3422

### 🔎 Review hints
#### Check on OS 10.15 Catalina
- Start the staging app and turn on Timeline Recording
- Play around the app for 15 mins.
- Check the Staging local database (/Users/<username>/Library/Application Support/Kopsik/development/kopsik.db) to make sure the title is same as the filename
<img width="1129" alt="Screen Shot 2019-10-22 at 13 52 44" src="https://user-images.githubusercontent.com/5878421/67268598-0e851d80-f4df-11e9-9d5f-cddd346361c7.png">
- Open Timeline in Web, make sure it presents correctly
<img width="217" alt="Screen Shot 2019-10-22 at 14 32 39" src="https://user-images.githubusercontent.com/5878421/67268618-1a70df80-f4df-11e9-9c66-f50812e79f90.png">

#### Check on OS 10.14
- Start the staging app and turn on Timeline Recording
- Play around the app for 15 mins.
- Check the Staging local database (/Users/<username>/Library/Application Support/Kopsik/development/kopsik.db) to make sure the app is able to record the WIndow title
![Screen Shot 2019-10-22 at 2 54 31 PM](https://user-images.githubusercontent.com/5878421/67268644-2f4d7300-f4df-11e9-85d9-13113186ab59.png)
- Open Timeline Web, and see if it is as usual
