### PR TITLE
Auto-release new pushes with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,8 @@ jobs:
         bash ./dist/linux/package.sh compose
     - name: Upload to GitHub
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="toggldesktop_x86_64.tar.gz" renameto="toggldesktop_linux_${TAG_NAME/v/}_x86_64.tar.gz"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="toggldesktop_x86_64.tar.gz" renameto="toggldesktop_linux_${TAG_NAME/v/}_x86_64.tar.gz"
 
   linux-ubuntu1804:
     runs-on: ubuntu-18.04
@@ -74,7 +72,7 @@ jobs:
         sudo apt install devscripts cmake debhelper pkg-config qtbase5-dev qtwebengine5-dev libqt5x11extras5-dev qtbase5-private-dev libssl-dev libxss-dev libxmu-dev
     - name: Build a Debian package
       run: |
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
+        TAG_NAME=$(./dist/get-tag-name.sh)
         cd dist/linux
         ln -s ../../src .
         ln -s ../../CMakeLists.txt .
@@ -84,10 +82,8 @@ jobs:
     - name: Upload to GitHub
       if: github.event_name == 'create'
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="dist/toggldesktop_${TAG_NAME/v/}_amd64.deb"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/toggldesktop_${TAG_NAME/v/}_amd64.deb"
 
   linux-flatpak-kde:
     runs-on: ubuntu-18.04
@@ -115,10 +111,8 @@ jobs:
     - name: Upload to GitHub
       if: github.event_name == 'create'
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="com.toggl.TogglDesktop.flatpak" renameto="com.toggl.TogglDesktop-${TAG_NAME/v/}.flatpak"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="com.toggl.TogglDesktop.flatpak" renameto="com.toggl.TogglDesktop-${TAG_NAME/v/}.flatpak"
 
   windows-32bit:
     runs-on: windows-2019
@@ -138,9 +132,7 @@ jobs:
     - name: Set version
       shell: bash
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
+        TAG_NAME=$(./dist/get-tag-name.sh)
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
     - name: Build on Windows x86
@@ -164,10 +156,8 @@ jobs:
     - name: Upload to GitHub
       if: github.event_name == 'create'
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}.exe"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}.exe"
       shell: bash
 
   windows-64bit:
@@ -188,9 +178,7 @@ jobs:
     - name: Set version
       shell: bash
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
+        TAG_NAME=$(./dist/get-tag-name.sh)
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
     - name: Build on Windows x64
@@ -214,10 +202,8 @@ jobs:
     - name: Upload to GitHub
       if: github.event_name == 'create'
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller-x64.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}-x64.exe"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller-x64.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}-x64.exe"
       shell: bash
 
   windows-store:
@@ -240,9 +226,7 @@ jobs:
     - name: Set version
       shell: bash
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
+        TAG_NAME=$(./dist/get-tag-name.sh)
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
     - name: Build on Windows for Microsoft Store
@@ -253,8 +237,6 @@ jobs:
     - name: Upload to GitHub
       if: github.event_name == 'create'
       run: |
-        EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-        if [[ "$EVENT_TYPE" != "tag" ]]; then exit 0; fi
-        TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} owner=toggl repo=toggldesktop tag="$TAG_NAME" filename="TogglDesktop.Package_${TAG_NAME/v/}.0_x86_x64_bundle_StoreRelease.appxupload"
+        TAG_NAME=$(./dist/get-tag-name.sh)
+        ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="TogglDesktop.Package_${TAG_NAME/v/}.0_x86_x64_bundle_StoreRelease.appxupload"
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Build on Windows x86
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=Release /p:Platform="x86" /t:Clean,Build /restore /m
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x86" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.sln
     - name: Sign binaries
       if: github.event_name == 'release'
       run: |
@@ -146,6 +146,7 @@ jobs:
         makensis TogglDesktopInstaller-x86.nsi
     - name: Sign the installer
       if: github.event_name == 'release'
+      shell: cmd
       run: |
         "C:\Program Files (x86)\Windows Kits\10\Tools\bin\i386\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx dist\windows\TogglDesktopInstaller.exe
     - name: Upload to GitHub
@@ -179,7 +180,7 @@ jobs:
     - name: Build on Windows x64
       shell: cmd
       run: |
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=Release /p:Platform="x64" /t:Clean,Build /restore /m
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=Release /p:Platform="x64" /t:Clean,Build /restore /m src\ui\windows\TogglDesktop\TogglDesktop.sln
     - name: Sign binaries
       if: github.event_name == 'release'
       run: |
@@ -192,6 +193,7 @@ jobs:
         makensis TogglDesktopInstaller-x64.nsi
     - name: Sign the installer
       if: github.event_name == 'release'
