### PR TITLE
Generate page content with javascript

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,3 +1,375 @@
----
-layout: style
----
+@import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
+
+body {
+  padding:50px;
+  font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color:#777;
+  font-weight:300;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color:#222;
+  margin:0 0 20px;
+}
+
+p, ul, ol, table, pre, dl {
+  margin:0 0 20px;
+}
+
+h1, h2, h3 {
+  line-height:1.1;
+}
+
+h1 {
+  font-size:28px;
+}
+
+h2 {
+  color:#393939;
+}
+
+h3, h4, h5, h6 {
+  color:#494949;
+}
+
+a {
+  color:#39c;
+  font-weight:400;
+  text-decoration:none;
+}
+
+a small {
+  font-size:11px;
+  color:#777;
+  margin-top:-0.6em;
+  display:block;
+}
+
+.wrapper {
+  width:860px;
+  margin:0 auto;
+}
+
+blockquote {
+  border-left:1px solid #e5e5e5;
+  margin:0;
+  padding:0 0 0 20px;
+  font-style:italic;
+}
+
+code, pre {
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  color:#333;
+  font-size:12px;
+}
+
+pre {
+  padding:8px 15px;
+  background: #f8f8f8;
+  border-radius:5px;
+  border:1px solid #e5e5e5;
+  overflow-x: auto;
+}
+
+table {
+  width:100%;
+  border-collapse:collapse;
+}
+
+th, td {
+  text-align:left;
+  padding:5px 10px;
+  border-bottom:1px solid #e5e5e5;
+}
+
+dt {
+  color:#444;
+  font-weight:700;
+}
+
+th {
+  color:#444;
+}
+
+img {
+  max-width:100%;
+}
+
+header {
+  width:500px;
+  margin: 0 auto;
+}
+
+header ul {
+  list-style:none;
+  height:40px;
+
+  padding:0;
+
+  background: #eee;
+  background: -moz-linear-gradient(top, #f8f8f8 0%, #dddddd 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f8f8f8), color-stop(100%,#dddddd));
+  background: -webkit-linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
+  background: -o-linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
+  background: -ms-linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
+  background: linear-gradient(top, #f8f8f8 0%,#dddddd 100%);
+
+  border-radius:5px;
+  border:1px solid #d2d2d2;
+  box-shadow:inset #fff 0 1px 0, inset rgba(0,0,0,0.03) 0 -1px 0;
+  width:270px;
+}
+
+header li {
+  width:89px;
+  float:left;
+  border-right:1px solid #d2d2d2;
+  height:40px;
+}
+
+header ul a {
+  line-height:1;
+  font-size:11px;
+  color:#999;
+  display:block;
+  text-align:center;
+  padding-top:6px;
+  height:40px;
+}
+
+strong {
+  color:#222;
+  font-weight:700;
+}
+
+header ul li + li {
+  width:88px;
+  border-left:1px solid #fff;
+}
+
+header ul li + li + li {
+  border-right:none;
+  width:89px;
+}
+
+header ul a strong {
+  font-size:14px;
+  display:block;
+  color:#222;
+}
+
+section {
+  width:500px;
+  margin: 0 auto;
+  padding-bottom:50px;
+}
+
+small {
+  font-size:11px;
+}
+
+hr {
+  border:0;
+  background:#e5e5e5;
+  height:1px;
+  margin:0 0 20px;
+}
+
+footer {
+  width:500px;
+  bottom:50px;
+  margin: 0 auto;
+}
+
+@media print, screen and (max-width: 960px) {
+
+  div.wrapper {
+    width:auto;
+    margin:0;
+  }
+
+  header, section, footer {
+    float:none;
+    position:static;
+    width:auto;
+  }
+
+  header {
+    padding-right:320px;
+  }
+
+  section {
+    border:1px solid #e5e5e5;
+    border-width:1px 0;
+    padding:20px 0;
+    margin:0 0 20px;
+  }
+
+  header a small {
+    display:inline;
+  }
+
+  header ul {
+    position:absolute;
+    right:50px;
+    top:52px;
+  }
+}
+
+@media print, screen and (max-width: 720px) {
+  body {
+    word-wrap:break-word;
+  }
+
+  header {
+    padding:0;
+  }
+
+  header ul, header p.view {
+    position:static;
+  }
+
+  pre, code {
+    word-wrap:normal;
+  }
+}
+
+@media print, screen and (max-width: 480px) {
+  body {
+    padding:15px;
+  }
+
+  header ul {
+    display:none;
+  }
+}
+
+@media print {
+  body {
+    padding:0.4in;
+    font-size:12pt;
+    color:#444;
+  }
+}
+
+
+/* toggldesktop page styles */
+
+h1 {
+  text-align: center;
+  font-size: 38px;
+}
+
+h3 {
+  border-bottom: 1px solid #e0e0e0;
+  line-height: 35px;
+  font-size: 20px;
+}
+
+.platform-links li {
+  list-style: none;
+  display: inline;
+  border-left: 1px solid #e5e5e5;
+  padding: 0 10px;
+  font-size: 18px;
+}
+
+.platform-links li:first-child {
+  border: none;
+}
+
+.platform-links li a {
+  text-align: center;
+  padding: 5px 10px;
+}
+
+.table {
+  display: table;
+  margin: 0 auto;
+}
+
+.table ul {
+  margin-top: 20px;
+}
+
+.os {
+  display: none;
+  min-height: 200px;
+  max-width: 500px;
+}
+
+.active {
+  display: block!important;
+}
+
+.current,
+.platform-links li a:hover {
+  background-color: #39c;
+  color: white;
+  border-radius: 5px;
+}
+
+.date {
+  float: right;
+  font: 14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #777;
+  font-weight: 300;
+  line-height: 35px;
+}
+
+.pages ul li {
+  font-size: 16px;
+}
+
+.beta {
+  font-size: 12px;
+  font-weight: normal;
+  color: #fff;
+  background-color: #6ECC33;
+  border-radius: 5px;
+  padding: 3px 5px;
+  margin-left: 13px;
+  line-height: 35px;
+  height: 35px;
+  vertical-align: middle;
+}
+
+.beta::after {
+  content: "beta";
+}
+
+.screenshots {
+  display: none;
+  margin-bottom: 20px;
+  margin-left: 22px;
+}
+
+.screenshots p {
+  margin-bottom: 5px;
+  font-style: italic;
+}
+
+.screenshots img {
+  max-width: 350px;
+}
+
+.active .screenshots {
+  display: block;
+}
+
+.download-link {
+  font-size: 12px;
+  height: 24px;
+  line-height: 24px;
+  vertical-align: middle;
+  padding: 5px;
+}
+
+.download-link:hover {
+  text-decoration: underline;
+}
+
+.anchor {
+  color: #000;
+  font-weight: 500;
+}

--- a/data/linux.json
+++ b/data/linux.json
@@ -1,0 +1,418 @@
+{
+  "versions": [
+    {
+        "version": "7.4.528",
+        "rows": [
+            "Setting decimal hour values works right again.",
+            "Idle notification behavior is more consistent."
+        ],
+        "date": "August 22nd 2019",
+        "beta": "false"
+    },
+    {
+        "version": "7.4.510",
+        "rows": [
+          "Version string is now properly displayed in the About section of the app.",
+          "Application now longer crashes on exit."
+        ],
+        "date": "August 12th 2019",
+        "beta": "true"
+    },
+    {
+        "version": "7.4.476",
+        "rows": [
+          "You can control TogglDesktop using your keyboard entirely. If in doubt, use Ctrl+Enter to open a Time entry or Ctrl+Delete to delete it.",
+          "Systemwide font, style and color palette settings are now used - the application should fit your environment a lot better.",
+          "Idle and tracking reminder notifications now use system notifications instead of popup windows.",
+          "Deleting a running time entry will prompt the user to confirm if it's running for more than 15 seconds.",
+          "Idle time calculation now takes locked screen into account.",
+          "Creating a client will automatically select and assign it to the project being created.",
+          "Adding tags is now possible.",
+          "When creating a new project, it gets created in the right workspace (the one of the time entry being edited).",
+          "Automatic crash reports now contain better backtraces.",
+          "Pressing Shift+Tab in the time entry editor now behaves as expected.",
+          "The continue button in the time entry list now needs to be clicked only once every time.",
+          "Creating a tab that already exists will select it in the list.",
+          "Timer widget now displays the current task right even when the window is resized.",
+          "The app now detects network state changes to represent the online/offline states appropriately."
+        ],
+        "date": "July 25th 2019",
+        "beta": "true"
+    },
+    {
+        "version": "7.4.358",
+        "rows": [
+          "Added confirmless delete for all items shorter than 15 seconds",
+          "Added handling for 'no workspace' scenario",
+          "Added overlay view logic and font fixes",
+          "Added tooltip for tags icon in timer",
+          "Added ToS Accept view",
+          "Added error messages and filesize restriction to feedback form",
+          "Added new custom autocomplete with grouping and colors",
+          "Added tabs to Preferences view",
+          "Added tracking reminder settings to Preferences",
+          "Added support for system native notifications",
+          "Added window size and position saving",
+          "Added setting 'Stop timer on shutdown'",
+          "Added a button to delete the selected project from timer",
+          "Trim leading and trailing whitespace in Description of TimeEntry",
+          "Instant sync after time entry stop",
+          "Updated signup form to comply with GDPR",
+          "Updated build framework to Qt 5.12.0",
+          "Improved idle detection with screen lock/unlock",
+          "Improved login view logic and field validation",
+          "Improved app shutdown speed",
+          "Improved the speed of data sorting",
+          "Improved duplicate project name check",
+          "Improved showing/hiding logic for different views",
+          "Improved log file sending logic",
+          "Improved syncing logic by moving all sync to background for non-freezing UI",
+          "Fixes for different data handling issue that caused crashes",
+          "Fixed multilevel tray icon menu issue",
+          "Fixed pomodoro mode stopping entry with incorrect duration",
+          "Fixed time entry editor tab order",
+          "Fixed issue with reminder being show right after coming from Idle mode",
+          "Fixed project create issues with certain scenarios",
+          "Fixed issues with 'missing GUID'"
+        ],
+        "date": "February 21st 2019",
+        "beta": "true"
+    },
+    {
+        "version": "7.4.122",
+        "rows": [
+          "Fixed wrong error message issue when backend is down",
+          "Fixed invalid 'project name exists' error",
+          "Close reminder popup when user starts tracking",
+          "Improved popup window titles for more clarity",
+          "Fixed long project name issue in timer",
+          "Fixed login after signup",
+          "Fixed login crash issues"
+        ],
+        "date": "March 5th 2018"
+    },
+    {
+        "version": "7.4.71",
+        "rows": [
+            "Fixed workspace assignment with Pomodoro Break entry",
+            "Fixed app freezing issue on logout",
+            "Fixed 'data not valid' issue",
+            "Added DBUS_SESSION_BUS_ADDRESS param to improve tray icon support",
+            "Tray icon support for Budgie Desktop"
+        ],
+        "date": "November 2nd 2017"
+    },
+    {
+        "version": "7.4.58",
+        "rows": [
+            "Improved autcomplete to do contains matching",
+            "Fixed issue with app freezing on quit"
+        ],
+        "date": "September 12th 2017"
+    },
+    {
+        "version": "7.4.52",
+        "rows": [
+            "Fixes for syncing issues that caused user inputs to be overwritten"
+        ],
+        "date": "June 21st 2017"
+    },
+    {
+      "version": "7.4.47",
+      "rows": [
+          "Fixed syncing issues that caused user inputs to be discarded",
+          "Fixed issue with not being able to remove all tags from entry"
+      ],
+      "date": "June 14th 2017"
+    },
+   {
+      "version": "7.4.38",
+      "rows": [
+          "Updated syncing logic to use api v9 in background",
+          "Added dbus-launch support for LXDE"
+      ],
+      "date": "May 12th 2017"
+    },
+    {
+      "version": "7.4.31",
+      "date": "April 27th 2017",
+      "rows": [
+        "Avoid showing tracking reminder if entry is stopped elsewhere",
+        "Fixed autocomplete not copying tags and billable"
+      ]
+    },
+    {
+      "version": "7.4.24",
+      "date": "March 3rd 2017",
+      "rows": [
+        "Use user profile time format in group total time",
+        "Clear old/synced timeline data on app start",
+        "Open/Close app window when left clicking on tray icon",
+        "Fixed support link to direct to linux article",
+        "Fixed entries syncing issue when clients or projects fail to sync",
+        "Account running timer to todays total time",
+        "Added '-b, --background' command line argument to start the app minimized to tray",
+        "Added support for workspace setting 'Project Billable by Default'",
+        "Fixed tray icon issue in Xubuntu and i3"
+      ]
+    },
+    {
+      "version": "7.4.7",
+      "date": "December 21st 2016",
+      "rows": [
+        "Fixed project color select issue",
+        "Added Load more button",
+        "Added unsynced icon for entries in the list",
+        "Fixed project creation time entry save",
+        "Added grouped entries mode",
+        "Set input backgrounds to always be white",
+        "Added text overflow ellipsis to description and project texts",
+        "Tray icon fix for Elementary OS",
+        "Tray icon script fixes"
+      ],
+      "screenshots": [
+        {
+          "text": "Grouping similar time entries",
+          "img": "assets/images/linux_7.3.353_grouped_entries.gif"
+        }
+      ]
+    },
+    {
+      "version": "7.3.346",
+      "date": "October 27th 2016",
+      "rows": [
+        "Added Pomodoro Break functionality",
+        "Increased local data kept to 30 days",
+        "Load more gets last 60 days of data",
+        "Added fast delete for entries without data",
+        "Added duration only mode support to Pomodoro timer",
+        "Fixed issue with entries being removed from list on app start",
+        "Fixed default project task overwriting issue",
+        "Updated About view design",
+        "Fixed font color issue with darker themes",
+        "Fixed font issues with HiDPI screens",
+        "Added support for new colors",
+        "Added color select to Add project form",
+        "Fixed tray icon issues in Cinnamon and XFCE",
+        "Fixed background color issues in dark themes",
+        "Updated project color select with new color selection"
+      ],
+      "screenshots": [
+        {
+          "text": "Project color selection popup in 'Add project' form",
+          "img": "assets/images/linux_7.3.345_project_color_select_linux.gif"
+        }
+      ]
+    },
+    {
+      "version": "7.3.326",
+      "date": "September 8th 2016",
+      "rows": [
+        "Added 'Discard and continue' button to idle popup",
+        "Added Pomodoro Timer",
+        "Added Global shortcuts for show/hide and continue/stop",
+        "Fixes for icon docking issues",
+        "Added support for using symbolic link for Toggl Desktop start"
+      ]
+    },
+    {
+      "version": "7.3.247",
+      "date": "January 21st 2016",
+      "rows": [
+        "Added time entry description to idle notification",
+        "Disabled workspace items in projects dropdown",
+        "Show start time when hovering running duration",
+        "Update startup script to run app in background",
+        "Fixed removing project from time entry",
+        "Fixed app closing when closing any window without main window opened"
+      ]
+    },
+    {
+      "version": "7.3.119",
+      "date": "November 3rd 2015",
+      "rows": [
+        "App should now be started with ./TogglDesktop.sh",
+        "Hide app when tray icon is present",
+        "Added tray icon to menu bar",
+        "Upgraded Qt version to 5.5",
+        "Added Tags and Billable icon to timer",
+        "Added logged in user to menubar menu",
+        "Fixed app close popup behaviour",
+        "Added 'Focus on shortcut' to preferences",
+        "Added 'show' item into tray menu"
+      ]
+    },
+    {
+      "version": "7.2.64",
+      "date": "April 27th 2015",
+      "rows": [
+        "Improved separation of Deb package and tar.gz",
+        "Added tooltip to error message",
+        "Fixes for About dialog",
+        "Workspace dropdown is not visible if user has only one workspace, fixes #1256",
+        "Down show workspace name in project dropdown when there are no projects",
+        "Better signup error text",
+        "Show start/end time in duration tooltip"
+      ]
+    },
+    {
+      "version": "7.1.264",
+      "date": "April 10th 2015",
+      "rows": [
+        "Fixed tag ToolTip colors"
+      ]
+    },
+    {
+      "version": "7.1.260",
+      "date": "March 31st 2015",
+      "rows": [
+        "Don't show start/end tooltip if there are no start/end times",
+        "Added Start Stop time tooltip to duration label",
+        "Show '(no description)' placeholder when description is empty",
+        "Added tooltips to timer",
+        "Fixed tooltip showing and colors",
+        "Fixed timer project name positioning",
+        "Fixed timer project name alignment",
+        "Fixed tab order in edit view",
+        "Fixed gray line under error message",
+        "Fixes for login view elements and positioning",
+        "Fixed checkbox alignment",
+        "Fixed start stop time field size with big font",
+        "Fixed edit form for Hi DPI"
+      ]
+    },
+    {
+      "version": "7.1.253",
+      "date": "March 31st 2015",
+      "rows": [
+        "Fixed timer duration cutoff",
+        "Fixed entry cell duration cutoff in Hi DPI",
+        "Fixed entry cell background color in HiDPI",
+        "Fixed entry cell description in Hi DPI",
+        "Fixed timer duration cutoff with high DPI",
+        "Fixed record timeline left margin in preferences",
+        "Fixed window resizing after entry edit",
+        "Fixed timer project text wordwrap",
+        "Fixed resizing issues for listing elements",
+        "Fixed entry cell hidden duration issue",
+        "Resources file typo fix",
+        "Linux non-silent in app updates",
+        "Enable non-silent updater callbacks for linux app",
+        "Enable update check without download",
+        "Online state",
+        "Use Roboto font",
+        "Fix update callback",
+        "Update callback",
+        "Disable self updater in linux app",
+        "Set app font to Helvetica 10",
+        "Add description to linux app idle notification",
+        "Run uitests from linux, too",
+        "Parse command line params",
+        "Enable uitests on linux too",
+        "Fixed lib loading"
+      ]
+    },
+    {
+      "version": "7.1.198",
+      "date": "February 4th 2015",
+      "rows": [
+        "Added missing libraries"
+      ]
+    },
+    {
+      "version": "7.1.192",
+      "date": "February 1st 2015",
+      "rows": [
+        "New JSON library",
+        "Handle umlauts in timeline uploader",
+        "Fixed Websocket updates",
+        "Time calculations use local timezone",
+        "Fix missing project colors",
+        "Format time duration according to user settings",
+        "Use user configured idle minutes setting",
+        "Cleanup on shutdown",
+        "App icons as resources, with scaling",
+        "Fixed memory leaks",
+        "Include OpenSSL libraries",
+        "Embed Lua for UI scripting",
+        "Duration change did not always propagate",
+        "Exceptions are tracked using Bugsnag",
+        "Use a less common character as tag separator",
+        "UTF8 aware sorting in autocompletes",
+        "Continue most recently stopped time entry",
+        "User can add clients",
+        "Use 2 places for decimal rounding",
+        "Fix login dialog layout",
+        "Confirm quit",
+        "Fix error dialog",
+        "Allow narrower window",
+        "Group autocomplete items by workspace",
+        "Append '1' to client name when its already taken",
+        "Dont crash when asking data with 0 ID",
+        "Check error uniqueness after massaging it",
+        "Forward user to support upon receiving 410",
+        "Open editor after starting a new time entry",
+        "Dont delay initial sync",
+        "Use sleep/wake for idle detection too",
+        "Randomize retry intervals",
+        "Auto update total duration",
+        "Remove time overview label and separate detail view",
+        "Added Signup",
+        "Only show TE history in TE autocomplete",
+        "Show workspace name under tags",
+        "Use user configured reminder minutes setting",
+        "Fixed dropdown size",
+        "POCO libraries version 1.6",
+        "Moved timeline shutdown after ui rendering in Logout",
+        "Show split time entry after idle dialog",
+        "OpenSSL 1.0.2",
+        "Improved project autocomplete item format",
+        "Prefer same date when editing end time",
+        "Disallow starting very short time entries from UI",
+        "Dont attempt to push model until its validation error is cleared",
+        "Track autocomplete usage via Google Analytics",
+        "toggl_desktop.log as log file name",
+        "Dont display non-active tasks",
+        "Handle server 5xx errors with retries"
+      ]
+    },
+    {
+      "version": "7.1.115",
+      "date": "October 22nd 2014",
+      "rows": [
+        "Include running time entry in daily total",
+        "Fixed Autocomplete dropdown",
+        "Support czech AM/PM symbols",
+        "Always change stop time when duration changes",
+        "'Certificate validation error' is a network error",
+        "Use UTC to calculate date when using last date",
+        "Stop timeline uploader faster",
+        "Stop websocket client faster",
+        "Dont use observers for timeline",
+        "Fix race conditions",
+        "OpenSSL 1.0.1j",
+        "Start tracking on return",
+        "Build shared, not static OpenSSL library on Linux",
+        "Fix crash on Fedora when starting Google login"
+      ]
+    },
+    {
+      "version": "7.1.73",
+      "date": "September 24th 2014",
+      "rows": [
+        "Remove min size constraint",
+        "Remove error widget from tab order",
+        "Hide error window if login succeeds",
+        "Linux app shortcuts",
+        "Parse '1h 25min' as '01:25:00', not '01:00:00'"
+      ]
+    },
+    {
+      "version": "7.1.71",
+      "date": "September 18th 2014",
+      "rows": [
+        "Initial release"
+      ]
+    }
+  ]
+}

--- a/data/mac.json
+++ b/data/mac.json
@@ -1,0 +1,591 @@
+{
+    "versions": [
+        {
+            "version": "7.4.1061",
+            "rows": [
+                "Support Screen Recording Permission on Catalina for Recording and Auto-Tracker",
+                "Improve how the Timer layout work",
+                "Update 10 unique TE in Touch Bar",
+                "Fixed The edit popup closing right after open when clicking on project label",
+                "Fixed Show selected task name in edit view project input",
+                "Fixex The AutoComplete appears unexpectedly when editing the TimeEntry",
+                "Fixed UI constrains issues when the list is empty"
+            ],
+            "date": "December 3rd 2019",
+            "beta": "true"
+        },
+        {
+            "version": "7.4.1041",
+            "rows": [
+                "Introduce new Toggl Touch Bar",
+                "Remove tags while editing TE with keyboard",
+                "Fixed New entry - description and project is not blank, but same as last entry",
+                "Fixed Long Description text cuts off the idle notification",
+                "Fixed Jump issues on duration, start and end text fields"
+            ],
+            "date": "December 2nd 2019"
+        },
+        {
+            "version": "7.4.1036",
+            "rows": [
+                "Highlight all tag text field after selection",
+                "Fixed Timeline Recording in Catalina: For Catalina users, Timeline is only capable of recording the app name, not Windows's title.",
+                "Fixed Continuing the time entry at the top starts the timer without description/project",
+                "Fixed Jump issues on duration, start time and end time text field during editing",
+                "Fixed Can't select a project from autocomplete popup",
+                "Fixed Cannot Create Tags Issue"
+            ],
+            "date": "November 1st 2019"
+        },
+        {
+            "version": "7.4.1023",
+            "rows": [
+                "Hotfix: revert bug with duplicating entries introduced in the previous hotfix"
+            ],
+            "date": "October 2nd 2019"
+        },
+        {
+            "version": "7.4.1022",
+            "rows": [
+                "New Google Authentication from default browsers",
+                "Improve the Start button on TimeEntry: Bigger and easier to tap",
+                "Attempt to resolve the SQL Constraint issues",
+                "Show precise time on tooltip of duration, start, stop time textbox",
+                "Remove CrashReporter",
+                "Fixed Tags popup on macOS doesn't go away after creating a new tag",
+                "Fixed the sync issues when it makes a lot of request to the Toggl Server"
+            ],
+            "date": "October 1st 2019"
+        },
+        {
+            "version": "7.4.1012",
+            "rows": [
+                "Notarization for TogglDesktop build",
+                "Start/continue/stop menu items to dock menu",
+                "Sign-up with Google",
+                "Add remove icon to project row in timer",
+                "Click to edit project/duration of the running entry",
+                "Fixed Cashed for large number of tags",
+                "Fixed Unsync state when the app launches",
+                "Fixed Clicking on New from the menu bar will stop the timer but not start the new one",
+                "New project color should be random",
+                "Minor UI improvement on new design",
+                "Bring Keep idle time button back",
+                "Fixed App crash if there are enormous tags",
+                "Fixed Invalid color space when reverting the project color",
+                "Fixed Respect notification center settings and Do not disturb when triggering notifications",
+                "Fixed Time entries list missing in Macos Desktop",
+                "Fixed Public projects created by Admins are being created as private projects",
+                "Fixed Editing time entries using Autocomplete doesn't contain Tags ",
+                "Fixed Running Time Entry clears if you've added a tag",
+                "Fixed Esc key does not work when focused on Add tags field",
+                "Fixed Beep sound when selecting the AutoComplete Item by hitting Enter",
+                "Fixed Choosing Edit From Menubar Does Not Focus App",
+                "Fixed Create Client/Project buttons hidden under long lists of clients/projects",
+                "Fixed Project name clears from time entry",
+                "Fixed Very hard to see dark project colours when using dark mode",
+                "Fixed Focus jumps when editing a running entry",
+                "Fixed Tabbing for Mac app, keyboard preference",
+                "Fixed Track usage of Edit view resize handle"
+            ],
+            "date": "September 24th 2019"
+        },
+        {
+            "version": "7.4.484",
+            "rows": [
+                "Fixed library rerefencing issues",
+                "Fixed window resizing issues",
+                "Fixed grouping detect with same tags in different order",
+                "Totally new clean design",
+                "Added new project and client add flow",
+                "Added new tags autocomplete solution",
+                "Added keyboard support to selecting date from calendar",
+                "Added support for notfications sound settings",
+                "Fixed Tooltip 0h 0m issue with single running entry for today",
+                "Fixed date header format for single digit numbers",
+                "Fixed tags popup editing logic",
+                "Fixed idle notification timer stop logic",
+                "Fixed description field clearing issue",
+                "Fixed grouping issues with new accounts"
+            ],
+            "date": "July 30th 2019"
+        },
+        {
+            "version": "7.4.373",
+            "rows": [
+                "Added 'Stop timer on shutdown' functionality",
+                "Added Dark mode support",
+                "Added Undo logic for time entry edit view",
+                "Improved user data handling to avoid crashes",
+                "Improved time entry list reloading speed",
+                "New design for Login screen",
+                "New design for Feedback screen",
+                "New design for Preferences screen",
+                "New design for About screen",
+                "New design for App Icon",
+                "Fixed issue with timer not starting in some cases",
+                "Fixed issues with global shortcut keys not being saved",
+                "Fixed issue with tracking reminder triggering when editing reminder settings",
+                "Fixed focus jumping issue"
+            ],
+            "date": "April 17th 2019"
+        },
+        {
+            "version": "7.4.330",
+            "rows": [
+                "Remove all old notifications when new one is triggered",
+                "Replaced deprecated convert function",
+                "Trim leading and trailing whitespace in Description of TimeEntry",
+                "Updated build conf form libstdc++ to libc++",
+                "Improved idle detection with screen lock/unlock",
+                "Fixed window dragging issue when 'on top' setting is enabled",
+                "Fixed issues with edit view reload not loading new data",
+                "Fixed syncing issues tha appeared after changing network or going offline",
+                "Fixed background color issues in autocomplete with dark theme",
+                "Added functionality for edit window arrow pointing to correct entry",
+                "Fixed data overwrite issue in timer",
+                "Fixed entry list automatic scrolling issue",
+                "Fixed entry list item highlight item after item position change"
+            ],
+            "date": "January 2nd 2019"
+        },
+        {
+            "version": "7.4.321",
+            "rows": [
+                "Fixed issue with invalid edit view opening",
+                "Fixed timer description clear on stop issue",
+                "Fixed client name grouping issue in autocomplete",
+                "Show notification on older macOS (< 10.11) about dropping support",
+                "Fixed cursor color issue in login view",
+                "More analytics for window size tracking"
+            ],
+            "date": "December 11th 2018"
+        },
+        {
+            "version": "7.4.299",
+            "rows": [
+                "Improved log file sending logic",
+                "Fixed random entry list scrolling issues",
+                "Added handling for 'no wokrspace' scenario",
+                "Overlay view logic and font fixes",
+                "Fixed selected text issue with not focused fields in edit view",
+                "Fixed frozen project field issue in edit view",
+                "Fixed signup country select validation",
+                "Improved field focusing logic in edit popup",
+                "Improved timer description focus logic on first load",
+                "Improved client id setting when creating new project",
+                "All syncing is done in background",
+                "Style fixes for Dark Mode"
+            ],
+            "date": "November 8th 2018",
+            "beta": "true"
+        },
+        {
+            "version": "7.4.253",
+            "rows": [
+                "Fixed autocomplete item select issues",
+                "Fixed 'no project' filtering issues",
+                "Fixed issues with categories shown multiple times in autocomplete",
+                "Fixed issue with autocomplete not showing all tasks",
+                "Fixed date header light text color issue in MacOs 10.14",
+                "Fixes for autocomplete item text formats"
+            ],
+            "date": "August 28th 2018"
+        },
+        {
+            "version": "7.4.232",
+            "rows": [
+                "Added 'no project' item to autocomplete",
+                "Added autocomplete open button to project autocomplete",
+                "Fixed new autocomplete for older MacOs versions",
+                "Fixed country select in signup form",
+                "Fixed autocomplete wrong item highlight issues",
+                "Fixed autocomplete mouse selecting issues",
+                "Group projects by workspace and client in autocomplete",
+                "Group tasks by project in autocomplete",
+                "Smaller ui updates and tweaks for new autocompelete",
+                "Style fixes for MacOs 10.14",
+                "Confirmless delete for all items shorter than 15 seconds",
+                "Fixed closing windows with Cmd+W",
+                "Improved login view field validation",
+                "Added ToS Accept view",
+                "Fixed issue with window restore hiding app when 'on top' setting is enabled",
+                "Fixed project create issues with certain scenarios",
+                "Fix for missing GUID issues",
+                "Added today total time to menubar icon tooltip",
+                "Fixed autocomplete in autotracker project selection"
+            ],
+            "date": "August 13rd 2018"
+        },
+        {
+            "version": "7.4.170",
+            "rows": [
+                "Added new custom Autocomplete with colors",
+                "Updated signup form to comply with GDPR",
+                "Group projects by clients in autocomplete",
+                "Improved keyboard actions inside autocomplete list",
+                "Fixed issue with billable not being set when selecting task item from autocomplete",
+                "Minor fixes for faster data handling",
+                "Improved autocomplete item text format",
+                "Added error messages and file size restriction to feedback form",
+                "Fixed issue with text paste overwriting inserted text",
+                "Fixed issue with reminder being show right after coming from Idle mode",
+                "Do actions in the background for a faster UI"
+            ],
+            "date": "June 5th 2018"
+        },
+        {
+            "version": "7.4.129",
+            "rows": [
+                "Fixed wrong error message issue when backend is down",
+                "Faster non-blocking autocomplete",
+                "Fixed layout issues in edit view",
+                "Fixed invalid 'project name exists' error",
+                "Fixed edit view tabbing issues",
+                "Added autocomplete to client select",
+                "Improved workspace select",
+                "Automatically solve easier errors that occur with data sync",
+                "Instant sync after entry stop",
+                "Faster app shutdown",
+                "Show entry description in list item delete popup",
+                "Fixed issues with notification button actions",
+                "Fixed pomodoro mode stopping entry with correct duration",
+                "Improved duplicate project name check",
+                "Fixed selected cell update after deleting entry from the list",
+                "Changed edit popup to not be transparent",
+                "Fixed login right after signup",
+                "Fixed login crash issues",
+                "Minor layout tweaks"
+            ],
+            "date": "February 22nd 2018"
+        },
+        {
+            "version": "7.4.84",
+            "rows": [
+                "Improved tags autocomplete to do matching search",
+                "SPACE key always continues selected entry",
+                "Small design tweaks",
+                "Fixed workspace assignment with Pomodoro Break entry",
+                "Fixed app freezing issue on logout",
+                "Fixed 'data not valid' issue"
+            ],
+            "date": "January 4th 2018"
+        },
+        {
+            "version": "7.4.58",
+            "rows": [
+                "Fixed list scrolling issue when continuing items",
+                "Upgraded autocomplete filtering to work with multi phrase search",
+                "Fixed issue with app freezing on quit",
+                "Fixed issue with multiple tracking reminder popups visible at once"
+            ],
+            "date": "September 12th 2017"
+        },
+        {
+            "version": "7.4.52",
+            "rows": [
+                "Fixes for syncing issues that caused user inputs to be overwritten"
+            ],
+            "date": "June 21st 2017"
+        },
+        {
+            "version": "7.4.47",
+            "rows": [
+                "Fixed syncing issues that caused user inputs to be discarded",
+                "Fixed issue with not being able to remove all tags from entry"
+            ],
+            "date": "June 14th 2017"
+        },
+        {
+            "version": "7.4.38",
+            "rows": [
+                "Updated syncing logic to use api v9 in background"
+            ],
+            "date": "June 6th 2017"
+        },
+        {
+            "version": "7.4.31",
+            "rows": [
+                "Added support for multiuser mode",
+                "Fixed autocomplete also setting billable flag",
+                "Avoid showing tracking reminder if entry is stopped elsewhere",
+                "Fixed issues with changing project in edit view"
+            ],
+            "date": "April 27th 2017"
+        },
+        {
+            "version": "7.4.18",
+            "rows": [
+                "Use user profile time format in group total time",
+                "Clear old/synced timeline data on app start",
+                "Fixed entries syncing issue when clients or projects fail to sync",
+                "Account running timer to todays total time",
+                "Paste starts timer only when in main window",
+                "Fixed autocomplete selection to also set tags",
+                "Fixed group open/close list scrolling issues"
+            ],
+            "date": "March 3rd 2017"
+        },
+        {
+            "version": "7.4.7",
+            "rows": [
+                "Fixed project creation issue at time entry save",
+                "Fixed ui glitch with graphite Appearance",
+                "Trigger full sync on app start",
+                "Added time entry grouping",
+                "Added keyboard support for time entry grouping LEFT/RIGHT to toggle group",
+                "Show unsynced icon if entry fails to sync because of restrictions",
+                "Added support for new project color logic",
+                "New color selection to project color select"
+            ],
+            "screenshots": [
+                {
+                    "text": "Grouping similar time entries",
+                    "img": "assets/images/osx_7.4.6_grouped.gif"
+                }
+            ],
+            "date": "December 21st 2016"
+        },
+        {
+            "version": "7.3.337",
+            "rows": [
+                "Added Pomodoro Break functionality",
+                "Increased local data kept to 30 days",
+                "Load more gets last 60 days of data",
+                "Added fast delete for entries without data",
+                "Added duration only mode support to Pomodoro timer",
+                "Fixed issue with entries being removed from list on app start"
+            ],
+            "date": "October 26th 2016"
+        },
+        {
+            "version": "7.3.326",
+            "rows": [
+                "Fixed issue with pomodoro stopping timer on app start",
+                "Added old data cleanup to keep app light and fast",
+                "Fixed empty description issue when selecting task from autocomplete",
+                "Fixed project overwriting issue when selecting item from autocomplete"
+            ],
+            "date": "September 8th 2016"
+        },
+        {
+            "version": "7.3.319",
+            "date": "May 16th 2016",
+            "rows": [
+                "Fixed creating same project under new client error",
+                "Fixed pomodoro stop on app start issue",
+                "Fixed Pomodoro notfication triggering when editing older entries",
+                "Fixed duration saving issue when pressing TAB"
+            ]
+        },
+        {
+            "version": "7.3.309",
+            "date": "March 10th 2016",
+            "rows": [
+                "Fixed bug with duplicate project and client creation",
+                "Fixed app crash issue when selecting no project",
+                "Fixed timeline empty event collection issue",
+                "Added Pomodoro Timer",
+                "Improved auto tracker and tracking reminder notifications to be consistent and reliable",
+                "Added time entries drag and drop between days",
+                "Added load-more button, loading the last month of time entries into the list",
+                "Fixed duration cut off in time entry list",
+                "Fixed menubar text cut off issue"
+            ],
+            "screenshots": [
+                {
+                    "text": "Pomodoro timer notfication shown when timer runs out",
+                    "img": "assets/images/osx_7.3.308_pomodoro.png"
+                },
+                {
+                    "text": "Change time entry date by drag and dropping them to another day",
+                    "img": "assets/images/osx_7.3.303_drag.gif"
+                },
+                {
+                    "text": "Load up to 1 month of past time entries for better overview",
+                    "img": "assets/images/osx_7.3.303_more.gif"
+                }
+            ]
+        },
+        {
+            "version": "7.3.254",
+            "date": "February 2nd 2016",
+            "rows": [
+                "Fixed menubar 'project name' setting changing issue",
+                "Added unsynced flag to Time Entries",
+                "Added Color selection to 'Add project form'",
+                "Remove all older installers when update is found",
+                "Fixed the frozen menubar issue after app start"
+            ],
+            "screenshots": [
+                {
+                    "text": "Not synced icon in the time entries list view",
+                    "img": "assets/images/osx_7.3.254_not_synced_icon.png"
+                },
+                {
+                    "text": "Color selection popup in the add project form",
+                    "img": "assets/images/osx_7.3.254_color_selection.png"
+                }
+            ]
+        },
+        {
+            "version": "7.3.197",
+            "date": "December 10th 2015",
+            "rows": [
+                "Write less data to log file",
+                "Fixed pasting also starting timer when in edit view",
+                "Fixed autotracker loading issues",
+                "Fixed `Abort due to constraint violation` error appearing when using multiple accounts"
+            ]
+        },
+        {
+            "version": "7.3.177",
+            "date": "November 25th 2015",
+            "rows": [
+                "Allow sending feedback when not logged in",
+                "Improved duplicate project names check",
+                "Added Change log link to menu",
+                "Added Default project setting",
+                "Show app when user selects 'Add idle time as new entry'",
+                "Fixed timer duration font size in El Capitan",
+                "Show restart button in About view when download is finished",
+                "Changed the Autoupdater name to TogglDesktopAutoUpdater",
+                "Fixed tab order in edit popup",
+                "Pasting text starts new time entry"
+            ]
+        },
+        {
+            "version": "7.2.302",
+            "date": "September 24th 2015",
+            "rows": [
+                "Use system default setting for idle notification sound",
+                "Use system default setting for Auto tracker notification sound",
+                "Added close button to Auto tracker notification",
+                "Assign tags when autocompleting from timer",
+                "Better grouping of settings checkboxes",
+                "Turned proxy selection into radio group",
+                "Uploaded poco to version 1.6.1"
+            ]
+        },
+        {
+            "version": "7.2.199",
+            "date": "July 17th 2015",
+            "rows": [
+                "Fixed timeline events issue",
+                "User setting for cmd+n also opening edit view",
+                "Added analytics",
+                "Added 'Discard idle time and continue' option to idle notification popup",
+                "Added logged in user email to menubar icon menu",
+                "Added Tags and Billable icon to timer",
+                "Added Beta promotion notification",
+                "Fixes for syncing issues"
+            ]
+        },
+        {
+            "version": "7.2.150",
+            "date": "June 19th 2015",
+            "rows": [
+                "Added Auto tracker",
+                "'Remind me to track' additional settings",
+                "Tabbed preferences view",
+                "Don't close edit popup when selecting autocomplete with enter"
+            ]
+        },
+        {
+            "version": "7.2.70",
+            "date": "May 22nd 2015",
+            "rows": [
+                "Better implementation of ENTER closing edit popup",
+                "Syncing improvements",
+                "Added automatic system proxy detection",
+                "Added start/end time tooltip to time entries",
+                "More clear error messages",
+                "New preferences window design with tabs",
+                "Added first version of Autotracker",
+                "More detailed Reminder preferences"
+            ]
+        },
+        {
+            "version": "7.1.224",
+            "date": "March 11th 2015",
+            "rows": [
+                "New design for Login and About view",
+                "Improved syncing",
+                "More informative error messages",
+                "Possibility to show project name in menubar"
+            ]
+        },
+        {
+            "version": "7.1.218",
+            "date": "March 5th 2015",
+            "rows": [
+                "Clearer error messages",
+                "Bottom network status bar is hidden when online",
+                "New design for Login view",
+                "New design for About view",
+                "Enter saves and closes edit view",
+                "Other bug fixes"
+            ]
+        },
+        {
+            "version": "7.1.203",
+            "date": "February 13th 2015",
+            "rows": [
+                "Remove 'time entry too short' message",
+                "Don't crash on invalid data from Toggl backend",
+                "Clear input fields on logout",
+                "Handle 'Too many requests' from Toggl backend",
+                "Increase HTTP timeout to 15 seconds (was 10)",
+                "Improved offline handling",
+                "Timeline could not be enabled (or disabled)",
+                "Handle 'Only admins can change project visibility' error from Toggl backend",
+                "Enable offline login"
+            ]
+        },
+        {
+            "version": "7.1.188",
+            "date": "February 4th 2015",
+            "rows": [
+                "Don't display non-active tasks",
+                "Handle server 5xx errors with retries",
+                "Better offline handling"
+            ]
+        },
+        {
+            "version": "7.1.179",
+            "date": "January 21st 2015",
+            "rows": [
+                "Fixed show menubar timer preference",
+                "Added manual mode and timer mode logic. More info <a href='http://blog.toggl.com/2015/01/toggl-desktop-7-past-present-and-future'/>here</a>",
+                "Fixed project items in autocomplete",
+                "Timer redesign"
+            ]
+        },
+        {
+            "version": "7.1.161",
+            "date": "December 19th 2014",
+            "rows": [
+                "Fixed start button size for Yosemite",
+                "Smoother, faster focusing animation",
+                "Added back possibility to TAB into duration field in Timer",
+                "Added 'focus on shortcut' preference",
+                "Added signup functionality",
+                "Added automatic update",
+                "Fixed resize handle when popup is on left",
+                "Added Keyboard shortcuts to move in listing. Read more: <a href='http://support.toggl.com/toggl-desktop-for-mac-osx/#shortcuts'>Keyboard shortcuts</a>",
+                "Minor UI tweaks",
+                "Added workspace name to edit view"
+            ]
+        },
+        {
+            "version": "7.1.139",
+            "date": "November 27th 2014",
+            "rows": [
+                "Added possibility to add new clients",
+                "Fixed Toggl logo in About view",
+                "Minor UI tweaks",
+                "Added changelog displaying on updates"
+            ]
+        }
+    ]
+}

--- a/data/win.json
+++ b/data/win.json
@@ -1,0 +1,719 @@
+{
+    "versions": [
+        {
+            "version": "7.4.1023",
+            "rows": [
+                "Hotfix: revert bug with duplicating entries introduced in the previous hotfix"
+            ],
+            "date": "October 2nd 2019",
+            "has64bit": "true"
+        },
+        {
+            "version": "7.4.1022",
+            "rows": [
+                "Show precise time on tooltip of duration, start, stop time textbox",
+                "Stop running entry on computer sleep/shutdown doesn't work on shutdown",
+                "Attempt to resolve the SQL Constraint issues",
+                "Fixed the sync issues when it makes a lot of request to the Toggl Server"
+            ],
+            "date": "October 1st 2019",
+            "has64bit": "true"
+        },
+        {
+            "version": "7.4.1015",
+            "rows": [
+                "Added Signup with Google",
+                "Fixed issue with app window being stuck in the tray after PC restart",
+                "Fixed system proxy detection to make it work with proxies of apps like Fiddler, Freedom, etc.",
+                "Fixed various crashes when opening browser links or logging in with Google",
+                "Fixed issue when similar time entries on different workspaces were grouped together",
+                "Fixed occasional crash when displaying notification",
+                "Made 'Show/Hide Toggl' bring the window to the front if it has no focus",
+                "Tiny UI improvements to Login/Signup page",
+                "Fixed crashes when having huge amount of tags"
+            ],
+            "date": "September 26th 2019",
+            "has64bit": "true"
+        },
+        {
+            "version": "7.4.529",
+            "rows": [
+                "Fixed crash when locking PC while being logged out",
+                "Added handling of errors during auto-update",
+                "Fixed crashes during startup",
+                "Fixed crashes after modal windows were being closed with Alt+F4",
+                "Fixed issues when switching between different screen setups",
+                "Fixed issues with grouping similar time entries",
+                "Added a few shortcuts (Quit, Preferences, Delete, Expand/Collapse)"
+            ],
+            "date": "August 27th 2019",
+            "has64bit": "true"
+        },
+        {
+            "version": "7.4.475",
+            "rows": [
+                "Created a 64-bit version",
+                "Made project name displayed before client name",
+                "Added possibility to create private projects",
+                "Fixed issue with time entry being stopped when computer gets locked",
+                "Made timeline stop tracking processes when computer is locked",
+                "Added standard behavior for selecting word with double click and whole field with triple click",
+                "Added command-line option to start minimized",
+                "Added checkbox to start the app minimized on Windows login",
+                "Fixed date selection issue when using custom date display format",
+                "Made all notifications hide the moment user starts the timer with a shortcut",
+                "Added Ctrl+F4 shortcut to minimize the app",
+                "Fixed issues with unsynced projects",
+                "Signed the uninstaller"
+            ],
+            "date": "August 6th 2019",
+            "has64bit": "true"
+        },
+        {
+            "version": "7.4.422",
+            "rows": [
+                "Fixed issue with confirmless deletion of a running time entry",
+                "Fixed crash when pressing up/down on autocomplete",
+                "Fixed cursor placement issue when clicking on text fields",
+                "Fixed issue with cursor changing text field while an entry is syncing",
+                "Fixed issue with Ctrl+Z changing text/time entry field to values unrelated to current time entry",
+                "Added more visual feedback when enabling/disabling 'Autotracker' and 'Reminder to track time' in Preferences",
+                "Fixed issue with incorrect autocomplete list in some cases",
+                "Fixed crash when pressing left arrow key when no fields are focused",
+                "Fixed issue with date field being automatically set to the day before the selected date",
+                "Disabled calendar when the timer is running",
+                "Fixed crash after idle notification was closed with Alt+F4",
+                "Improved signup error messages"
+            ],
+            "date": "June 6th 2019"
+        },
+        {
+            "version": "7.4.345",
+            "rows": [
+                "Send more log info with in-app feedback",
+                "Do all syncing in background for non-freezing UI",
+                "Added proper 'No workspaces' scenario overlay",
+                "Added 'Total today' text to tray icon tooltip",
+                "Add project, client and task label into tray icon tooltip",
+                "Improved client id setting when creating new project",
+                "Improved Idle detection when Locking/Unlocking session",
+                "Fixed issue with tracking reminder triggering when editing reminder settings",
+                "Improved user data handling to avoid crashes",
+                "Added 'Stop timer on shutdown' functionality",
+                "Updated Google login framework"
+            ],
+            "date": "February 22nd 2019"
+        },
+        {
+            "version": "7.4.252",
+            "rows": [
+                "Fixed 'no project' filtering issues",
+                "Fixed issues with categories shown multiple times in autocomplete",
+                "Improved project and client name display in autotomcplete time entry items"
+            ],
+            "date": "August 30th 2018"
+        },
+        {
+            "version": "7.4.231",
+            "rows": [
+                "Added 'no project' item to autocomplete",
+                "Fixed country select in signup form",
+                "Fixed autocomplete mouse selecting issues",
+                "Group projects by workspace and client in autocomplete",
+                "Group tasks by project in autocomplete",
+                "Smaller ui updates and tweaks for new autocompelete",
+                "Confirmless delete for all items shorter than 15 seconds",
+                "Fixed transparent empty window issue",
+                "Improved login error display",
+                "Fixed handling future start time for entries"
+            ],
+            "date": "August 9th 2018"
+        },
+        {
+            "version": "7.4.197",
+            "rows": [
+                "Added ToS Accept view",
+                "Fixed crash with pressing down on autocomplete",
+                "Fixed project and client create issues with certain scenarios",
+                "Fix for missing GUID issues",
+                "Fixed updating billable flag when selecting billable project",
+                "Fixed tag selection issues",
+                "Fixed autocomplete dropdown small width issue",
+                "Added 'no project' item to autocomplete"
+            ],
+            "date": "July 5th 2018",
+            "beta": "true"
+        },
+        {
+            "version": "7.4.184",
+            "rows": [
+                "Fixed autocomplete selecting previous items",
+                "Improved autocomplete dropdown closing logic",
+                "Fixed filtering with multi word input text",
+                "Fixed autocomplete small width issue",
+                "Fixed autotracker selecting issue"
+            ],
+            "date": "June 7th 2018"
+        },
+        {
+            "version": "7.4.176",
+            "rows": [
+                "Autocomplete data is parsed in the background for non-blocking UI",
+                "New Ultrafast autocomplete with categories",
+                "Load clients in add project form based on selected Workspace",
+                "Updated signup form to comply with GDPR",
+                "Improved keyboard actions inside autocomplete list",
+                "Fixed issue with billable not being set when selecting task item from autocomplete",
+                "Fixed default project select issue",
+                "Faster sync at entry stop",
+                "Improved setting duration according to pomodoro setting",
+                "Fixed duplicate project name check",
+                "Open edit view with double click on minitimer",
+                "Fixed issue with tracking reminder being show right after coming from Idle mode",
+                "Added error messages and file size restriction to feedback form"
+            ],
+            "date": "June 5th 2018"
+        },
+        {
+            "version": "7.4.122",
+            "rows": [
+                "Fixed issue with task select activating entry underneath",
+                "Fixed login crash issues",
+                "Fixed wrong error message issue when backend is down",
+                "Fixed invalid 'project name exists' error",
+                "Fixed login right after signup",
+                "Solve easier errors that occur with data sync",
+                "Minor layout tweaks"
+            ],
+            "date": "February 20th 2018"
+        },
+        {
+            "version": "7.4.73",
+            "rows": [
+                "Fixed workspace assignment with Pomodoro Break entry",
+                "Fixed app freezing issue on logout",
+                "Fixed 'data not valid' issue",
+                "Fixed issue with autocomplete item click opening edit view",
+                "Fixed issue with context menu close quitting the app",
+                "Reset windows position on 'clear cache' to avoid missing windows issue",
+                "Fixed issue with idle tracker continuing a future entry"
+            ],
+            "date": "November 2nd 2017"
+        },
+        {
+            "version": "7.4.58",
+            "rows": [
+                "Fixed issue with app freezing on quit"
+            ],
+            "date": "September 12th 2017"
+        },
+        {
+            "version": "7.4.52",
+            "rows": [
+                "Fixes for syncing issues that caused user inputs to be overwritten",
+                "Handle error when Toggl Desktop is running while installing"
+            ],
+            "date": "June 21st 2017"
+        },
+        {
+            "version": "7.4.47",
+            "rows": [
+                "Fixed syncing issues that caused user inputs to be discarded",
+                "Fixed issue with not being able to remove all tags from entry",
+                "Removed old msi unistall to avoid freeze while installing",
+                "Added notification when installing and older version of Toggl Desktop was running"
+            ],
+            "date": "June 14th 2017"
+        },
+        {
+            "version": "7.4.38",
+            "rows": [
+                "Updated syncing logic to use api v9 in background",
+                "Fixed issue with faulty date input crashing app"
+            ],
+            "date": "June 6th 2017"
+        },
+        {
+            "version": "7.4.31",
+            "rows": [
+                "Fixed autocomplete not setting tags and billable flag",
+                "Avoid showing tracking reminder if entry is stopped elsewhere"
+            ],
+            "date": "April 27th 2017"
+        },
+        {
+            "version": "7.4.18",
+            "rows": [
+                "Use user profile time format in group total time",
+                "Clear old/synced timeline data on app start",
+                "Fixed entries syncing issue when clients or projects fail to sync",
+                "Account running timer to todays total time",
+                "Fixed text color issue with grouping mode subitems"
+            ],
+            "date": "March 3rd 2017"
+        },
+        {
+            "version": "7.4.7",
+            "date": "December 21st 2016",
+            "rows": [
+                "Fixes for UI issues",
+                "Added time entry grouping",
+                "Trigger full sync on app start",
+                "Fixed project creation time entry save",
+                "Show unsynced icon if entry fails to sync because of restrictions",
+                "Added support for new project color logic",
+                "New color selection to project color select",
+                "Fixed app loading issues",
+                "Style fixes"
+            ],
+            "screenshots": [
+                {
+                    "text": "Grouping similar time entries",
+                    "img": "assets/images/win_7.4.6_grouped.gif"
+                }
+            ]
+        },
+        {
+            "version": "7.3.337",
+            "rows": [
+                "Added Pomodoro Break functionality",
+                "Increased local data kept to 30 days",
+                "Load more gets last 60 days of data",
+                "Added fast delete for entries without data",
+                "Added duration only mode support to Pomodoro timer",
+                "Fixed issue with entries being removed from list on app start"
+            ],
+            "date": "October 26th 2016"
+        },
+        {
+            "version": "7.3.326",
+            "rows": [
+                "Fixed issue with pomodoro stopping timer on app start",
+                "Added old data cleanup to keep app light and fast",
+                "Fixed position and size saving when minimizing and closin the app",
+                "Fixed pomodoro setting disabled issue when idle detection was disabled",
+                "Fixed default project task overwriting issue"
+            ],
+            "date": "September 8th 2016"
+        },
+        {
+            "version": "7.3.318",
+            "date": "May 24th 2016",
+            "rows": [
+                "Fixed app crash on quit",
+                "Fixed pomodoro stop on app start issue",
+                "Fixed timeline event tracking issues",
+                "Fixed Pomodoro notfication triggering when editing older entries",
+                "Fixed 'Datepicker selecting previous date' issue"
+            ]
+        },
+        {
+            "version": "7.3.307",
+            "date": "March 8th 2016",
+            "rows": [
+                "Fixed bug with duplicate project and client creation",
+                "Fixed app crash issue when selecting no project",
+                "Fixed timeline empty event collection issue"
+            ]
+        },
+        {
+            "version": "7.3.301",
+            "beta": "true",
+            "date": "February 25th 2016",
+            "rows": [
+                "Added mini timer",
+                "Added time entry locking for Toggl Business",
+                "Improved pomodoro notification to automatically stop time entries and play system sound",
+                "Fixed alignment of tags and billable icons in time entry list",
+                "Added right-lick menu to time entry day headers",
+                "Added transparent time entry while dragging",
+                "Added load-more button, loading the last month of time entries into the list"
+            ],
+            "screenshots": [
+                {
+                    "text": "Pomodoro Timer improvements. If time ends, entry is stopped and alert sound is played. User is shown notification with options to continue tracking the latest entry or start new one. Starting new entry will open the new entry in edit view.",
+                    "img": "assets/images/win_7.3.301_pomodoro_v2.png"
+                },
+                {
+                    "text": "Added mini timer. It makes it easy to keep your eye on the timer without the need for the whole app window taking screen space.",
+                    "img": "assets/images/win_7.3.301_mini_timer.png"
+                },
+                {
+                    "text": "Added possibility to load 1 month of past entries",
+                    "img": "assets/images/win_7.3.301_load.gif"
+                },
+                {
+                    "text": "Drag and drop between days with visual hovering time entry to make it more clear what is dragged",
+                    "img": "assets/images/win_7.3.301_drag.gif"
+                },
+                {
+                    "text": "Added possiblility to expand all days when everything is collapsed",
+                    "img": "assets/images/win_7.3.301_collapse.gif"
+                }
+            ]
+        },
+        {
+            "version": "7.3.289",
+            "beta": "true",
+            "date": "February 15th 2016",
+            "rows": [
+                "Fixed duration cutoff in time entry listing elements",
+                "Fixed clearing default project when empty string",
+                "Added right-click menu to time entries",
+                "Fixed rare crash when opening edit popup",
+                "Fixed message boxes appearing behind window if set to on-top",
+                "Changed project color selected to pre-select random colour",
+                "Added pomodoro timer",
+                "Added keyboard shortcuts to collapse and expand days in time entry list",
+                "Improved edit-popup description auto complete (is now the same as timer auto complete)",
+                "Added drag-dropping of time entries between days",
+                "Fixed flickering sync spinner",
+                "Improved auto tracker and tracking reminder notifications to be consistent and reliable",
+                "Fixed not being able to select projects with tasks as default projects and in auto tracker settings",
+                "Improved behaviour and fixed crashes related to alt+f4 and ctrl+f4 shortcuts"
+            ],
+            "screenshots": [
+                {
+                    "text": "Pomodoro Timer. If the timer has tracked for the amount defined in the pomodoro settings, user is shown a notification.",
+                    "img": "assets/images/win_7.3.289_pomodoro.png"
+                },
+                {
+                    "text": "Collapsing all days. Days can be also collapsed with LEFT and RIGHT keyboard keys",
+                    "img": "assets/images/win_7.3.289_day_collapse.gif"
+                },
+                {
+                    "text": "Drag and drop items between days",
+                    "img": "assets/images/win_7.3.289_drag_drop.gif"
+                }
+            ]
+        },
+        {
+            "version": "7.3.252",
+            "date": "January 12th 2016",
+            "rows": [
+                "Made days in time entry list collapse on click",
+                "Fixed a variety of graphical issues related to DPI scaling",
+                "Fixed issue that caused incorrect 'duplicate project' errors"
+            ],
+            "screenshots": [
+                {
+                    "text": "Collapsible days",
+                    "img": "assets/images/win_7.3.252.gif"
+                }
+            ]
+        },
+        {
+            "version": "7.3.232",
+            "beta": "true",
+            "date": "December 16th 2015",
+            "rows": [
+                "Made the app try to sync after waking up from sleep",
+                "Increased maximum height of auto completion popups",
+                "Added number of tags to time entries",
+                "Added tooltip to tag-icon hover in time entry list showing tags",
+                "Several fixes and improvements to OBM experiment logic",
+                "Added indicator to unsynced time entries if sync failed",
+                "Fixed support for non-latin script",
+                "Fixed window minimum size not taking into account DPI settings",
+                "Added more informative error message, in case automatic updater fails",
+                "Fixed highlight color in combo boxes with Windows 7 classic theme",
+                "Added framework to track anonymous app usage statistics and start tracking basic settings"
+            ],
+            "screenshots": [
+                {
+                    "text": "Un-synced icon in the left and tags number on top of tag icon",
+                    "img": "assets/images/win_7.3.232.png"
+                }
+            ]
+        },
+        {
+            "version": "7.3.199",
+            "date": "December 7th 2015",
+            "rows": [
+                "Fixed autotracker loading issues",
+                "Fixed `Abort due to constraint violation` when using multilpe accounts",
+                "Updated channel combobox design to match other comboboxes",
+                "Fixed first login experiment logic",
+                "Fixed font issues with latest Win 10 update",
+                "Added setting controlling whether duration of end-time is changed when editing start-time",
+                "Re-added time textbox to timer.",
+                "Starting timer with entered time will now create running time entry",
+                "Added start-time tooltip to running timer",
+                "Fixed bug causing incorrect times when confirming duration change of running time entry with Enter",
+                "Tasks are now grouped by projects in the project selection list and can be expanded when needed (same as web-app)"
+            ]
+        },
+        {
+            "version": "7.3.157",
+            "date": "November 13th 2015",
+            "rows": [
+                "Added first time login tutorial",
+                "Added possibility to select color when adding projects",
+                "Removed duration textbox from timer (functionality is replaced by manual mode)",
+                "Improved and changed the overall layout and styling to make it more compact and uniform",
+                "Changed description and project fields to be the first in the edit popup",
+                "Removed back button from edit popup (did the same as X)",
+                "Added ESC and ENTER controls to all OK/CANCEL message boxes",
+                "Fixed bug causing entry list to scroll to top on focus",
+                "Fixed continue in manual mode creating running time entry",
+                "Fixed SPACE not being recognized for global keyboard shortcuts",
+                "Added tooltip to taskbar icon showing current time entry and running time",
+                "Enabled hardware accelerated rendering",
+                "Added restart button to about window to restart and install updates",
+                "Made idle notification stay on top of other windows more aggressively",
+                "Fixed duplicate project names in different workspaces not being displayed correctly",
+                "Fixed project creation allowing to select workspaces if user cannot create projects in them",
+                "Made ESC close edit popup even if timer or time entry list are focussed",
+                "Fixed window appearing black when restored by starting second instance of app",
+                "Added Ctrl+V shortcut to create time entry from clipboard content",
+                "Added task support to auto tracker and default project",
+                "Fixed window position not being saved correctly when app is minimised or maximised",
+                "Made description in edit popup also complete on client/project/task",
+                "Made preferences detect and prevent global shortcut collisions",
+                "Changed order of client/project and task/description rows in timer and entries",
+                "Added animation to edit popup opening and closing",
+                "Added fading animation to login screen",
+                "Improved all windows to now use default window drop shadows and animations",
+                "Added display of tasks to all project text boxes"
+            ]
+        },
+        {
+            "version": "7.3.27",
+            "date": "October 14th 2015",
+            "rows": [
+                "Finished WPF convert",
+                "New taskbar notfication",
+                "Improved Global shortcuts",
+                "Improved window resizing",
+                "Keep 'Add project' form open when editing other parts of the edit form",
+                "Added keyboard shortcuts to move around the app",
+                "Added custom styled scrollbars",
+                "Made global start shortcut continue instead of starting new entry",
+                "Fixed fields overwrite issues",
+                "Fixed saving user preferences across updates",
+                "Show main window when user clicks 'Add idle time as new entry'",
+                "Fixed timer assuming invalid state when starting with duration",
+                "Made end time change after TAB confirming duration change",
+                "Added 'Launch Toggl Desktop' option to installer finish page",
+                "Added 'Open Toggl Desktop Tips' option to installer finish page",
+                "Added 'Remove all local data' option to uninstaller",
+                "Don't create desktop shortcut when upgrading",
+                "Added smooth data transition when upgrading from version 7.1"
+            ]
+        },
+        {
+            "version": "7.2.313",
+            "date": "September 21st 2015",
+            "rows": [
+                "Save tags right after making changes",
+                "Fixed start shortcut behaviour in manual mode",
+                "Close edit window on start/stop click",
+                "Close preferences window on ESC",
+                "Added performance measurements",
+                "Improved autocomplete rendering performance",
+                "Fixed reminder times and days not being saved",
+                "Improved edit view text box logic",
+                "Improved running timer time display formatting",
+                "Fixed window position saving not working with multiple-monitors"
+            ]
+        },
+        {
+            "version": "7.2.281",
+            "date": "August 14th 2015",
+            "rows": [
+                "Fixed edit view updating issues",
+                "Fixed tags re-appearing after delete",
+                "Added tag deletion with backspace",
+                "Instant UI updates when adding/removing tags",
+                "Improved tags autocomplete dropdown rendering",
+                "Enter saves the time entry edit form changes",
+                "Fixed global shortcuts save issue",
+                "Fixed time entry highlight issue",
+                "Improved decription autocomplete dropdown"
+            ]
+        },
+        {
+            "version": "7.2.265",
+            "date": "August 12th 2015",
+            "rows": [
+                "Redesigned settings window",
+                "Added 'Reminder days' to reminder settings",
+                "Changed proxy settings to use radio buttons instead of check boxes",
+                "Redesigned timer, including better auto completion",
+                "Added manual mode (switch in cog menu)",
+                "Added mouse control for adding tags",
+                "Added clear save and cancel buttons when adding projects and clients",
+                "Made all auto completion more intuitive and easier to use",
+                "Changed layout of time entries and timer to be the same",
+                "Fixed project auto completion being case sensitive",
+                "Made keyboard shortcuts work more reliably",
+                "Made timer and edit window not lose keyboard focus",
+                "Made light background pattern have lower contrast"
+            ]
+        },
+        {
+            "version": "7.2.219",
+            "date": "July 30th 2015",
+            "rows": [
+                "Move edit popup to the inside of the main window when maximised",
+                "Fixed display issues with maximising and Aero Snap",
+                "Fixed time entry listing rendering issues",
+                "Now showing tasks in new edit popup project selection",
+                "Manually opening auto completion now shows all entries"
+            ]
+        },
+        {
+            "version": "7.2.204",
+            "date": "July 20th 2015",
+            "rows": [
+                "New edit popup design",
+                "Label based tags with autocomplete",
+                "Projects dropdown grouped by Workspace and Client",
+                "Fixed time entry listing rendering issues",
+                "Fixed app display issues with multiple monitors"
+            ]
+        },
+        {
+            "version": "7.2.172",
+            "date": "June 19th 2015",
+            "rows": [
+                "New improved Time entry listing",
+                "Added logged in user email to cog menu",
+                "Removed edit popup arrow",
+                "New login view design",
+                "Fixed menu keyboard shortcuts",
+                "Open dropdowns when pressing DOWN key",
+                "Keep window settings in local database"
+            ]
+        },
+        {
+            "version": "7.2.36",
+            "date": "June 19th 2015",
+            "rows": [
+                "Fixed disabled project dropdown items"
+            ]
+        },
+        {
+            "version": "7.2.34",
+            "date": "April 4th 2015",
+            "rows": [
+                "Added System proxy support",
+                "Improved showing workpsace name in Project dropdown",
+                "Show start/end time in duration tooltip",
+                "Other minor UI tweaks and improvements",
+                "Added notice when user tries to send feedback without topic",
+                "Better signup error text"
+            ]
+        },
+        {
+            "version": "7.1.237",
+            "date": "March 25th 2015",
+            "rows": [
+                "Syncing improvements",
+                "Fixed timer description Paste issues",
+                "Fixed timer description being hidden",
+                "Added placeholders to login view",
+                "Fixed the blank screen issue",
+                "Show running entry description in idle notification",
+                "Fixed resize handle for Login view",
+                "Added tooltip to error messages",
+                "Show checked tags on top of the tags list",
+                "Improved new installer UI"
+            ]
+        },
+        {
+            "version": "7.1.224",
+            "date": "March 11th 2015",
+            "rows": [
+                "New installer software",
+                "Install doesn't require admin permissions",
+                "Fixed duration cutoff",
+                "Improved syncing",
+                "Background updates",
+                "More informative error messages"
+            ]
+        },
+        {
+            "version": "7.1.208",
+            "date": "February 19th 2015",
+            "rows": [
+                "Fixed continue button in new design",
+                "Remove extra calculations while resizing list"
+            ]
+        },
+        {
+            "version": "7.1.207",
+            "date": "February 19th 2015",
+            "rows": [
+                "New design for application window and listing view"
+            ]
+        },
+        {
+            "version": "7.1.203",
+            "date": "February 13th 2015",
+            "rows": [
+                "Updater dialog popped up too often",
+                "App startup could fail with certain session data"
+            ]
+        },
+        {
+            "version": "7.1.202",
+            "date": "February 12th 2015",
+            "rows": [
+                "More friendly error messages",
+                "Offline login",
+                "Fix enabling/disabling Timeline",
+                "Handle 'Only admins can change project visibility.'",
+                "Dont upload timeline events older than 7 days",
+                "Increase https client timeout to 15 seconds (was 10)",
+                "Handle HTTP status code 429",
+                "Improved online state",
+                "Ignore invalid updates from Toggl backend",
+                "Remove 'time entry too short' message",
+                "Handle Toggl backend downtime with retries",
+                "Dont display non-active tasks",
+                "Collect autocomplete usage to Google Analytics",
+                "Invalid data is not synced unless error is fixed",
+                "OpenSSL 1.0.2",
+                "Project autocomplete grouping now resembles more the web",
+                "Changed idle window startpos to center screen",
+                "Reset tags when rendering editor",
+                "Check for updates each hour",
+                "Prefer same date when editing end time",
+                "Sync time entries less than 5 sec, too"
+            ]
+        },
+        {
+            "version": "7.1.171",
+            "date": "January 8th 2015",
+            "rows": [
+                "Improved app and tray icons",
+                "Close edit popup on logout",
+                "Removed Entries list flickering",
+                "Removed custom DPI scaling",
+                "Fixed idle window opening on top when restoring window",
+                "Fixed multi screen edit popup replacement",
+                "Added signup to login page",
+                "Fixed restoring window docked state",
+                "Added workspace name to edit view",
+                "Fixed add client button",
+                "Fixed data loading issues after signup",
+                "Added 'Reminder minutes' preference",
+                "Other smaller improvements"
+            ]
+        },
+        {
+            "version": "7.1.145",
+            "date": "December 2nd 2014",
+            "rows": [
+                "Added possibility to add new clients",
+                "Added possibility to filter and add tags",
+                "Added possibility to resize so that only timer is visible (mini mode)",
+                "Added configurable global keyboard shortcuts",
+                "Fixed field focusing issues",
+                "Fixed workspace and client dropdown scroll",
+                "Minor UI tweaks"
+            ]
+        }
+    ]
+}

--- a/index.html
+++ b/index.html
@@ -1,5 +1,45 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://toggl-open-source.github.io/toggldesktop/</title>
-<meta http-equiv="refresh" content="0; URL=https://toggl-open-source.github.io/toggldesktop">
-<link rel="canonical" href="https://toggl-open-source.github.io/toggldesktop">
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="chrome=1">
+		<meta name="description" content="Native desktop applications for the leading time tracking tool Toggl">
+		<title>Change log for Toggl Desktop</title>
+		<link rel="canonical" href="https://toggl.com/toggldesktop/">
+		<link href="assets/images/favicon.ico" rel="shortcut icon" id="favicon">
+		<link rel="stylesheet" href="assets/style.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+		<!--[if lt IE 9]>
+		<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+		<![endif]-->
+	</head>
+  <body>
+    <div class="wrapper">
+      <header>
+        <h1>Change log for Toggl Desktop</h1>
+      </header>
+      <section>
+        <div class="table">
+          <ul class="platform-links">
+            <li><a href="#mac" class="mac">Mac</a></li>
+            <li><a href="#win" class="win">Windows</a></li>
+            <li><a href="#linux" class="linux">Linux</a></li>
+          </ul>
+        </div>
+        <div class="pages">
+          <div class="os mac">
+          </div>
+          <div class="os win">
+          </div>
+          <div class="os linux">
+          </div>
+        </div>
+      </section>
+      <footer>
+        <p>This project is maintained by <a href="https://github.com/toggl">toggl</a></p>
+      </footer>
+    </div>
+    <script src="assets/scale.fix.js"></script>
+    <script src="assets/toggldesktop.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This makes the public page a simple static HTML page.

It generates the page content from the changelog JSON files.

Currently, we keep the JSON files in this repo as there are no JSON files in the other open-source repo public page. 

This is so because we use Jekyll on that repo and it generates static pages from JSON files and no JSON files are kept online for us to fetch. If we move the JSON files to a location that is possible to access we can finalize this PR.