### PR TITLE
Incorrect Timer State when stopping by Pomodoro 

### DIFF
--- a/src/ui/osx/TogglDesktop/TimerEditViewController.m
+++ b/src/ui/osx/TogglDesktop/TimerEditViewController.m
@@ -258,8 +258,8 @@ NSString *kInactiveTimerColor = @"#999999";
 	}
 	else
 	{
-		self.descriptionLabel.editable = YES;
 		[self showDefaultTimer];
+		self.descriptionLabel.editable = YES;
 	}
 
 	// Display project name


### PR DESCRIPTION
### 📒 Description
This PR fixes the issues when the Timer State is updated improperly when the TE is stopped by Pomodoro.

### 🕶️ Types of changes
**Bug fix** (non-breaking change which fixes an issue) 

### 🤯 List of changes
- [x] Switch back to Input mode properly.
 
### 👫 Relationships
Close #3432 
Close #3468

### 🔎 Review hints
1. Set Pomodoro is 1 min
2. Start any TE with full detail 
3. Wait when it stops (after 1 min)
4. The Timer switches back to Input mode (No pre-populate TE) -> 💯 