+      shell: cmd
       run: |
         "C:\Program Files (x86)\Windows Kits\10\Tools\bin\i386\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload to GitHub
@@ -225,9 +227,10 @@ jobs:
         echo "Setting version to ${TAG_NAME/v/}"
         bash dist/windows/scripts/set_version.sh "${TAG_NAME/v/}"
     - name: Build on Windows for Microsoft Store
+      shell: cmd
       run: |
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=StoreRelease /p:Platform="x86" /p:AppxPackageSigningEnabled=false /t:Clean,Build /restore -m
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=StoreRelease /p:Platform="x64" /p:UapAppxPackageBuildMode=CI /p:AppxBundle=Always /p:AppxBundlePlatforms="x86|x64" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="322D8592D0FDB01F1C8FCA56ED3FBFAF646D3739" /p:AppxPackageDir="..\\..\\..\\..\\..\\" /t:Clean,Build /restore -m
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=StoreRelease /p:Platform="x86" /p:AppxPackageSigningEnabled=false /t:Clean,Build /restore -m src\ui\windows\TogglDesktop\TogglDesktop.sln
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /p:Configuration=StoreRelease /p:Platform="x64" /p:UapAppxPackageBuildMode=CI /p:AppxBundle=Always /p:AppxBundlePlatforms="x86|x64" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="322D8592D0FDB01F1C8FCA56ED3FBFAF646D3739" /p:AppxPackageDir="..\\..\\..\\..\\..\\" /t:Clean,Build /restore -m src\ui\windows\TogglDesktop\TogglDesktop.sln
         dir
     - name: Upload to GitHub
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,16 +4,13 @@ on:
   push:
     branches:
       - '**'
-  create:
-    branches:
-      - 'master'
-    tags:
-      - '**'
+  release:
+    types: [ created ]
 
 jobs:
   linux-basic:
     runs-on: ubuntu-latest
-    if: github.event_name != 'create'
+    if: github.event_name != 'release'
     steps:
     - uses: actions/checkout@v1
       with:
@@ -29,7 +26,7 @@ jobs:
 
   linux-tarball:
     runs-on: ubuntu-16.04
-    if: github.event_name == 'create'
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v1
       with:
@@ -58,7 +55,7 @@ jobs:
 
   linux-ubuntu1804:
     runs-on: ubuntu-18.04
-    if: github.event_name == 'create'
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v1
       with:
@@ -80,14 +77,13 @@ jobs:
         dch -b -D unstable --package "toggldesktop" -v ${TAG_NAME/v/} "General bug fixes and improvements" -u low -M
         debuild
     - name: Upload to GitHub
-      if: github.event_name == 'create'
       run: |
         TAG_NAME=$(./dist/get-tag-name.sh)
         ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/toggldesktop_${TAG_NAME/v/}_amd64.deb"
 
   linux-flatpak-kde:
     runs-on: ubuntu-18.04
-    if: github.event_name == 'create'
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v1
       with:
@@ -109,7 +105,6 @@ jobs:
         mv com.toggl.TogglDesktop.flatpak ../../..
         popd
     - name: Upload to GitHub
-      if: github.event_name == 'create'
       run: |
         TAG_NAME=$(./dist/get-tag-name.sh)
         ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="com.toggl.TogglDesktop.flatpak" renameto="com.toggl.TogglDesktop-${TAG_NAME/v/}.flatpak"
@@ -140,21 +135,21 @@ jobs:
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=Release /p:Platform="x86" /t:Clean,Build /restore /m
     - name: Sign binaries
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         ./dist/windows/scripts/sign.sh
       shell: bash
     - name: Create x86 installer
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         cd dist/windows
         makensis TogglDesktopInstaller-x86.nsi
     - name: Sign the installer
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         "C:\Program Files (x86)\Windows Kits\10\Tools\bin\i386\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx dist\windows\TogglDesktopInstaller.exe
     - name: Upload to GitHub
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         TAG_NAME=$(./dist/get-tag-name.sh)
         ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}.exe"
@@ -186,21 +181,21 @@ jobs:
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=Release /p:Platform="x64" /t:Clean,Build /restore /m
     - name: Sign binaries
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         ./dist/windows/scripts/sign.sh
       shell: bash
     - name: Make x64 installer
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         cd dist/windows
         makensis TogglDesktopInstaller-x64.nsi
     - name: Sign the installer
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         "C:\Program Files (x86)\Windows Kits\10\Tools\bin\i386\signtool.exe" sign -a -t http://timestamp.verisign.com/scripts/timestamp.dll -f Certificate.pfx dist\windows\TogglDesktopInstaller-x64.exe
     - name: Upload to GitHub
