### PR TITLE
Don't Update Duration, Start and End Text Field if it's editing

### DIFF
--- a/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
+++ b/src/ui/osx/TogglDesktop/Feature/TimeEntryEditor/EditorViewController.swift
@@ -358,11 +358,17 @@ extension EditorViewController {
     }
 
     private func renderTime() {
-        durationTextField.stringValue = timeEntry.duration
-        startAtTextField.stringValue = timeEntry.startTimeString
-        endAtTextField.stringValue = timeEntry.endTimeString
-        startAtTextField.toolTip = dateFormatter.string(from: timeEntry.started)
-        endAtTextField.toolTip = dateFormatter.string(from: timeEntry.ended)
+        if durationTextField.currentEditor() == nil {
+            durationTextField.stringValue = timeEntry.duration
+        }
+        if startAtTextField.currentEditor() == nil {
+            startAtTextField.stringValue = timeEntry.startTimeString
+            startAtTextField.toolTip = dateFormatter.string(from: timeEntry.started)
+        }
+        if endAtTextField.currentEditor() == nil {
+            endAtTextField.stringValue = timeEntry.endTimeString
+            endAtTextField.toolTip = dateFormatter.string(from: timeEntry.ended)
+        }
     }
 
     fileprivate func updateNextKeyViews() {


### PR DESCRIPTION
### 📒 Description
The library will notify the UI Update when the sync is done, which cause update the current editing text in Duration, Start and End Text Fields.

This PR will prevent this the UI update action. 

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue)

### 🤯 List of changes
- [x] Don't update value of Duration, Start and End Text Fields if they're editing

### 👫 Relationships
Close #3440 
Close #3457

### 🔎 Review hints
1. Open Editor for any TE
2. Quick editor some content and tab to focus on next field then quickly typing something. For instance, change the Duration and tap to Start Text Field and change the value.
3. If the current editing Text Field doesn't update -> 💯 

