### PR TITLE
Fixed the download links to point to releases in new repo

### DIFF
--- a/download/linux-beta.html
+++ b/download/linux-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.358/toggldesktop_linux_x86_64-7_4_358.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux-beta/
 ---

--- a/download/linux-dev.html
+++ b/download/linux-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.410/toggldesktop_linux_x86_64-7_4_410.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux-dev/
 ---

--- a/download/linux-stable.html
+++ b/download/linux-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.122/toggldesktop_linux_x86_64-7_4_122.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux-stable/
 ---

--- a/download/linux_deb64-beta.html
+++ b/download/linux_deb64-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_deb64/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_7.4.528_amd64.deb
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_deb64-beta/
 ---

--- a/download/linux_deb64-dev.html
+++ b/download/linux_deb64-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_deb64/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_7.4.528_amd64.deb
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_deb64-dev/
 ---

--- a/download/linux_deb64-stable.html
+++ b/download/linux_deb64-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_deb64/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_7.4.528_amd64.deb
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_deb64-stable/
 ---

--- a/download/linux_flatpak-beta.html
+++ b/download/linux_flatpak-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_flatpak/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.476/com.toggl.TogglDesktop_linux_x86_64-7_4_476.flatpak
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_flatpak-beta/
 ---

--- a/download/linux_flatpak-dev.html
+++ b/download/linux_flatpak-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_flatpak/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.504/com.toggl.TogglDesktop_linux_x86_64-7_4_504.flatpak
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_flatpak-dev/
 ---

--- a/download/linux_tar.gz-beta.html
+++ b/download/linux_tar.gz-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_tar.gz/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_linux_x86_64-7_4_528.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_tar.gz-beta
 ---

--- a/download/linux_tar.gz-dev.html
+++ b/download/linux_tar.gz-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_tar.gz/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_linux_x86_64-7_4_528.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_tar.gz-dev/
 ---

--- a/download/linux_tar.gz-stable.html
+++ b/download/linux_tar.gz-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/linux_tar.gz/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.528/toggldesktop_linux_x86_64-7_4_528.tar.gz
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/linux_tar.gz-stable/
 ---

--- a/download/mac-beta.html
+++ b/download/mac-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/mac/beta/
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.444/TogglDesktop-7_4_444.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/mac-beta/
 ---

--- a/download/mac-dev.html
+++ b/download/mac-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/mac/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.455/TogglDesktop-7_4_455.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/mac-dev/
 ---

--- a/download/mac-stable.html
+++ b/download/mac-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/mac/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.373/TogglDesktop-7_4_373.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/mac-stable/
 ---

--- a/download/macos-beta.html
+++ b/download/macos-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/macos/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1041/TogglDesktop-7_4_1041.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/macos-beta/
 ---

--- a/download/macos-dev.html
+++ b/download/macos-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/macos/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1041/TogglDesktop-7_4_1041.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/macos-dev/
 ---

--- a/download/macos-stable.html
+++ b/download/macos-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/macos/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1036/TogglDesktop-7_4_1036.dmg
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/macos-stable/
 ---

--- a/download/windows-beta.html
+++ b/download/windows-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows/beta/
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows-beta/
 ---

--- a/download/windows-dev.html
+++ b/download/windows-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows-dev/
 ---

--- a/download/windows-stable.html
+++ b/download/windows-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows-stable/
 ---

--- a/download/windows64-beta.html
+++ b/download/windows64-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows64/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-x64-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows64-beta/
 ---

--- a/download/windows64-dev.html
+++ b/download/windows64-dev.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows64/dev
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-x64-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows64-dev/
 ---

--- a/download/windows64-stable.html
+++ b/download/windows64-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows64/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.1023/TogglDesktopInstaller-x64-7.4.1023.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows64-stable/
 ---

--- a/download/windows_enterprise-beta.html
+++ b/download/windows_enterprise-beta.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows_enterprise/beta
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.422/TogglDesktopEnterpriseInstaller-7.4.422.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows_enterprise-beta/
 ---

--- a/download/windows_enterprise-stable.html
+++ b/download/windows_enterprise-stable.html
@@ -1,5 +1,5 @@
 ---
 redirect_from: 
   - /download/windows_enterprise/stable
-redirect_to: https://github.com/toggl-open-source/toggldesktop/releases/download/v7.4.422/TogglDesktopEnterpriseInstaller-7.4.422.exe
+redirect_to: https://toggl-open-source.github.io/toggldesktop/download/windows_enterprise-stable/
 ---

--- a/installers/index.html
+++ b/installers/index.html
@@ -27,8 +27,8 @@
   </table>
 
   <div class="links">
-    <a href="https://toggl.github.io/toggldesktop/assets/releases/releases.json">releases.json</a>
-    <a href="https://toggl.github.io/toggldesktop/assets/releases/updates.json">updates.json</a>
+    <a href="https://toggl-open-source.github.io/toggldesktop/assets/releases/releases.json">releases.json</a>
+    <a href="https://toggl-open-source.github.io/toggldesktop/assets/releases/updates.json">updates.json</a>
   </div>
   <script src="installers.js"></script>
 </body>


### PR DESCRIPTION
### 📒 Description
Should fix the issue with download links. They always point to the same links in the new repo.