-      if: github.event_name == 'create'
+      if: github.event_name == 'release'
       run: |
         TAG_NAME=$(./dist/get-tag-name.sh)
         ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="dist/windows/TogglDesktopInstaller-x64.exe" renameto="TogglDesktopInstaller-${TAG_NAME/v/}-x64.exe"
@@ -208,7 +203,7 @@ jobs:
 
   windows-store:
     runs-on: windows-2019
-    if: github.event_name == 'create'
+    if: github.event_name == 'release'
     steps:
     - uses: actions/checkout@v1
       with:
@@ -235,7 +230,6 @@ jobs:
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe" src/ui/windows/TogglDesktop/TogglDesktop.sln /p:Configuration=StoreRelease /p:Platform="x64" /p:UapAppxPackageBuildMode=CI /p:AppxBundle=Always /p:AppxBundlePlatforms="x86|x64" /p:AppxPackageSigningEnabled=true /p:PackageCertificateThumbprint="322D8592D0FDB01F1C8FCA56ED3FBFAF646D3739" /p:AppxPackageDir="..\\..\\..\\..\\..\\" /t:Clean,Build /restore -m
         dir
     - name: Upload to GitHub
-      if: github.event_name == 'create'
       run: |
         TAG_NAME=$(./dist/get-tag-name.sh)
         ./dist/upload-github-release-asset.sh github_api_token=${{ secrets.GITHUB_TOKEN }} tag="$TAG_NAME" filename="TogglDesktop.Package_${TAG_NAME/v/}.0_x86_x64_bundle_StoreRelease.appxupload"

--- a/.github/workflows/pr_tagger.yml
+++ b/.github/workflows/pr_tagger.yml
@@ -1,0 +1,15 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true

--- a/.github/workflows/pr_tagger.yml
+++ b/.github/workflows/pr_tagger.yml
@@ -4,12 +4,10 @@ on:
     branches:
       - master
 jobs:
-  build:
+  bump:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
+      run: |
+        ./dist/tag-and-release.sh github_api_token=${{ secrets.TAGGING_SECRET }} PATCH=1

--- a/dist/get-tag-name.sh
+++ b/dist/get-tag-name.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-set -e
+PROBABLY_TAG=${GITHUB_REF/refs\/tags\//}
 
-echo ${GITHUB_REF/refs\/tags\//}
+grep "^v[0-9][0-9]*[.][0-9][0-9]*[.][0-9][0-9]*$" <<< "$PROBABLY_TAG"
+
+exit 0

--- a/dist/get-tag-name.sh
+++ b/dist/get-tag-name.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
+if [[ "$EVENT_TYPE" != "tag" ]]; then exit 1; fi
+TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
+
+echo $TAG_NAME

--- a/dist/get-tag-name.sh
+++ b/dist/get-tag-name.sh
@@ -2,8 +2,4 @@
 
 set -e
 
-EVENT_TYPE=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref_type")
-if [[ "$EVENT_TYPE" != "tag" ]]; then exit 1; fi
-TAG_NAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".ref")
-
-echo $TAG_NAME
+echo ${GITHUB_REF/refs\/tags\//}

--- a/dist/tag-and-release.sh
+++ b/dist/tag-and-release.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+CONFIG=$@
+
+MINOR=0
+MAJOR=0
+PATCH=0
+
+for line in $CONFIG; do
+  eval "$line"
+done
+
+# cloning takes a while, it'd be better to check if the commit has not been tagged in the meantime
+git fetch --tags --force
+
+# first get the commit hash of HEAD
+CURRENT_COMMIT=$(git rev-parse --verify HEAD)
+
+# then try looking if HEAD is tagged already or not
+NEW_TAG=$(git tag --points-at $CURRENT_COMMIT)
+
+# if it is not tagged, create a new tag, while adding the values of MINOR, MAJOR and PATCH
+if [[ "$NEW_TAG" == "" ]]; then
+    CURRENT_TAG=$(git tag -l 'v7.*.*' --sort=-v:refname | head -n1)
+    CURRENT_MAJOR=$(cut -d. -f1 <<< ${CURRENT_TAG/v/})
+    CURRENT_MINOR=$(cut -d. -f2 <<< ${CURRENT_TAG/v/})
+    CURRENT_PATCH=$(cut -d. -f3 <<< ${CURRENT_TAG/v/})
+
+    NEW_TAG="v$(($CURRENT_MAJOR+$MAJOR)).$(($CURRENT_MINOR+$MINOR)).$(($CURRENT_PATCH+$PATCH))"
+fi
+
+# Define variables.
+OWNER=${GITHUB_REPOSITORY/\/*/}
+REPO=${GITHUB_REPOSITORY/*\//}
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$OWNER/$REPO"
+GH_RELEASES="$GH_REPO/releases"
+GH_TAGS="$GH_REPO/git/tags/"
+GH_TAG="$GH_RELEASES/tags/$NEW_TAG"
+AUTH="Authorization: token $github_api_token"
+WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+CURL_ARGS="-LJO#"
+
+if [[ "$tag" == 'LATEST' ]]; then
+  GH_TAG="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# and push the tag, that will make it discoverable later
+curl -d '{ "tag": "'$NEW_TAG'", "message": "'$NEW_TAG'",  "object": "'$CURRENT_COMMIT'", "type": "commit" }' -H "Content-Type: application/json" -X POST -o /dev/null -sH "$AUTH" $GH_RELEASES
+
+# Create a release out of the tag (shouldn't fail if it's already released)
+curl -d '{ "tag_name": "'$NEW_TAG'", "target_commitish": "'$CURRENT_COMMIT'", "name": "'$NEW_TAG'", "body": "'$NEW_TAG'", "draft": false, "prerelease": true }' -H "Content-Type: application/json" -X POST -o /dev/null -sH "$AUTH" $GH_RELEASES
+
+# Read asset tags.
+response=$(curl -sH "$AUTH" $GH_TAG)
+
+# Get ID of the asset based on given filename.
+eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+[ "$id" ] || { echo "Error: Failed to get release id for tag: $NEW_TAG"; echo "$response" | awk 'length($0)<100' >&2; exit 1; }
+

--- a/dist/upload-github-release-asset.sh
+++ b/dist/upload-github-release-asset.sh
@@ -22,7 +22,7 @@
 
 # Check dependencies.
 set -e
-xargs=$(which gxargs || which xargs)
+set -x
 
 # Validate settings.
 [ "$TRACE" ] && set -x

--- a/dist/upload-github-release-asset.sh
+++ b/dist/upload-github-release-asset.sh
@@ -7,17 +7,17 @@
 #
 # This script accepts the following parameters:
 #
-# * owner
-# * repo
 # * tag
 # * filename
 # * github_api_token
 #
 # Script to upload a release asset using the GitHub API v3.
 #
+# Expects $GITHUB_REPOSITORY in the environment (set by GitHub Actions)
+#
 # Example:
 #
-# upload-github-release-asset.sh github_api_token=TOKEN owner=stefanbuck repo=playground tag=v0.1.0 filename=./build.zip
+# upload-github-release-asset.sh github_api_token=TOKEN tag=v0.1.0 filename=./build.zip
 #
 
 # Check dependencies.
@@ -34,8 +34,10 @@ for line in $CONFIG; do
 done
 
 # Define variables.
+OWNER=${GITHUB_REPOSITORY/\/*/}
+REPO=${GITHUB_REPOSITORY/*\//}
 GH_API="https://api.github.com"
-GH_REPO="$GH_API/repos/$owner/$repo"
+GH_REPO="$GH_API/repos/$OWNER/$REPO"
 GH_RELEASES="$GH_REPO/releases"
 GH_TAGS="$GH_RELEASES/tags/$tag"
 AUTH="Authorization: token $github_api_token"
@@ -67,7 +69,7 @@ eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:al
 echo "Uploading asset... "
 
 # Construct url
-GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
+GH_ASSET="https://uploads.github.com/repos/$OWNER/$REPO/releases/$id/assets?name=$(basename $filename)"
 
 curl "$GITHUB_OAUTH_BASIC" --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET
 

--- a/dist/windows/scripts/set_version.sh
+++ b/dist/windows/scripts/set_version.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+set -e
+set -x
+
 VERSION="$1"
+
+if [[ "$VERSION" == "" ]]; then
+    exit 0
+fi
 
 sed -i.bak "s/7\.0\.0\.0/$VERSION\.0/g" src/ui/windows/TogglDesktop/TogglDesktop/Properties/AssemblyInfo.cs
 sed -i.bak "s/7\.0\.0\.0/$VERSION\.0/g" src/ui/windows/TogglDesktop/TogglDesktop.Package/Package.appxmanifest


### PR DESCRIPTION
### 📒 Description
This modifies our GitHub Actions workflow so it doesn't run when a new branch gets created. It also automatically tags and releases everything resulting from a `push` event on the `master` branch (that means all commit batches - not individual commits and PRs).

*IMPORTANT* @IndrekV, For this to work, we need to add the `TAGGING_SECRET` variable to the Secrets section in the repo settings. It should be a GitHub API token with the rights to modify the repository. I can provide mine, but I think it'll be safer if we use yours. You can generate one in the Settings of your own GitHub profile.

### 🕶️ Types of changes
- **New feature** (non-breaking change which adds functionality)

### 🔎 Review hints
You can see the results from this in my fork.

